### PR TITLE
feat(core): implement MCP layer, LLM client, supervisor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.10"
           cache: pip
 
       - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,8 @@ repos:
           - typer>=0.9
           - rich>=13.0
           - types-setuptools
+          - jsonschema>=4.20
+          - openai>=1.0
         args: [--config-file=pyproject.toml]
         files: ^src/
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # Agentic Dev Tool (adt)
 
 [![CI](https://github.com/brunoramosmartins/agentic-dev-tool/actions/workflows/ci.yml/badge.svg)](https://github.com/brunoramosmartins/agentic-dev-tool/actions/workflows/ci.yml)
-[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A context-oriented AI assistant CLI built with a simplified Model Context Protocol (MCP). The project is designed for extensibility, real-world engineering use, and professional demonstration.
 
 ## Status
 
-**Phase 0 — Project Bootstrap:** repository structure, tooling, and CI are in place. Application features land in later phases (see project planning docs if available locally).
+**Phase 1 — Core Infrastructure:** Pydantic models, LLM client, MCP layer (context, registry, executor), supervisor, runner, and stub agents are implemented. User-facing CLI flows land in Phase 2 (see local planning docs if you keep them outside git).
 
 ## Quick start (development)
 
 ```bash
-# Requires Python 3.11 or newer
+# Requires Python 3.10 or newer
 python -m venv .venv
 source .venv/bin/activate   # Windows: .venv\Scripts\activate
 make install

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-1. Use Python 3.11+ and a virtual environment.
+1. Use Python 3.10+ and a virtual environment.
 2. Install dev dependencies: `pip install -e ".[dev]"` (or `make install` where `make` is available).
 3. Run `ruff check .`, `ruff format .`, `mypy src/`, and `pytest` before opening a PR.
 4. Enable pre-commit: `pre-commit install`.
@@ -9,7 +9,7 @@ Pull requests should follow the template in `.github/PULL_REQUEST_TEMPLATE.md`.
 
 ## GitHub labels, milestones, and issues
 
-Optional automation for maintainers (requires `gh auth login`):
+Optional automation for maintainers (requires `gh auth login`). All live under `scripts/`; if you already ran an older copy from the repo root, re-running is safe and skips existing GitHub entities.
 
 - `scripts/setup_all.sh` — runs `setup_labels.sh`, `setup_milestones.sh`, and `setup_issues.sh` in order.
 - `ADT_DELETE_DEFAULT_LABELS=1 ./scripts/setup_labels.sh` — opt-in removal of GitHub’s stock labels before creating the project label set.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,11 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentic-dev-tool"
-version = "0.1.0"
+version = "0.2.0"
 description = "Context-oriented AI assistant CLI with a simplified MCP-style tool layer."
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 authors = [{ name = "Bruno Ramos Martins" }]
 keywords = ["cli", "ai", "agents", "mcp", "llm"]
 classifiers = [
@@ -17,6 +17,7 @@ classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Typing :: Typed",
@@ -27,6 +28,7 @@ dependencies = [
   "httpx>=0.25",
   "openai>=1.0",
   "rich>=13.0",
+  "jsonschema>=4.20",
 ]
 
 [project.optional-dependencies]
@@ -57,7 +59,7 @@ packages = ["src/adt"]
 include = ["src/adt", "README.md", "LICENSE"]
 
 [tool.ruff]
-target-version = "py311"
+target-version = "py310"
 line-length = 88
 src = ["src", "tests"]
 
@@ -65,12 +67,16 @@ src = ["src", "tests"]
 select = ["E", "F", "I", "UP", "B", "SIM"]
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.10"
 strict = true
 warn_return_any = true
 warn_unused_configs = true
 mypy_path = "src"
 packages = ["adt"]
+
+[[tool.mypy.overrides]]
+module = "jsonschema"
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -85,5 +91,5 @@ branch = true
 omit = ["tests/*"]
 
 [tool.coverage.report]
-fail_under = 0
+fail_under = 80
 show_missing = true

--- a/scripts/setup_all.sh
+++ b/scripts/setup_all.sh
@@ -17,6 +17,11 @@
 #   3. Issues — references labels and milestones
 #
 # All scripts are idempotent: safe to run multiple times.
+#
+# NOTE: If you already ran an older copy of these scripts from the repository
+# root before they were consolidated under scripts/, you do not need to undo
+# anything on GitHub—just run this file again; existing labels, milestones, and
+# issues are detected and skipped.
 # ==============================================================================
 
 set -euo pipefail

--- a/scripts/setup_issues.sh
+++ b/scripts/setup_issues.sh
@@ -13,6 +13,9 @@
 #   - Run from the repository root directory
 #
 # This script is idempotent: issues with the same title are skipped.
+#
+# NOTE: This file lives under scripts/. If you created issues using an older
+# workflow, re-running is safe—existing titles are skipped.
 # ==============================================================================
 
 set -euo pipefail

--- a/src/adt/__init__.py
+++ b/src/adt/__init__.py
@@ -1,3 +1,3 @@
 """Agentic Dev Tool — context-oriented AI assistant CLI."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/adt/agents/base.py
+++ b/src/adt/agents/base.py
@@ -1,1 +1,36 @@
-"""Abstract base agent (implemented in Phase 1)."""
+"""Abstract base type for all specialized agents."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from adt.models.schemas import AgentResponse, QueryRequest
+
+
+class BaseAgent(ABC):
+    """Contract: system prompt, declared tool names, and a handle entrypoint.
+
+    Phase 1 provides stubs; Phase 2+ flesh out ``handle`` and real tool wiring.
+    The :class:`~adt.core.runner.Runner` uses ``system_prompt`` and ``tools`` for
+    the LLM loop; ``handle`` remains available for higher-level orchestration.
+    """
+
+    @property
+    @abstractmethod
+    def system_prompt(self) -> str:
+        """Instructions injected as the system message for this agent."""
+
+    @property
+    @abstractmethod
+    def tools(self) -> list[str]:
+        """Names of tools this agent may call (must exist in the registry)."""
+
+    @abstractmethod
+    def handle(self, request: QueryRequest, context: str) -> AgentResponse:
+        """Produce a response given the user request and assembled context text."""
+
+    @property
+    def name(self) -> str:
+        """Stable agent id from the class name (``RepoAgent`` → ``repo_agent``)."""
+        stem = self.__class__.__name__.removesuffix("Agent").lower()
+        return f"{stem}_agent"

--- a/src/adt/agents/project_agent.py
+++ b/src/adt/agents/project_agent.py
@@ -1,1 +1,28 @@
-"""Project and issue management agent (implemented in Phase 4)."""
+"""Project and issue management agent (stub for Phase 1)."""
+
+from __future__ import annotations
+
+from adt.agents.base import BaseAgent
+from adt.models.schemas import AgentResponse, QueryRequest
+
+
+class ProjectAgent(BaseAgent):
+    """GitHub-centric project insights; Phase 4 adds API-backed tools."""
+
+    @property
+    def system_prompt(self) -> str:
+        return (
+            "You are a technical project manager. "
+            "Summarize issues and milestones when tools exist."
+        )
+
+    @property
+    def tools(self) -> list[str]:
+        return []
+
+    def handle(self, request: QueryRequest, context: str) -> AgentResponse:
+        return AgentResponse(
+            answer=f"(stub project_agent) Query: {request.query!r}",
+            tools_used=[],
+            context_summary=context[:500],
+        )

--- a/src/adt/agents/repo_agent.py
+++ b/src/adt/agents/repo_agent.py
@@ -1,1 +1,28 @@
-"""Repository analysis agent (implemented in Phase 2)."""
+"""Repository analysis agent (stub implementation for Phase 1)."""
+
+from __future__ import annotations
+
+from adt.agents.base import BaseAgent
+from adt.models.schemas import AgentResponse, QueryRequest
+
+
+class RepoAgent(BaseAgent):
+    """Analyzes local repositories; Phase 2 adds real repo tools and prompts."""
+
+    @property
+    def system_prompt(self) -> str:
+        return (
+            "You are a senior engineer analyzing a codebase. "
+            "Answer clearly using tools when they are available."
+        )
+
+    @property
+    def tools(self) -> list[str]:
+        return ["echo"]
+
+    def handle(self, request: QueryRequest, context: str) -> AgentResponse:
+        return AgentResponse(
+            answer=f"(stub repo_agent) Query: {request.query!r}",
+            tools_used=[],
+            context_summary=context[:500],
+        )

--- a/src/adt/agents/research_agent.py
+++ b/src/adt/agents/research_agent.py
@@ -1,1 +1,28 @@
-"""Technical research agent (implemented in Phase 3)."""
+"""Technical research agent (stub for Phase 1)."""
+
+from __future__ import annotations
+
+from adt.agents.base import BaseAgent
+from adt.models.schemas import AgentResponse, QueryRequest
+
+
+class ResearchAgent(BaseAgent):
+    """Literature and article workflows; Phase 3 adds arXiv and fetch tools."""
+
+    @property
+    def system_prompt(self) -> str:
+        return (
+            "You are a technical researcher. "
+            "Use search tools when available to ground answers."
+        )
+
+    @property
+    def tools(self) -> list[str]:
+        return []
+
+    def handle(self, request: QueryRequest, context: str) -> AgentResponse:
+        return AgentResponse(
+            answer=f"(stub research_agent) Query: {request.query!r}",
+            tools_used=[],
+            context_summary=context[:500],
+        )

--- a/src/adt/cli/app.py
+++ b/src/adt/cli/app.py
@@ -26,8 +26,7 @@ def version_cmd() -> None:
 def info_cmd() -> None:
     """Print short bootstrap status (full CLI in Phase 2)."""
     typer.echo(
-        "adt Phase 0 — tooling and skeleton ready. "
-        "The `ask` command ships in Phase 2.",
+        "adt Phase 0 — tooling and skeleton ready. The `ask` command ships in Phase 2.",
     )
 
 

--- a/src/adt/core/llm.py
+++ b/src/adt/core/llm.py
@@ -1,1 +1,139 @@
-"""OpenAI-compatible LLM client (implemented in Phase 1)."""
+"""OpenAI-compatible chat client with retries and usage tracking."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import Sequence
+from typing import Any
+
+from openai import APIStatusError, OpenAI
+
+from adt.models.schemas import LLMMessage, ToolCall
+
+logger = logging.getLogger(__name__)
+
+_RETRY_STATUS = frozenset({429, 500, 502, 503})
+
+
+def _messages_to_openai(messages: Sequence[LLMMessage]) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for m in messages:
+        if m.role == "tool":
+            out.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": m.tool_call_id or "",
+                    "content": m.content,
+                },
+            )
+            continue
+
+        entry: dict[str, Any] = {"role": m.role, "content": m.content}
+        if m.tool_calls:
+            entry["tool_calls"] = [
+                {
+                    "id": tc.id or "",
+                    "type": "function",
+                    "function": {
+                        "name": tc.name,
+                        "arguments": json.dumps(tc.arguments),
+                    },
+                }
+                for tc in m.tool_calls
+            ]
+        out.append(entry)
+    return out
+
+
+def _tool_calls_from_openai(raw: Any) -> list[ToolCall] | None:
+    if not raw:
+        return None
+    calls: list[ToolCall] = []
+    for tc in raw:
+        fn = tc.function
+        try:
+            args = json.loads(fn.arguments or "{}")
+        except json.JSONDecodeError:
+            args = {}
+        calls.append(
+            ToolCall(
+                id=tc.id,
+                name=fn.name,
+                arguments=args if isinstance(args, dict) else {},
+            ),
+        )
+    return calls or None
+
+
+class LLMClient:
+    """Thin wrapper around the OpenAI chat completions API."""
+
+    def __init__(
+        self,
+        model: str = "gpt-4o-mini",
+        api_key: str | None = None,
+        *,
+        max_retries: int = 3,
+        client: OpenAI | None = None,
+    ) -> None:
+        self._model = model
+        self._max_retries = max(1, max_retries)
+        self._client = client or OpenAI(api_key=api_key)
+        self._last_usage: dict[str, int] = {}
+
+    @property
+    def last_usage(self) -> dict[str, int]:
+        """Token usage from the most recent successful API call."""
+        return dict(self._last_usage)
+
+    def chat(
+        self,
+        messages: Sequence[LLMMessage],
+        tools: list[dict[str, Any]] | None = None,
+    ) -> LLMMessage:
+        """Send chat messages and return the assistant (or tool-bearing) reply."""
+        payload = _messages_to_openai(messages)
+        kwargs: dict[str, Any] = {
+            "model": self._model,
+            "messages": payload,
+        }
+        if tools:
+            kwargs["tools"] = tools
+
+        last_error: Exception | None = None
+        for attempt in range(self._max_retries):
+            try:
+                completion = self._client.chat.completions.create(**kwargs)
+                choice = completion.choices[0].message
+                usage = completion.usage
+                if usage is not None:
+                    self._last_usage = {
+                        "prompt_tokens": usage.prompt_tokens,
+                        "completion_tokens": usage.completion_tokens,
+                        "total_tokens": usage.total_tokens,
+                    }
+                    logger.info("llm_usage %s", self._last_usage)
+                tool_calls = _tool_calls_from_openai(choice.tool_calls)
+                return LLMMessage(
+                    role="assistant",
+                    content=choice.content or "",
+                    tool_calls=tool_calls,
+                )
+            except APIStatusError as exc:
+                last_error = exc
+                code = getattr(exc, "status_code", None)
+                if code in _RETRY_STATUS and attempt < self._max_retries - 1:
+                    delay = 2**attempt
+                    logger.warning(
+                        "llm_retry attempt=%s code=%s sleep=%ss",
+                        attempt + 1,
+                        code,
+                        delay,
+                    )
+                    time.sleep(delay)
+                    continue
+                raise
+        assert last_error is not None
+        raise last_error

--- a/src/adt/core/runner.py
+++ b/src/adt/core/runner.py
@@ -1,1 +1,136 @@
-"""Orchestrates the full request lifecycle (implemented in Phase 1)."""
+"""Orchestrates routing, context, LLM calls, and the tool execution loop."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, Protocol
+
+from adt.agents.base import BaseAgent
+from adt.mcp.context import ContextBuilder
+from adt.mcp.executor import ExecutionController
+from adt.mcp.registry import ToolRegistry
+from adt.models.schemas import (
+    AgentResponse,
+    LLMMessage,
+    QueryRequest,
+    ToolCall,
+)
+
+if TYPE_CHECKING:
+    from adt.core.supervisor import Supervisor
+
+logger = logging.getLogger(__name__)
+
+
+class LLMBackend(Protocol):
+    """Minimal interface for anything that can run a chat completion."""
+
+    def chat(
+        self,
+        messages: Sequence[LLMMessage],
+        tools: list[dict[str, Any]] | None = None,
+    ) -> LLMMessage: ...
+
+
+class Runner:
+    """Wires supervisor, context, LLM, registry, and executor into one request path."""
+
+    def __init__(
+        self,
+        supervisor: Supervisor,
+        llm: LLMBackend,
+        context_builder: ContextBuilder,
+        executor: ExecutionController,
+        registry: ToolRegistry,
+        agents: dict[str, BaseAgent],
+        *,
+        max_tool_iterations: int = 5,
+    ) -> None:
+        self._supervisor = supervisor
+        self._llm = llm
+        self._context = context_builder
+        self._executor = executor
+        self._registry = registry
+        self._agents = agents
+        self._max_tool_iterations = max_tool_iterations
+
+    def run(self, request: QueryRequest) -> AgentResponse:
+        """Route the query, build context, run the LLM/tool loop, return an answer."""
+        routed = self._supervisor.route(request)
+        agent = self._agents[routed.agent_name]
+
+        if routed.request.repo_path:
+            raw_context = self._context.build_from_repo(routed.request.repo_path)
+        else:
+            raw_context = self._context.build_from_text("")
+
+        context_summary = raw_context[:400]
+        user_content = (
+            f"{raw_context}\n\nUser question:\n{routed.request.query.strip()}\n"
+        )
+
+        messages: list[LLMMessage] = [
+            LLMMessage(role="system", content=agent.system_prompt),
+            LLMMessage(role="user", content=user_content),
+        ]
+
+        tools_openai = self._tools_for_agent(agent)
+        tools_used: list[str] = []
+
+        for _ in range(self._max_tool_iterations):
+            reply = self._llm.chat(messages, tools_openai or None)
+
+            if reply.tool_calls:
+                assistant_tc = [
+                    ToolCall(
+                        id=tc.id,
+                        name=tc.name,
+                        arguments=tc.arguments,
+                        agent=routed.agent_name,
+                    )
+                    for tc in reply.tool_calls
+                ]
+                messages.append(
+                    LLMMessage(
+                        role="assistant",
+                        content=reply.content,
+                        tool_calls=assistant_tc,
+                    ),
+                )
+                for tc in assistant_tc:
+                    result = self._executor.execute(tc)
+                    tools_used.append(tc.name)
+                    messages.append(
+                        LLMMessage(
+                            role="tool",
+                            content=result.output
+                            if result.success
+                            else (result.error or "error"),
+                            tool_call_id=tc.id or f"call_{tc.name}",
+                        ),
+                    )
+                continue
+
+            return AgentResponse(
+                answer=reply.content.strip(),
+                tools_used=tools_used,
+                context_summary=context_summary,
+            )
+
+        logger.warning("runner_max_iterations exceeded agent=%s", routed.agent_name)
+        return AgentResponse(
+            answer=(
+                "Stopped after maximum tool iterations "
+                f"({self._max_tool_iterations}). Partial tool trail: {tools_used}."
+            ),
+            tools_used=tools_used,
+            context_summary=context_summary,
+        )
+
+    def _tools_for_agent(self, agent: BaseAgent) -> list[dict[str, Any]]:
+        all_tools = self._registry.to_openai_format(agent.name)
+        if not agent.tools:
+            return []
+        allowed = set(agent.tools)
+        return [t for t in all_tools if t["function"]["name"] in allowed]

--- a/src/adt/core/supervisor.py
+++ b/src/adt/core/supervisor.py
@@ -1,1 +1,58 @@
-"""Intent classification and agent routing (implemented in Phase 1)."""
+"""Rule-based intent routing to specialized agents."""
+
+from __future__ import annotations
+
+from adt.models.schemas import QueryRequest, RoutedRequest
+
+_PROJECT_KEYWORDS = (
+    "issue",
+    "milestone",
+    "roadmap",
+    "project",
+    "sprint",
+    "backlog",
+)
+_RESEARCH_KEYWORDS = (
+    "paper",
+    "article",
+    "research",
+    "search",
+    "study",
+    "literature",
+)
+_REPO_KEYWORDS = (
+    "repo",
+    "code",
+    "architecture",
+    "explain",
+    "file",
+    "function",
+)
+
+
+class Supervisor:
+    """Classifies a query and selects an agent using lightweight keyword rules."""
+
+    def route(self, request: QueryRequest) -> RoutedRequest:
+        """Return the agent name and a possibly enriched ``QueryRequest``.
+
+        Precedence: project keywords, then research, then repository, then default
+        ``repo_agent``. Matching is case-insensitive via substring search.
+        """
+        text = request.query.lower()
+        enriched = request.model_copy(deep=True)
+
+        if any(k in text for k in _PROJECT_KEYWORDS):
+            enriched.options = {**enriched.options, "route": "project_keywords"}
+            return RoutedRequest(agent_name="project_agent", request=enriched)
+
+        if any(k in text for k in _RESEARCH_KEYWORDS):
+            enriched.options = {**enriched.options, "route": "research_keywords"}
+            return RoutedRequest(agent_name="research_agent", request=enriched)
+
+        if any(k in text for k in _REPO_KEYWORDS):
+            enriched.options = {**enriched.options, "route": "repo_keywords"}
+            return RoutedRequest(agent_name="repo_agent", request=enriched)
+
+        enriched.options = {**enriched.options, "route": "default"}
+        return RoutedRequest(agent_name="repo_agent", request=enriched)

--- a/src/adt/mcp/context.py
+++ b/src/adt/mcp/context.py
@@ -1,1 +1,156 @@
-"""Context builder for repos and text (implemented in Phase 1)."""
+"""Build text context from repositories or raw strings with token heuristics."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+_SKIP_DIR_NAMES = {
+    ".git",
+    ".hg",
+    ".svn",
+    "__pycache__",
+    ".venv",
+    "venv",
+    "node_modules",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".pytest_cache",
+    "dist",
+    "build",
+    ".eggs",
+}
+_TEXT_SUFFIXES = {
+    ".py",
+    ".md",
+    ".toml",
+    ".txt",
+    ".json",
+    ".yaml",
+    ".yml",
+    ".cfg",
+    ".ini",
+}
+
+
+class ContextBuilder:
+    """Assembles bounded context strings for LLM prompts."""
+
+    def estimate_tokens(self, text: str) -> int:
+        """Rough token count using the roadmap heuristic (1 token ≈ 0.75 words)."""
+        words = len(text.split())
+        return max(1, int(words / 0.75))
+
+    def truncate(self, text: str, max_tokens: int) -> str:
+        """Trim text to an approximate token budget, keeping start and end."""
+        if self.estimate_tokens(text) <= max_tokens:
+            return text
+        max_words = max(1, int(max_tokens * 0.75))
+        words = text.split()
+        if len(words) <= max_words:
+            return text
+        head = max_words // 2
+        tail = max_words - head
+        beginning = " ".join(words[:head])
+        ending = " ".join(words[-tail:])
+        return f"{beginning}\n...\n{ending}"
+
+    def build_from_text(self, text: str, *, max_tokens: int | None = None) -> str:
+        """Wrap arbitrary text as a labeled context block."""
+        body = text.strip()
+        if max_tokens is not None:
+            body = self.truncate(body, max_tokens)
+        return f"[context:text]\n{body}\n[/context:text]"
+
+    def build_from_repo(
+        self,
+        path: str,
+        *,
+        max_depth: int = 4,
+        max_files: int = 24,
+        max_chars_per_file: int = 4000,
+        max_total_tokens: int = 8000,
+    ) -> str:
+        """Walk a repository: tree listing plus a slice of readable text files."""
+        root = Path(path).resolve()
+        if not root.is_dir():
+            return self.build_from_text(f"(missing directory: {path})")
+
+        lines: list[str] = [f"[context:repo path={root}]"]
+
+        tree_lines = self._walk_tree(root, max_depth=max_depth)
+        lines.append("[tree]")
+        lines.extend(tree_lines)
+        lines.append("[/tree]")
+
+        files_read = 0
+        for fp in self._iter_text_files(root, max_depth=max_depth):
+            if files_read >= max_files:
+                break
+            rel = fp.relative_to(root)
+            try:
+                raw = fp.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            snippet = raw[:max_chars_per_file]
+            if len(raw) > max_chars_per_file:
+                snippet += "\n... (truncated)"
+            lines.append(f"[file:{rel.as_posix()}]")
+            lines.append(snippet)
+            lines.append(f"[/file:{rel.as_posix()}]")
+            files_read += 1
+
+        body = "\n".join(lines) + "\n[/context:repo]"
+        return self.truncate(body, max_total_tokens)
+
+    def _walk_tree(self, root: Path, *, max_depth: int) -> list[str]:
+        lines: list[str] = []
+
+        def walk(current: Path, prefix: str, depth: int) -> None:
+            if depth > max_depth:
+                return
+            try:
+                entries = sorted(current.iterdir(), key=lambda p: p.name.lower())
+            except OSError:
+                return
+            for p in entries:
+                if p.name in _SKIP_DIR_NAMES or p.name.endswith(".egg-info"):
+                    continue
+                lines.append(f"{prefix}{p.name}")
+                if p.is_dir():
+                    walk(p, prefix + "  ", depth + 1)
+
+        walk(root, "", 0)
+        return lines
+
+    def _iter_text_files(self, root: Path, *, max_depth: int) -> list[Path]:
+        """Prefer shallow, small, common source files."""
+        candidates: list[tuple[int, int, Path]] = []
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [
+                d
+                for d in dirnames
+                if d not in _SKIP_DIR_NAMES and not d.endswith(".egg-info")
+            ]
+            rel_depth = len(Path(dirpath).relative_to(root).parts)
+            if rel_depth > max_depth:
+                dirnames[:] = []
+                continue
+            for name in filenames:
+                path = Path(dirpath) / name
+                suf = path.suffix.lower()
+                if suf not in _TEXT_SUFFIXES and name not in {
+                    "Dockerfile",
+                    "Makefile",
+                    "LICENSE",
+                }:
+                    continue
+                try:
+                    size = path.stat().st_size
+                except OSError:
+                    continue
+                priority = 0 if name.lower().startswith("readme") else 1
+                candidates.append((priority, size, path))
+
+        candidates.sort(key=lambda t: (t[0], t[1], str(t[2])))
+        return [p for _, _, p in candidates]

--- a/src/adt/mcp/executor.py
+++ b/src/adt/mcp/executor.py
@@ -1,1 +1,134 @@
-"""Tool execution controller (implemented in Phase 1)."""
+"""Validate and execute tool calls through a registry."""
+
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+import time
+from typing import Any
+
+import jsonschema
+from jsonschema import ValidationError
+
+from adt.mcp.registry import ToolRegistry
+from adt.models.schemas import ToolCall, ToolResult
+
+logger = logging.getLogger(__name__)
+
+
+class ExecutionController:
+    """Runs tools registered in a ``ToolRegistry`` with schema checks and logging."""
+
+    def __init__(self, registry: ToolRegistry) -> None:
+        self._registry = registry
+
+    def execute(self, tool_call: ToolCall) -> ToolResult:
+        """Resolve ``tool_call.name``, validate args, invoke handler, return result."""
+        start = time.perf_counter()
+        try:
+            definition = self._registry.get(tool_call.name)
+        except KeyError as exc:
+            duration_ms = (time.perf_counter() - start) * 1000
+            self._log(
+                tool_call.name,
+                tool_call.arguments,
+                duration_ms,
+                False,
+                str(exc),
+            )
+            return ToolResult(
+                name=tool_call.name,
+                output="",
+                success=False,
+                error=str(exc),
+            )
+
+        try:
+            jsonschema.validate(
+                instance=tool_call.arguments,
+                schema=definition.parameters,
+            )
+        except ValidationError as exc:
+            duration_ms = (time.perf_counter() - start) * 1000
+            err = f"argument validation failed: {exc.message}"
+            self._log(
+                tool_call.name,
+                tool_call.arguments,
+                duration_ms,
+                False,
+                err,
+            )
+            return ToolResult(
+                name=tool_call.name,
+                output="",
+                success=False,
+                error=err,
+            )
+
+        try:
+            bound = self._bind_arguments(definition.handler, tool_call.arguments)
+            raw = definition.handler(**bound)
+            out = raw if isinstance(raw, str) else json.dumps(raw, default=str)
+            duration_ms = (time.perf_counter() - start) * 1000
+            self._log(tool_call.name, tool_call.arguments, duration_ms, True, None)
+            return ToolResult(name=tool_call.name, output=out, success=True)
+        except Exception as exc:  # noqa: BLE001 — tools must never crash the runner
+            duration_ms = (time.perf_counter() - start) * 1000
+            err = f"{type(exc).__name__}: {exc}"
+            self._log(
+                tool_call.name,
+                tool_call.arguments,
+                duration_ms,
+                False,
+                err,
+            )
+            return ToolResult(
+                name=tool_call.name,
+                output="",
+                success=False,
+                error=err,
+            )
+
+    def _bind_arguments(
+        self,
+        handler: Any,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Pass only keys the callable accepts (variadic-safe)."""
+        try:
+            sig = inspect.signature(handler)
+        except (TypeError, ValueError):
+            return dict(arguments)
+        params = sig.parameters
+        if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values()):
+            return dict(arguments)
+        allowed = {
+            name
+            for name, p in params.items()
+            if p.kind
+            in (
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                inspect.Parameter.KEYWORD_ONLY,
+            )
+        }
+        return {k: v for k, v in arguments.items() if k in allowed}
+
+    def _log(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        duration_ms: float,
+        success: bool,
+        error: str | None,
+    ) -> None:
+        payload: dict[str, Any] = {
+            "event": "tool_execution",
+            "tool": name,
+            "arguments": arguments,
+            "duration_ms": round(duration_ms, 2),
+            "success": success,
+        }
+        if error is not None:
+            payload["error"] = error
+        logger.info("%s", json.dumps(payload, default=str))

--- a/src/adt/mcp/registry.py
+++ b/src/adt/mcp/registry.py
@@ -1,1 +1,70 @@
-"""Tool registry and permissions (implemented in Phase 1)."""
+"""Register tools, enforce per-agent permissions, and export OpenAI function schemas."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ToolDefinition(BaseModel):
+    """Metadata and handler for a callable tool."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, extra="forbid")
+
+    name: str = Field(..., description="Unique tool name used in API calls.")
+    description: str = Field(..., description="Human-readable purpose for the model.")
+    parameters: dict[str, Any] = Field(
+        ...,
+        description="JSON Schema object describing the function parameters.",
+    )
+    allowed_agents: list[str] = Field(
+        ...,
+        description="Agent names that may invoke this tool.",
+    )
+    handler: Callable[..., Any] = Field(
+        ...,
+        description="Python callable executed by the controller.",
+    )
+
+
+class ToolRegistry:
+    """In-memory catalog mapping tool names to definitions and permissions."""
+
+    def __init__(self) -> None:
+        self._tools: dict[str, ToolDefinition] = {}
+
+    def register(self, tool_def: ToolDefinition) -> None:
+        """Add a tool; raises ``ValueError`` if the name is already registered."""
+        if tool_def.name in self._tools:
+            msg = f"tool already registered: {tool_def.name}"
+            raise ValueError(msg)
+        self._tools[tool_def.name] = tool_def
+
+    def get(self, name: str) -> ToolDefinition:
+        """Return a tool definition by name."""
+        if name not in self._tools:
+            msg = f"unknown tool: {name}"
+            raise KeyError(msg)
+        return self._tools[name]
+
+    def list_for_agent(self, agent: str) -> list[ToolDefinition]:
+        """Tools where ``agent`` appears in ``allowed_agents``."""
+        return [t for t in self._tools.values() if agent in t.allowed_agents]
+
+    def to_openai_format(self, agent: str) -> list[dict[str, Any]]:
+        """OpenAI Chat Completions ``tools`` payload for one agent."""
+        tools: list[dict[str, Any]] = []
+        for t in self.list_for_agent(agent):
+            tools.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": t.name,
+                        "description": t.description,
+                        "parameters": t.parameters,
+                    },
+                },
+            )
+        return tools

--- a/src/adt/models/__init__.py
+++ b/src/adt/models/__init__.py
@@ -1,1 +1,19 @@
 """Pydantic models and shared schemas."""
+
+from adt.models.schemas import (
+    AgentResponse,
+    LLMMessage,
+    QueryRequest,
+    RoutedRequest,
+    ToolCall,
+    ToolResult,
+)
+
+__all__ = [
+    "AgentResponse",
+    "LLMMessage",
+    "QueryRequest",
+    "RoutedRequest",
+    "ToolCall",
+    "ToolResult",
+]

--- a/src/adt/models/schemas.py
+++ b/src/adt/models/schemas.py
@@ -1,1 +1,125 @@
-"""Core request/response schemas (implemented in Phase 1)."""
+"""Pydantic models for queries, tool calls, LLM messages, and agent responses."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+Role = Literal["system", "user", "assistant", "tool"]
+
+
+class QueryRequest(BaseModel):
+    """User query and optional repository context for a single agent run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    query: str = Field(..., description="Natural language question or instruction.")
+    repo_path: str | None = Field(
+        default=None,
+        description="Optional filesystem path to a repository root.",
+    )
+    options: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Arbitrary flags and metadata (e.g. routing hints, verbosity).",
+    )
+
+
+class ToolCall(BaseModel):
+    """A function-style tool invocation produced by the model or the framework."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str | None = Field(
+        default=None,
+        description="Provider-specific tool call id (e.g. OpenAI tool_call id).",
+    )
+    name: str = Field(..., description="Registered tool name.")
+    arguments: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Arguments matching the tool JSON Schema.",
+    )
+    agent: str = Field(
+        default="",
+        description="Agent context that issued or owns this call (for auditing).",
+    )
+
+
+class ToolResult(BaseModel):
+    """Normalized outcome of executing a single tool."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., description="Tool that was executed.")
+    output: str = Field(default="", description="Serialized tool output (often text).")
+    success: bool = Field(..., description="Whether execution finished without error.")
+    error: str | None = Field(
+        default=None,
+        description="Error message when success is False.",
+    )
+
+
+class AgentResponse(BaseModel):
+    """Final answer returned to the user after a full agent run."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    answer: str = Field(..., description="Natural language response shown to the user.")
+    tools_used: list[str] = Field(
+        default_factory=list,
+        description="Names of tools invoked during the run.",
+    )
+    context_summary: str = Field(
+        default="",
+        description="Short description of context that was available (for logging).",
+    )
+
+
+class LLMMessage(BaseModel):
+    """One message in an OpenAI-style chat transcript, including optional tool calls."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    role: Role = Field(..., description="Message role in the chat protocol.")
+    content: str = Field(
+        default="",
+        description="Visible text; may be empty when the model emits tool_calls only.",
+    )
+    tool_calls: list[ToolCall] | None = Field(
+        default=None,
+        description="Tool calls proposed by an assistant message.",
+    )
+    tool_call_id: str | None = Field(
+        default=None,
+        description="Required for role 'tool': links the result to a prior tool call.",
+    )
+
+    @model_validator(mode="after")
+    def tool_role_requires_call_id(self) -> LLMMessage:
+        if self.role == "tool" and not self.tool_call_id:
+            raise ValueError("tool_call_id is required when role is 'tool'")
+        return self
+
+    @field_validator("role")
+    @classmethod
+    def role_must_be_known(cls, v: str) -> str:
+        allowed = {"system", "user", "assistant", "tool"}
+        if v not in allowed:
+            msg = f"role must be one of {allowed}, got {v!r}"
+            raise ValueError(msg)
+        return v
+
+
+class RoutedRequest(BaseModel):
+    """Supervisor output: chosen agent and the (possibly enriched) request."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    agent_name: str = Field(
+        ...,
+        description="Agent id: repo_agent, project_agent, or research_agent.",
+    )
+    request: QueryRequest = Field(
+        ...,
+        description="Original or enriched request (options may hold routing metadata).",
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,38 @@
-"""Shared pytest fixtures (populated in later phases)."""
+"""Shared pytest fixtures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from adt.mcp.registry import ToolDefinition, ToolRegistry
+
+
+def _echo_handler(message: str) -> str:
+    return f"echo:{message}"
+
+
+@pytest.fixture
+def tool_registry() -> ToolRegistry:
+    reg = ToolRegistry()
+    reg.register(
+        ToolDefinition(
+            name="echo",
+            description="Echo a string back to the model.",
+            parameters={
+                "type": "object",
+                "properties": {"message": {"type": "string"}},
+                "required": ["message"],
+                "additionalProperties": False,
+            },
+            allowed_agents=["repo_agent"],
+            handler=_echo_handler,
+        ),
+    )
+    return reg
+
+
+@pytest.fixture
+def sample_repo_path() -> str:
+    return str(Path(__file__).resolve().parent / "fixtures" / "sample_repo")

--- a/tests/fake_llm.py
+++ b/tests/fake_llm.py
@@ -1,0 +1,29 @@
+"""Test doubles for the LLM layer."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from adt.models.schemas import LLMMessage
+
+
+class FakeLLM:
+    """Returns a fixed sequence of assistant messages (for integration tests)."""
+
+    def __init__(self, replies: list[LLMMessage]) -> None:
+        self._replies = list(replies)
+        self._idx = 0
+        self.last_usage: dict[str, int] = {}
+
+    def chat(
+        self,
+        messages: Sequence[LLMMessage],
+        tools: list[dict[str, Any]] | None = None,
+    ) -> LLMMessage:
+        del messages, tools
+        if self._idx >= len(self._replies):
+            return LLMMessage(role="assistant", content="")
+        r = self._replies[self._idx]
+        self._idx += 1
+        return r

--- a/tests/integration/test_full_flow.py
+++ b/tests/integration/test_full_flow.py
@@ -1,0 +1,96 @@
+"""End-to-end runner test with a fake LLM and real tool execution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adt.agents.project_agent import ProjectAgent
+from adt.agents.repo_agent import RepoAgent
+from adt.agents.research_agent import ResearchAgent
+from adt.core.runner import Runner
+from adt.core.supervisor import Supervisor
+from adt.mcp.context import ContextBuilder
+from adt.mcp.executor import ExecutionController
+from adt.models.schemas import LLMMessage, QueryRequest, ToolCall
+from tests.fake_llm import FakeLLM
+
+
+def test_runner_tool_loop_then_answer(
+    tool_registry,
+    sample_repo_path: str,
+) -> None:
+    replies = [
+        LLMMessage(
+            role="assistant",
+            content="",
+            tool_calls=[
+                ToolCall(
+                    id="call_1",
+                    name="echo",
+                    arguments={"message": "ping"},
+                    agent="repo_agent",
+                ),
+            ],
+        ),
+        LLMMessage(role="assistant", content="Final synthesis."),
+    ]
+    fake = FakeLLM(replies)
+    supervisor = Supervisor()
+    context = ContextBuilder()
+    executor = ExecutionController(tool_registry)
+    agents = {
+        "repo_agent": RepoAgent(),
+        "project_agent": ProjectAgent(),
+        "research_agent": ResearchAgent(),
+    }
+    runner = Runner(
+        supervisor,
+        fake,
+        context,
+        executor,
+        tool_registry,
+        agents,
+        max_tool_iterations=5,
+    )
+    req = QueryRequest(query="explain this file tree", repo_path=sample_repo_path)
+    res = runner.run(req)
+    assert res.answer == "Final synthesis."
+    assert "echo" in res.tools_used
+
+
+def test_runner_max_iterations_stops(
+    tool_registry,
+) -> None:
+    """LLM always requests a tool -> runner hits iteration cap."""
+    tc = ToolCall(
+        id="loop",
+        name="echo",
+        arguments={"message": "again"},
+        agent="repo_agent",
+    )
+    replies = [
+        LLMMessage(role="assistant", content="", tool_calls=[tc]),
+    ] * 3
+    fake = FakeLLM(replies)
+    supervisor = Supervisor()
+    context = ContextBuilder()
+    executor = ExecutionController(tool_registry)
+    agents = {
+        "repo_agent": RepoAgent(),
+        "project_agent": ProjectAgent(),
+        "research_agent": ResearchAgent(),
+    }
+    runner = Runner(
+        supervisor,
+        fake,
+        context,
+        executor,
+        tool_registry,
+        agents,
+        max_tool_iterations=3,
+    )
+    repo = Path(__file__).resolve().parents[1] / "fixtures" / "sample_repo"
+    res = runner.run(
+        QueryRequest(query="explain the repo", repo_path=str(repo)),
+    )
+    assert "maximum tool iterations" in res.answer

--- a/tests/unit/test_agents_base.py
+++ b/tests/unit/test_agents_base.py
@@ -1,0 +1,22 @@
+"""Base agent contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from adt.agents.base import BaseAgent
+from adt.agents.repo_agent import RepoAgent
+from adt.models.schemas import AgentResponse, QueryRequest
+
+
+def test_cannot_instantiate_base() -> None:
+    with pytest.raises(TypeError):
+        BaseAgent()  # type: ignore[abstract,misc]
+
+
+def test_repo_agent_name_and_handle() -> None:
+    a = RepoAgent()
+    assert a.name == "repo_agent"
+    r = a.handle(QueryRequest(query="q"), context="ctx")
+    assert isinstance(r, AgentResponse)
+    assert "stub" in r.answer

--- a/tests/unit/test_cli_app.py
+++ b/tests/unit/test_cli_app.py
@@ -1,0 +1,21 @@
+"""Smoke tests for the Typer CLI."""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from adt.cli.app import app
+
+
+def test_cli_version() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["version"])
+    assert result.exit_code == 0
+    assert result.stdout.strip()
+
+
+def test_cli_info() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["info"])
+    assert result.exit_code == 0
+    assert "Phase" in result.stdout

--- a/tests/unit/test_context.py
+++ b/tests/unit/test_context.py
@@ -1,0 +1,34 @@
+"""Context builder heuristics and repo scanning."""
+
+from __future__ import annotations
+
+from adt.mcp.context import ContextBuilder
+
+
+def test_estimate_tokens() -> None:
+    cb = ContextBuilder()
+    # 3 words -> ceil(3/0.75) = 4
+    assert cb.estimate_tokens("a b c") == 4
+
+
+def test_truncate_preserves_ends() -> None:
+    cb = ContextBuilder()
+    words = " ".join(f"w{i}" for i in range(100))
+    out = cb.truncate(words, max_tokens=10)
+    assert out.startswith("w0")
+    assert "w99" in out
+    assert "..." in out
+
+
+def test_build_from_text_wraps() -> None:
+    cb = ContextBuilder()
+    s = cb.build_from_text("  hi  ")
+    assert "[context:text]" in s
+    assert "hi" in s
+
+
+def test_build_from_repo_sample(sample_repo_path: str) -> None:
+    cb = ContextBuilder()
+    ctx = cb.build_from_repo(sample_repo_path, max_depth=5)
+    assert "[tree]" in ctx
+    assert "main.py" in ctx

--- a/tests/unit/test_executor.py
+++ b/tests/unit/test_executor.py
@@ -1,0 +1,82 @@
+"""Execution controller validation and error handling."""
+
+from __future__ import annotations
+
+import pytest
+
+from adt.mcp.executor import ExecutionController
+from adt.mcp.registry import ToolDefinition, ToolRegistry
+from adt.models.schemas import ToolCall
+
+
+@pytest.fixture
+def reg_with_tool() -> ToolRegistry:
+    reg = ToolRegistry()
+
+    def double(n: int) -> int:
+        return n * 2
+
+    reg.register(
+        ToolDefinition(
+            name="double",
+            description="Double an integer.",
+            parameters={
+                "type": "object",
+                "properties": {"n": {"type": "integer"}},
+                "required": ["n"],
+                "additionalProperties": False,
+            },
+            allowed_agents=["repo_agent"],
+            handler=double,
+        ),
+    )
+    return reg
+
+
+def test_execute_success(reg_with_tool: ToolRegistry) -> None:
+    ex = ExecutionController(reg_with_tool)
+    res = ex.execute(
+        ToolCall(name="double", arguments={"n": 3}, agent="repo_agent"),
+    )
+    assert res.success
+    assert res.output == "6"
+
+
+def test_execute_validation_error(reg_with_tool: ToolRegistry) -> None:
+    ex = ExecutionController(reg_with_tool)
+    res = ex.execute(
+        ToolCall(name="double", arguments={"n": "bad"}, agent="repo_agent")
+    )
+    assert not res.success
+    assert res.error is not None
+
+
+def test_execute_unknown_tool(reg_with_tool: ToolRegistry) -> None:
+    ex = ExecutionController(reg_with_tool)
+    res = ex.execute(ToolCall(name="missing", arguments={}, agent="repo_agent"))
+    assert not res.success
+
+
+def test_execute_handler_exception(reg_with_tool: ToolRegistry) -> None:
+    reg = ToolRegistry()
+
+    def boom() -> str:
+        raise RuntimeError("fail")
+
+    reg.register(
+        ToolDefinition(
+            name="boom",
+            description="x",
+            parameters={
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+            allowed_agents=["repo_agent"],
+            handler=boom,
+        ),
+    )
+    ex = ExecutionController(reg)
+    res = ex.execute(ToolCall(name="boom", arguments={}, agent="repo_agent"))
+    assert not res.success
+    assert "RuntimeError" in (res.error or "")

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -1,0 +1,67 @@
+"""LLM client unit tests with a mocked OpenAI client."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from openai import APIStatusError
+
+from adt.core.llm import LLMClient
+from adt.models.schemas import LLMMessage
+
+
+def _choice(content: str, tool_calls: object | None = None) -> MagicMock:
+    msg = MagicMock(content=content, tool_calls=tool_calls)
+    return MagicMock(message=msg)
+
+
+def test_chat_returns_text() -> None:
+    client = MagicMock()
+    client.chat.completions.create.return_value = MagicMock(
+        choices=[_choice("hello")],
+        usage=MagicMock(prompt_tokens=2, completion_tokens=3, total_tokens=5),
+    )
+    llm = LLMClient(client=client)
+    out = llm.chat([LLMMessage(role="user", content="hi")])
+    assert out.content == "hello"
+    assert out.tool_calls is None
+    assert llm.last_usage["total_tokens"] == 5
+
+
+def test_chat_parses_tool_calls() -> None:
+    client = MagicMock()
+    tc = MagicMock()
+    tc.id = "id1"
+    tc.function.name = "echo"
+    tc.function.arguments = '{"message": "z"}'
+    client.chat.completions.create.return_value = MagicMock(
+        choices=[_choice("", tool_calls=[tc])],
+        usage=MagicMock(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+    llm = LLMClient(client=client)
+    out = llm.chat([LLMMessage(role="user", content="go")])
+    assert out.tool_calls is not None
+    assert out.tool_calls[0].name == "echo"
+    assert out.tool_calls[0].arguments == {"message": "z"}
+
+
+def test_chat_retries_on_429(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = MagicMock()
+    sleeps: list[float] = []
+    monkeypatch.setattr("adt.core.llm.time.sleep", lambda s: sleeps.append(s))
+
+    err = APIStatusError(
+        message="rate limit",
+        response=MagicMock(status_code=429),
+        body=None,
+    )
+    ok = MagicMock(
+        choices=[_choice("ok")],
+        usage=MagicMock(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+    client.chat.completions.create.side_effect = [err, ok]
+    llm = LLMClient(client=client, max_retries=3)
+    out = llm.chat([LLMMessage(role="user", content="x")])
+    assert out.content == "ok"
+    assert sleeps == [1.0]

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -1,0 +1,83 @@
+"""Tool registry registration and OpenAI export."""
+
+from __future__ import annotations
+
+import pytest
+
+from adt.mcp.registry import ToolDefinition, ToolRegistry
+
+
+def test_register_get_list() -> None:
+    reg = ToolRegistry()
+
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    reg.register(
+        ToolDefinition(
+            name="add",
+            description="Add integers.",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "a": {"type": "integer"},
+                    "b": {"type": "integer"},
+                },
+                "required": ["a", "b"],
+                "additionalProperties": False,
+            },
+            allowed_agents=["repo_agent"],
+            handler=add,
+        ),
+    )
+    assert reg.get("add").name == "add"
+    listed = reg.list_for_agent("repo_agent")
+    assert len(listed) == 1
+    assert listed[0].name == "add"
+    assert reg.list_for_agent("project_agent") == []
+
+
+def test_duplicate_register_raises() -> None:
+    reg = ToolRegistry()
+
+    def fn() -> str:
+        return "x"
+
+    td = ToolDefinition(
+        name="dup",
+        description="d",
+        parameters={
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+        allowed_agents=["repo_agent"],
+        handler=fn,
+    )
+    reg.register(td)
+    with pytest.raises(ValueError, match="already registered"):
+        reg.register(td)
+
+
+def test_to_openai_format() -> None:
+    reg = ToolRegistry()
+
+    def noop() -> str:
+        return "ok"
+
+    reg.register(
+        ToolDefinition(
+            name="noop",
+            description="No parameters.",
+            parameters={
+                "type": "object",
+                "properties": {},
+                "additionalProperties": False,
+            },
+            allowed_agents=["repo_agent", "project_agent"],
+            handler=noop,
+        ),
+    )
+    fmt = reg.to_openai_format("project_agent")
+    assert fmt[0]["type"] == "function"
+    assert fmt[0]["function"]["name"] == "noop"

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1,0 +1,41 @@
+"""Validation tests for Pydantic schemas."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from adt.models.schemas import LLMMessage, QueryRequest, RoutedRequest, ToolCall
+
+
+def test_query_request_defaults() -> None:
+    q = QueryRequest(query="hello")
+    assert q.repo_path is None
+    assert q.options == {}
+
+
+def test_tool_call_agent_default() -> None:
+    tc = ToolCall(name="t", arguments={})
+    assert tc.agent == ""
+
+
+def test_llm_message_role_literal() -> None:
+    with pytest.raises(ValidationError):
+        LLMMessage(role="nope", content="x")  # type: ignore[arg-type]
+
+
+def test_llm_message_tool_requires_id() -> None:
+    with pytest.raises(ValidationError):
+        LLMMessage(role="tool", content="result")
+
+
+def test_llm_message_tool_ok() -> None:
+    m = LLMMessage(role="tool", content="ok", tool_call_id="abc")
+    assert m.tool_call_id == "abc"
+
+
+def test_routed_request_roundtrip() -> None:
+    q = QueryRequest(query="x", options={"k": 1})
+    r = RoutedRequest(agent_name="repo_agent", request=q)
+    assert r.agent_name == "repo_agent"
+    assert r.request.query == "x"

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -6,4 +6,4 @@ import adt
 
 
 def test_package_version() -> None:
-    assert adt.__version__ == "0.1.0"
+    assert adt.__version__ == "0.2.0"

--- a/tests/unit/test_supervisor.py
+++ b/tests/unit/test_supervisor.py
@@ -1,0 +1,32 @@
+"""Supervisor routing rules."""
+
+from __future__ import annotations
+
+import pytest
+
+from adt.core.supervisor import Supervisor
+from adt.models.schemas import QueryRequest
+
+
+@pytest.fixture
+def supervisor() -> Supervisor:
+    return Supervisor()
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("open issues in the backlog", "project_agent"),
+        ("read the project roadmap", "project_agent"),
+        ("find papers on RAG", "research_agent"),
+        ("literature review", "research_agent"),
+        ("explain this repo architecture", "repo_agent"),
+        ("where is this function defined", "repo_agent"),
+        ("hello world", "repo_agent"),
+    ],
+)
+def test_route_agents(supervisor: Supervisor, query: str, expected: str) -> None:
+    req = QueryRequest(query=query)
+    out = supervisor.route(req)
+    assert out.agent_name == expected
+    assert "route" in out.request.options


### PR DESCRIPTION
## Summary

Implements **Phase 1 — Core Infrastructure**: Pydantic data models, OpenAI-compatible
`LLMClient`, MCP-style **context builder**, **tool registry**, **execution controller**,
**supervisor** routing, **runner** with a bounded tool-call loop, and **stub agents**
ready for Phase 2–4 specialization.

## Changes

- Core schemas and validation (`QueryRequest`, `ToolCall`, `ToolResult`, `AgentResponse`,
  `LLMMessage`, `RoutedRequest`)
- `LLMClient` with tool calling, token usage logging, and retries on retryable HTTP errors
- `ToolRegistry` + `ToolDefinition` with per-agent permissions and OpenAI function export
- `ContextBuilder` (repo tree + file snippets, token heuristic, truncation)
- `ExecutionController` with JSON Schema argument validation and structured execution logs
- `Supervisor` keyword routing; `Runner` wires the full path (default 5 tool iterations)
- `BaseAgent` contract; `RepoAgent` / `ProjectAgent` / `ResearchAgent` stubs (`echo` for tests)
- Python **3.10+**; CI on **3.10**; `jsonschema` runtime dependency; mypy override for jsonschema
- Tests: unit coverage across modules, integration test with fake LLM, CLI smoke tests
- Docs/scripts: note that `scripts/setup_all.sh` is safe to re-run after moving scripts under `scripts/`

## Testing

- [x] `ruff check .` / `ruff format --check .`
- [x] `mypy src/`
- [x] `pytest` with `--cov=adt` (≥ 80% gate)

## Related

- Milestone: **Phase 1 — Core Infrastructure**
