### PR TITLE
feat(agent): implement repo agent with CLI interface

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
           - types-setuptools
           - jsonschema>=4.20
           - openai>=1.0
+          - pathspec>=0.12
         args: [--config-file=pyproject.toml]
         files: ^src/
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ typecheck:
 	mypy src/
 
 run:
-	$(PYTHON) -m adt.cli.app --help
+	$(PYTHON) -m adt.cli.app ask --help
 
 clean:
 	rm -rf build dist *.egg-info .pytest_cache .mypy_cache .ruff_cache htmlcov .coverage

--- a/README.md
+++ b/README.md
@@ -8,31 +8,84 @@ A context-oriented AI assistant CLI built with a simplified Model Context Protoc
 
 ## Status
 
-**Phase 1 — Core Infrastructure:** Pydantic models, LLM client, MCP layer (context, registry, executor), supervisor, runner, and stub agents are implemented. User-facing CLI flows land in Phase 2 (see local planning docs if you keep them outside git).
+**Phase 2 — MVP (Repo Agent):** The `adt ask` command analyzes a local repository (directory tree, file reads, regex search) and answers questions via an LLM. Supervisor routing, tool registry, and Rich-formatted output are wired end-to-end.
 
-## Quick start (development)
+## Installation
+
+Requires **Python 3.10+**.
 
 ```bash
-# Requires Python 3.10 or newer
 python -m venv .venv
 source .venv/bin/activate   # Windows: .venv\Scripts\activate
-make install
-make lint test typecheck
+pip install -e ".[dev]"
+# optional: pre-commit install
 ```
 
-Configure API access when you implement LLM-backed commands:
+Or with Make (Unix-like shell):
+
+```bash
+make install
+```
+
+## Configuration
+
+Copy the example env file and set your OpenAI API key:
 
 ```bash
 cp .env.example .env
-# Set OPENAI_API_KEY (and optionally GITHUB_TOKEN) in .env
+# Edit .env: OPENAI_API_KEY=...
 ```
 
-## CLI entry point
+`adt` reads `OPENAI_API_KEY` from the process environment. Load `.env` with your shell or a tool such as [direnv](https://direnv.net/) if you use one.
 
-After install, the `adt` command is available (bootstrap placeholder until Phase 2):
+### Environment variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `OPENAI_API_KEY` | Yes, for `ask` | OpenAI API key for chat completions. |
+| `GITHUB_TOKEN` | No | Reserved for future GitHub-backed agents (see `.env.example`). |
+
+## Usage
+
+### Ask about a repository
+
+```bash
+adt ask "What does this project do?" --repo .
+```
+
+Options:
+
+- `--repo`, `-r` — repository root (default: current directory; must exist).
+- `--verbose`, `-v` — debug logging, last token usage, and a truncated context summary.
+- `--model`, `-m` — OpenAI model name (default: `gpt-4o-mini`).
+
+Other commands:
 
 ```bash
 adt --help
+adt ask --help
+adt version
+adt info
+```
+
+### Example session (shape of output)
+
+With a valid key, you will see a green **Answer** panel (Rich), then a dim line listing **Tools used** (for example `read_repo_tree`, `read_file`, `search_code`). With `--verbose`, extra debug lines appear after that.
+
+## Development
+
+```bash
+make lint      # ruff check
+make format    # ruff format
+make test      # pytest with coverage (excludes live LLM tests by default)
+make typecheck # mypy src/
+```
+
+Default pytest runs exclude tests marked `@pytest.mark.live` (real API calls). To exercise a live OpenAI call locally:
+
+```bash
+export OPENAI_API_KEY=...   # Windows PowerShell: $env:OPENAI_API_KEY="..."
+pytest -m live
 ```
 
 ## GitHub automation (optional)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentic-dev-tool"
-version = "0.2.0"
+version = "0.3.0"
 description = "Context-oriented AI assistant CLI with a simplified MCP-style tool layer."
 readme = "README.md"
 license = { text = "MIT" }
@@ -29,6 +29,7 @@ dependencies = [
   "openai>=1.0",
   "rich>=13.0",
   "jsonschema>=4.20",
+  "pathspec>=0.12",
 ]
 
 [project.optional-dependencies]
@@ -78,9 +79,13 @@ packages = ["adt"]
 module = "jsonschema"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "pathspec"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "-ra -q --strict-markers"
+addopts = "-ra -q --strict-markers -m \"not live\""
 markers = [
   "live: calls real external APIs (not run in CI by default)",
 ]

--- a/src/adt/__init__.py
+++ b/src/adt/__init__.py
@@ -1,3 +1,3 @@
 """Agentic Dev Tool — context-oriented AI assistant CLI."""
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/src/adt/agents/repo_agent.py
+++ b/src/adt/agents/repo_agent.py
@@ -1,28 +1,82 @@
-"""Repository analysis agent (stub implementation for Phase 1)."""
+"""Repository analysis agent with repo-scoped tools (MVP)."""
 
 from __future__ import annotations
 
 from adt.agents.base import BaseAgent
+from adt.mcp.context import ContextBuilder
 from adt.models.schemas import AgentResponse, QueryRequest
+
+_REPO_SYSTEM_PROMPT = """You are a senior software engineer analyzing a codebase.
+
+## Workflow
+1. Call read_repo_tree first (path '.' = repo root) for overall structure.
+2. Identify the most relevant files based on the user's question.
+3. Read files with read_file; prefer at most a few files per answer.
+4. For symbols or patterns, use search_code with a focused regex.
+5. Synthesize findings into a clear, actionable answer.
+
+## Analytical principles
+- Start with the big picture (directory structure) before diving into files.
+- Prioritize entry points (main.py, app.py, __init__.py) for architecture questions.
+- Look at pyproject.toml, requirements, or package files for stack questions.
+- Read tests to understand expected behavior when relevant.
+
+## Tool usage
+- Always begin with read_repo_tree unless the user already provided exact file paths.
+- Do not read more than five files in a single request unless strictly necessary.
+- Prefer search_code for locating symbols instead of reading large files blindly.
+
+## Stopping criteria
+- Stop when you can answer confidently from the files you inspected.
+- If information is missing, say what you checked and what is still unknown.
+
+## Response format
+- Lead with a direct answer, then cite evidence (paths, brief snippets).
+- Do not dump the entire tree; summarize structure instead.
+
+## Exclusions
+- Do not invent files or APIs you did not observe in tool output.
+- Do not execute shell commands or modify the filesystem.
+"""
 
 
 class RepoAgent(BaseAgent):
-    """Analyzes local repositories; Phase 2 adds real repo tools and prompts."""
+    """Agent for local repository analysis using read/search tools."""
 
     @property
     def system_prompt(self) -> str:
-        return (
-            "You are a senior engineer analyzing a codebase. "
-            "Answer clearly using tools when they are available."
-        )
+        """Return the system message guiding repository-focused tool use."""
+        return _REPO_SYSTEM_PROMPT
 
     @property
     def tools(self) -> list[str]:
-        return ["echo"]
+        """Names of tools registered for this agent in :mod:`adt.bootstrap`."""
+        return ["read_repo_tree", "read_file", "search_code"]
 
     def handle(self, request: QueryRequest, context: str) -> AgentResponse:
+        """Build a short preview of context without invoking the LLM.
+
+        The interactive ``adt ask`` command uses :class:`~adt.core.runner.Runner`, which
+        performs the full LLM and tool loop. This method supports unit tests and future
+        orchestration that may call agents directly.
+
+        Args:
+            request: Original user query and optional ``repo_path``.
+            context: Pre-built context string when the caller already assembled it.
+
+        Returns:
+            A response describing preview length and declared tool names.
+        """
+        builder = ContextBuilder()
+        if request.repo_path:
+            built = builder.build_from_repo(request.repo_path)
+        else:
+            built = builder.build_from_text(context or "")
         return AgentResponse(
-            answer=f"(stub repo_agent) Query: {request.query!r}",
-            tools_used=[],
-            context_summary=context[:500],
+            answer=(
+                "repo_agent: use `adt ask` (Runner) for LLM-backed answers. "
+                f"Context preview length: {len(built)} characters."
+            ),
+            tools_used=list(self.tools),
+            context_summary=built[:400],
         )

--- a/src/adt/bootstrap.py
+++ b/src/adt/bootstrap.py
@@ -1,0 +1,175 @@
+"""Wire default services for the ``ask`` command and integration tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adt.agents.base import BaseAgent
+from adt.agents.project_agent import ProjectAgent
+from adt.agents.repo_agent import RepoAgent
+from adt.agents.research_agent import ResearchAgent
+from adt.core.llm import LLMClient
+from adt.core.runner import Runner
+from adt.core.supervisor import Supervisor
+from adt.mcp.context import ContextBuilder
+from adt.mcp.executor import ExecutionController
+from adt.mcp.registry import ToolDefinition, ToolRegistry
+from adt.tools import repo as repo_tools
+
+
+def register_repo_tools(registry: ToolRegistry, repo_root: Path) -> None:
+    """Register repo tools (tree, file read, search) scoped to ``repo_root``.
+
+    Handlers resolve paths strictly under ``repo_root`` to avoid path traversal.
+
+    Args:
+        registry: Empty or partially filled tool registry (must not already define
+            these three names).
+        repo_root: Filesystem root passed to ``--repo`` for the current run.
+    """
+    root = repo_root.resolve()
+
+    def read_repo_tree(path: str = ".", max_depth: int = 3) -> str:
+        """Delegate to :func:`adt.tools.repo.read_repo_tree` with a fixed root."""
+        return repo_tools.read_repo_tree(root, path=path, max_depth=max_depth)
+
+    def read_file(path: str, max_lines: int = 200) -> str:
+        """Delegate to :func:`adt.tools.repo.read_file` with a fixed root."""
+        return repo_tools.read_file(root, path, max_lines=max_lines)
+
+    def search_code(pattern: str, path: str = ".", max_results: int = 20) -> str:
+        """Delegate to :func:`adt.tools.repo.search_code` with a fixed root."""
+        return repo_tools.search_code(
+            root,
+            path,
+            pattern,
+            max_results=max_results,
+        )
+
+    registry.register(
+        ToolDefinition(
+            name="read_repo_tree",
+            description=(
+                "Return a text tree of files and directories under a path, "
+                "respecting .gitignore and skipping common build/venv folders."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Directory relative to repo root (default '.').",
+                    },
+                    "max_depth": {
+                        "type": "integer",
+                        "description": "Maximum depth below path (default 3, max 20).",
+                        "minimum": 0,
+                        "maximum": 20,
+                    },
+                },
+                "additionalProperties": False,
+            },
+            allowed_agents=["repo_agent"],
+            handler=read_repo_tree,
+        ),
+    )
+    registry.register(
+        ToolDefinition(
+            name="read_file",
+            description=(
+                "Read a UTF-8 text file under the repo with line numbers; "
+                "truncates after max_lines."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "File path relative to repository root.",
+                    },
+                    "max_lines": {
+                        "type": "integer",
+                        "description": "Max lines from start of file (default 200).",
+                        "minimum": 1,
+                        "maximum": 2000,
+                    },
+                },
+                "required": ["path"],
+                "additionalProperties": False,
+            },
+            allowed_agents=["repo_agent"],
+            handler=read_file,
+        ),
+    )
+    registry.register(
+        ToolDefinition(
+            name="search_code",
+            description=(
+                "Regex search across text files under a directory; "
+                "skips gitignored paths and binary files."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Directory relative to repo root (default '.').",
+                    },
+                    "pattern": {
+                        "type": "string",
+                        "description": "Regular expression (Python re syntax).",
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Maximum matching lines to return (default 20).",
+                        "minimum": 1,
+                        "maximum": 200,
+                    },
+                },
+                "required": ["pattern"],
+                "additionalProperties": False,
+            },
+            allowed_agents=["repo_agent"],
+            handler=search_code,
+        ),
+    )
+
+
+def build_runner_for_repo(
+    repo_root: Path,
+    *,
+    model: str = "gpt-4o-mini",
+    api_key: str | None = None,
+    max_tool_iterations: int = 5,
+) -> Runner:
+    """Construct a :class:`~adt.core.runner.Runner` scoped to one repository path.
+
+    Args:
+        repo_root: Local repository directory for tools and context.
+        model: OpenAI chat model name.
+        api_key: Optional API key (falls back to ``OPENAI_API_KEY`` in the client).
+        max_tool_iterations: Upper bound on LLM/tool round-trips.
+
+    Returns:
+        A fully wired runner with repo tools registered for ``repo_agent``.
+    """
+    registry = ToolRegistry()
+    register_repo_tools(registry, repo_root)
+    supervisor = Supervisor()
+    llm = LLMClient(model=model, api_key=api_key)
+    context = ContextBuilder()
+    executor = ExecutionController(registry)
+    agents: dict[str, BaseAgent] = {
+        "repo_agent": RepoAgent(),
+        "project_agent": ProjectAgent(),
+        "research_agent": ResearchAgent(),
+    }
+    return Runner(
+        supervisor,
+        llm,
+        context,
+        executor,
+        registry,
+        agents,
+        max_tool_iterations=max_tool_iterations,
+    )

--- a/src/adt/cli/app.py
+++ b/src/adt/cli/app.py
@@ -1,19 +1,30 @@
-"""Typer CLI entry point (bootstrap; `ask` and agents ship in later phases)."""
+"""Typer CLI entry point including the ``ask`` command (repo MVP)."""
 
 from __future__ import annotations
 
+import logging
+import os
 from importlib import metadata
+from pathlib import Path
+from typing import Annotated
 
 import typer
+from rich.console import Console
+from rich.panel import Panel
+
+from adt.bootstrap import build_runner_for_repo
+from adt.models.schemas import QueryRequest
 
 app = typer.Typer(help="Agentic Dev Tool CLI", add_completion=False)
+console = Console()
 
 
 def _version_string() -> str:
+    """Return the installed distribution version, or a dev fallback."""
     try:
         return metadata.version("agentic-dev-tool")
     except metadata.PackageNotFoundError:
-        return "0.1.0-dev"
+        return "0.3.0-dev"
 
 
 @app.command("version")
@@ -24,10 +35,70 @@ def version_cmd() -> None:
 
 @app.command("info")
 def info_cmd() -> None:
-    """Print short bootstrap status (full CLI in Phase 2)."""
+    """Print short project status and feature summary."""
     typer.echo(
-        "adt Phase 0 — tooling and skeleton ready. The `ask` command ships in Phase 2.",
+        'adt — Phase 2 MVP. Run: adt ask "your question" --repo .',
     )
+
+
+@app.command("ask")
+def ask_cmd(
+    query: Annotated[
+        str,
+        typer.Argument(help="Natural language question about the repository."),
+    ],
+    repo: Annotated[
+        Path,
+        typer.Option(
+            "--repo",
+            "-r",
+            help="Path to the repository root to analyze.",
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+            resolve_path=True,
+        ),
+    ] = Path("."),
+    verbose: Annotated[
+        bool,
+        typer.Option("--verbose", "-v", help="Print debug logs and token usage."),
+    ] = False,
+    model: Annotated[
+        str,
+        typer.Option(
+            "--model",
+            "-m",
+            help="OpenAI chat model name (default: gpt-4o-mini).",
+        ),
+    ] = "gpt-4o-mini",
+) -> None:
+    """Ask a question about a local repository (supervisor → agent → tools → LLM)."""
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        console.print(
+            "[red]Missing OPENAI_API_KEY.[/red] "
+            "Set it in the environment or in a `.env` file.",
+        )
+        raise typer.Exit(code=1)
+
+    repo_path = repo.resolve()
+    runner = build_runner_for_repo(
+        repo_path,
+        model=model,
+        api_key=api_key,
+    )
+    request = QueryRequest(query=query, repo_path=str(repo_path))
+    response = runner.run(request)
+
+    console.print(Panel(response.answer, title="Answer", border_style="green"))
+    tools_line = ", ".join(response.tools_used) if response.tools_used else "none"
+    console.print(f"[dim]Tools used:[/dim] {tools_line}")
+    if verbose:
+        console.print(f"[dim]Last LLM token usage:[/dim] {runner.last_token_usage}")
+        ctx = response.context_summary
+        console.print(f"[dim]Context summary (truncated):[/dim] {ctx!r}")
 
 
 if __name__ == "__main__":

--- a/src/adt/core/llm.py
+++ b/src/adt/core/llm.py
@@ -18,6 +18,7 @@ _RETRY_STATUS = frozenset({429, 500, 502, 503})
 
 
 def _messages_to_openai(messages: Sequence[LLMMessage]) -> list[dict[str, Any]]:
+    """Convert internal :class:`LLMMessage` objects to OpenAI chat message dicts."""
     out: list[dict[str, Any]] = []
     for m in messages:
         if m.role == "tool":
@@ -48,6 +49,7 @@ def _messages_to_openai(messages: Sequence[LLMMessage]) -> list[dict[str, Any]]:
 
 
 def _tool_calls_from_openai(raw: Any) -> list[ToolCall] | None:
+    """Parse provider tool call objects into :class:`ToolCall` models."""
     if not raw:
         return None
     calls: list[ToolCall] = []

--- a/src/adt/core/runner.py
+++ b/src/adt/core/runner.py
@@ -55,6 +55,14 @@ class Runner:
         self._agents = agents
         self._max_tool_iterations = max_tool_iterations
 
+    @property
+    def last_token_usage(self) -> dict[str, int]:
+        """Return token counts from the last LLM call when the backend exposes them."""
+        raw = getattr(self._llm, "last_usage", None)
+        if isinstance(raw, dict):
+            return raw
+        return {}
+
     def run(self, request: QueryRequest) -> AgentResponse:
         """Route the query, build context, run the LLM/tool loop, return an answer."""
         routed = self._supervisor.route(request)

--- a/src/adt/tools/repo.py
+++ b/src/adt/tools/repo.py
@@ -1,1 +1,305 @@
-"""Repository tools: tree, file read, code search (implemented in Phase 2)."""
+"""Repository tools: directory tree, file reads, and regex search."""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pathspec
+
+_ALWAYS_SKIP_DIR_NAMES = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        "__pycache__",
+        ".venv",
+        "venv",
+        "node_modules",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".pytest_cache",
+        "dist",
+        "build",
+        ".eggs",
+    },
+)
+
+
+def _load_gitignore_spec(repo_root: Path) -> pathspec.PathSpec | None:
+    """Load and compile ``.gitignore`` patterns from the repository root, if present.
+
+    Args:
+        repo_root: Absolute or resolved repository root directory.
+
+    Returns:
+        A :class:`pathspec.PathSpec` in ``gitwildmatch`` mode, or ``None`` when
+        no ``.gitignore`` file exists.
+    """
+    gitignore = repo_root / ".gitignore"
+    if not gitignore.is_file():
+        return None
+    try:
+        lines = gitignore.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except OSError:
+        return None
+    if not lines:
+        return None
+    return pathspec.PathSpec.from_lines("gitwildmatch", lines)
+
+
+def _safe_resolve_under(repo_root: Path, relative_path: str) -> Path:
+    """Resolve ``relative_path`` under ``repo_root``; reject path traversal.
+
+    Args:
+        repo_root: Repository root (should be resolved by the caller).
+        relative_path: User- or model-supplied relative path (POSIX-style ok).
+
+    Returns:
+        An absolute, resolved path inside ``repo_root``.
+
+    Raises:
+        ValueError: If the resolved path would escape ``repo_root``.
+    """
+    base = repo_root.resolve()
+    candidate = (base / relative_path).resolve()
+    try:
+        candidate.relative_to(base)
+    except ValueError as exc:
+        msg = "path escapes repository root"
+        raise ValueError(msg) from exc
+    return candidate
+
+
+def _posix_relative_to(repo_root: Path, path: Path) -> str:
+    """Return ``path`` relative to ``repo_root`` using forward slashes.
+
+    Args:
+        repo_root: Resolved repository root.
+        path: A path under ``repo_root``.
+
+    Returns:
+        A POSIX-style relative path string.
+    """
+    return path.relative_to(repo_root).as_posix()
+
+
+def _is_ignored(
+    rel_posix: str,
+    *,
+    spec: pathspec.PathSpec | None,
+    is_dir: bool,
+) -> bool:
+    """Return whether a path should be skipped according to gitignore rules.
+
+    Args:
+        rel_posix: Path relative to repo root, POSIX separators.
+        spec: Compiled gitignore spec, or ``None`` to skip pattern checks.
+        is_dir: Whether this entry is a directory (affects trailing-slash rules).
+
+    Returns:
+        ``True`` if the entry matches an ignore pattern.
+    """
+    if spec is None:
+        return False
+    paths_to_try = [rel_posix]
+    if is_dir and not rel_posix.endswith("/"):
+        paths_to_try.append(f"{rel_posix}/")
+    return any(spec.match_file(p) for p in paths_to_try)
+
+
+def read_repo_tree(
+    repo_root: Path,
+    path: str = ".",
+    max_depth: int = 3,
+) -> str:
+    """Build a printable directory tree under ``repo_root``.
+
+    Respects ``.gitignore`` when present. Always skips common bulky directories
+    (``.git``, ``node_modules``, virtualenvs, caches).
+
+    Args:
+        repo_root: Root of the repository on disk.
+        path: Subdirectory relative to ``repo_root`` to start the tree (default ``.``).
+        max_depth: Maximum directory depth below the start path (0 = start only).
+
+    Returns:
+        Indented tree as a single string. On missing directory, returns an error line.
+    """
+    try:
+        start = _safe_resolve_under(repo_root, path)
+    except ValueError as exc:
+        return f"error: {exc}"
+
+    if not start.exists():
+        return f"error: path does not exist: {path}"
+    if not start.is_dir():
+        return f"error: not a directory: {path}"
+
+    spec = _load_gitignore_spec(repo_root.resolve())
+    lines: list[str] = []
+
+    def walk(current: Path, depth: int, prefix: str) -> None:
+        """Recursively append tree lines for ``current``."""
+        if depth > max_depth:
+            return
+        rel = _posix_relative_to(repo_root.resolve(), current)
+        if rel != "." and _is_ignored(rel, spec=spec, is_dir=current.is_dir()):
+            return
+        name = "." if rel == "." else current.name
+        lines.append(f"{prefix}{name}/" if current.is_dir() else f"{prefix}{name}")
+        if not current.is_dir():
+            return
+        try:
+            children = sorted(current.iterdir(), key=lambda p: p.name.lower())
+        except OSError:
+            return
+        for child in children:
+            if child.name in _ALWAYS_SKIP_DIR_NAMES:
+                continue
+            child_rel = _posix_relative_to(repo_root.resolve(), child)
+            if _is_ignored(child_rel, spec=spec, is_dir=child.is_dir()):
+                continue
+            walk(child, depth + 1, prefix + "  ")
+
+    walk(start, 0, "")
+    header = f"tree: {path} (max_depth={max_depth})\n"
+    return header + ("\n".join(lines) if lines else "(empty)")
+
+
+def read_file(
+    repo_root: Path,
+    path: str,
+    max_lines: int = 200,
+) -> str:
+    """Read a text file under the repository with line numbers and a line cap.
+
+    Args:
+        repo_root: Repository root used to resolve ``path`` safely.
+        path: File path relative to ``repo_root``.
+        max_lines: Maximum number of lines to return (from the start of the file).
+
+    Returns:
+        Numbered file contents, or an error message string.
+    """
+    try:
+        target = _safe_resolve_under(repo_root, path)
+    except ValueError as exc:
+        return f"error: {exc}"
+
+    if not target.is_file():
+        return f"error: not a file: {path}"
+
+    try:
+        text = target.read_text(encoding="utf-8", errors="replace")
+    except OSError as exc:
+        return f"error: cannot read file: {exc}"
+
+    out_lines = text.splitlines()
+    trimmed = out_lines[:max_lines]
+    numbered = [f"{i + 1:4d} | {line}" for i, line in enumerate(trimmed)]
+    body = "\n".join(numbered)
+    if len(out_lines) > max_lines:
+        body += f"\n... ({len(out_lines) - max_lines} more lines omitted)"
+    return f"file: {path}\n{body}"
+
+
+def _is_probably_binary(chunk: bytes) -> bool:
+    """Return ``True`` if ``chunk`` looks like binary data.
+
+    Args:
+        chunk: First bytes of a file.
+
+    Returns:
+        ``True`` when null bytes are present (heuristic for binary files).
+    """
+    return b"\0" in chunk
+
+
+def search_code(
+    repo_root: Path,
+    path: str,
+    pattern: str,
+    max_results: int = 20,
+) -> str:
+    """Search for a regex ``pattern`` in text files under ``path``.
+
+    Skips gitignored paths and binary files. Collects up to ``max_results`` hits.
+
+    Args:
+        repo_root: Repository root for safe resolution and ignore rules.
+        path: Directory relative to ``repo_root`` to search within.
+        pattern: Regular expression (Python ``re`` syntax).
+        max_results: Maximum match lines to return across all files.
+
+    Returns:
+        Formatted search results or an error description.
+    """
+    try:
+        start = _safe_resolve_under(repo_root, path)
+    except ValueError as exc:
+        return f"error: {exc}"
+
+    if not start.is_dir():
+        return f"error: not a directory: {path}"
+
+    try:
+        regex = re.compile(pattern)
+    except re.error as exc:
+        return f"error: invalid regex: {exc}"
+
+    root_resolved = repo_root.resolve()
+    spec = _load_gitignore_spec(root_resolved)
+    results: list[str] = []
+    count = 0
+
+    for dirpath, dirnames, filenames in os.walk(start, topdown=True):
+        current = Path(dirpath)
+        dirnames[:] = [
+            d
+            for d in dirnames
+            if d not in _ALWAYS_SKIP_DIR_NAMES and not d.endswith(".egg-info")
+        ]
+        rel_dir = _posix_relative_to(root_resolved, current)
+        if rel_dir != "." and _is_ignored(rel_dir, spec=spec, is_dir=True):
+            dirnames[:] = []
+            continue
+        for d in list(dirnames):
+            child = current / d
+            cr = _posix_relative_to(root_resolved, child)
+            if _is_ignored(cr, spec=spec, is_dir=True):
+                dirnames.remove(d)
+
+        for name in filenames:
+            if count >= max_results:
+                break
+            fp = current / name
+            rel_file = _posix_relative_to(root_resolved, fp)
+            if _is_ignored(rel_file, spec=spec, is_dir=False):
+                continue
+            if not fp.is_file():
+                continue
+            try:
+                raw = fp.read_bytes()[:8192]
+            except OSError:
+                continue
+            if _is_probably_binary(raw):
+                continue
+            try:
+                text = fp.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            for lineno, line in enumerate(text.splitlines(), start=1):
+                if count >= max_results:
+                    break
+                if regex.search(line):
+                    results.append(f"{rel_file}:{lineno}:{line.rstrip()}")
+                    count += 1
+        if count >= max_results:
+            break
+
+    if not results:
+        return f"search: no matches for pattern {pattern!r} under {path}"
+    header = f"search: pattern={pattern!r} path={path} (max_results={max_results})\n"
+    return header + "\n".join(results)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,33 +6,19 @@ from pathlib import Path
 
 import pytest
 
-from adt.mcp.registry import ToolDefinition, ToolRegistry
-
-
-def _echo_handler(message: str) -> str:
-    return f"echo:{message}"
+from adt.bootstrap import register_repo_tools
+from adt.mcp.registry import ToolRegistry
 
 
 @pytest.fixture
-def tool_registry() -> ToolRegistry:
+def tool_registry(sample_repo_path: str) -> ToolRegistry:
+    """A tool registry with repo tools bound to the sample fixture repository."""
     reg = ToolRegistry()
-    reg.register(
-        ToolDefinition(
-            name="echo",
-            description="Echo a string back to the model.",
-            parameters={
-                "type": "object",
-                "properties": {"message": {"type": "string"}},
-                "required": ["message"],
-                "additionalProperties": False,
-            },
-            allowed_agents=["repo_agent"],
-            handler=_echo_handler,
-        ),
-    )
+    register_repo_tools(reg, Path(sample_repo_path))
     return reg
 
 
 @pytest.fixture
 def sample_repo_path() -> str:
+    """Absolute path to the minimal sample repository under ``tests/fixtures``."""
     return str(Path(__file__).resolve().parent / "fixtures" / "sample_repo")

--- a/tests/integration/test_full_flow.py
+++ b/tests/integration/test_full_flow.py
@@ -19,6 +19,7 @@ def test_runner_tool_loop_then_answer(
     tool_registry,
     sample_repo_path: str,
 ) -> None:
+    """Model requests read_file; executor runs real tool; second turn returns text."""
     replies = [
         LLMMessage(
             role="assistant",
@@ -26,8 +27,8 @@ def test_runner_tool_loop_then_answer(
             tool_calls=[
                 ToolCall(
                     id="call_1",
-                    name="echo",
-                    arguments={"message": "ping"},
+                    name="read_file",
+                    arguments={"path": "main.py", "max_lines": 50},
                     agent="repo_agent",
                 ),
             ],
@@ -55,7 +56,7 @@ def test_runner_tool_loop_then_answer(
     req = QueryRequest(query="explain this file tree", repo_path=sample_repo_path)
     res = runner.run(req)
     assert res.answer == "Final synthesis."
-    assert "echo" in res.tools_used
+    assert "read_file" in res.tools_used
 
 
 def test_runner_max_iterations_stops(
@@ -64,8 +65,8 @@ def test_runner_max_iterations_stops(
     """LLM always requests a tool -> runner hits iteration cap."""
     tc = ToolCall(
         id="loop",
-        name="echo",
-        arguments={"message": "again"},
+        name="read_repo_tree",
+        arguments={"path": ".", "max_depth": 1},
         agent="repo_agent",
     )
     replies = [

--- a/tests/integration/test_live_ask.py
+++ b/tests/integration/test_live_ask.py
@@ -1,0 +1,33 @@
+"""Optional live tests against the real OpenAI API (not run in default CI)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from adt.bootstrap import build_runner_for_repo
+from adt.models.schemas import QueryRequest
+
+
+@pytest.mark.live
+def test_live_ask_minimal_repo(sample_repo_path: str) -> None:
+    """End-to-end call with a real API key (run with ``pytest -m live``).
+
+    Skips automatically when ``OPENAI_API_KEY`` is unset.
+    """
+    if not os.environ.get("OPENAI_API_KEY"):
+        pytest.skip("OPENAI_API_KEY not set")
+
+    runner = build_runner_for_repo(
+        Path(sample_repo_path),
+        model=os.environ.get("ADT_LIVE_MODEL", "gpt-4o-mini"),
+    )
+    res = runner.run(
+        QueryRequest(
+            query="In one sentence, what does main.py do?",
+            repo_path=sample_repo_path,
+        ),
+    )
+    assert len(res.answer.strip()) > 10

--- a/tests/unit/test_agents_base.py
+++ b/tests/unit/test_agents_base.py
@@ -19,4 +19,5 @@ def test_repo_agent_name_and_handle() -> None:
     assert a.name == "repo_agent"
     r = a.handle(QueryRequest(query="q"), context="ctx")
     assert isinstance(r, AgentResponse)
-    assert "stub" in r.answer
+    assert "repo_agent" in r.answer
+    assert r.tools_used

--- a/tests/unit/test_cli_app.py
+++ b/tests/unit/test_cli_app.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import os
+from unittest.mock import MagicMock, patch
+
 from typer.testing import CliRunner
 
 from adt.cli.app import app
+from adt.models.schemas import AgentResponse
 
 
 def test_cli_version() -> None:
+    """The ``version`` command should print a non-empty string."""
     runner = CliRunner()
     result = runner.invoke(app, ["version"])
     assert result.exit_code == 0
@@ -15,7 +20,43 @@ def test_cli_version() -> None:
 
 
 def test_cli_info() -> None:
+    """The ``info`` command should mention the MVP ``ask`` flow."""
     runner = CliRunner()
     result = runner.invoke(app, ["info"])
     assert result.exit_code == 0
-    assert "Phase" in result.stdout
+    assert "ask" in result.stdout.lower()
+
+
+def test_cli_ask_requires_api_key(tmp_path) -> None:
+    """``ask`` without ``OPENAI_API_KEY`` must exit with an error."""
+    runner = CliRunner()
+    repo = tmp_path / "r"
+    repo.mkdir()
+    with patch.dict(os.environ, {"OPENAI_API_KEY": ""}):
+        result = runner.invoke(app, ["ask", "hello?", "--repo", str(repo)])
+    assert result.exit_code == 1
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
+@patch("adt.cli.app.build_runner_for_repo")
+def test_cli_ask_runs_runner(mock_build, tmp_path) -> None:
+    """``ask`` should call ``build_runner_for_repo`` and print the model answer."""
+    mock_runner = MagicMock()
+    mock_runner.run.return_value = AgentResponse(
+        answer="Stubbed answer.",
+        tools_used=["read_repo_tree"],
+        context_summary="ctx",
+    )
+    mock_runner.last_token_usage = {"total_tokens": 10}
+    mock_build.return_value = mock_runner
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "x.py").write_text("a = 1\n", encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["ask", "Describe this repo.", "--repo", str(repo)],
+    )
+    assert result.exit_code == 0
+    assert "Stubbed answer." in result.stdout
+    mock_build.assert_called_once()

--- a/tests/unit/test_repo_agent.py
+++ b/tests/unit/test_repo_agent.py
@@ -1,0 +1,28 @@
+"""Tests for :class:`~adt.agents.repo_agent.RepoAgent`."""
+
+from __future__ import annotations
+
+from adt.agents.repo_agent import RepoAgent
+from adt.models.schemas import QueryRequest
+
+
+def test_repo_agent_tools_and_prompt() -> None:
+    """Declared tools and prompt should match the MVP contract."""
+    agent = RepoAgent()
+    assert agent.tools == ["read_repo_tree", "read_file", "search_code"]
+    assert "senior software engineer" in agent.system_prompt.lower()
+
+
+def test_repo_agent_handle_builds_context(sample_repo_path: str) -> None:
+    """``handle`` should assemble context from ``repo_path`` when set."""
+    agent = RepoAgent()
+    req = QueryRequest(query="what is this?", repo_path=sample_repo_path)
+    res = agent.handle(req, context="")
+    assert "read_repo_tree" in res.tools_used
+    assert len(res.context_summary) > 0
+    assert "Runner" in res.answer or "adt ask" in res.answer
+
+
+def test_repo_agent_name() -> None:
+    """Agent id should remain ``repo_agent``."""
+    assert RepoAgent().name == "repo_agent"

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -6,4 +6,4 @@ import adt
 
 
 def test_package_version() -> None:
-    assert adt.__version__ == "0.2.0"
+    assert adt.__version__ == "0.3.0"

--- a/tests/unit/test_tools_repo.py
+++ b/tests/unit/test_tools_repo.py
@@ -1,0 +1,38 @@
+"""Unit tests for repository tool functions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adt.tools import repo as repo_tools
+
+
+def test_read_repo_tree_lists_sample_files(sample_repo_path: str) -> None:
+    """``read_repo_tree`` should list known files in the fixture repo."""
+    root = Path(sample_repo_path)
+    out = repo_tools.read_repo_tree(root, path=".", max_depth=4)
+    assert "main.py" in out
+    assert "utils.py" in out
+
+
+def test_read_file_numbered_lines(sample_repo_path: str) -> None:
+    """``read_file`` should prefix lines and respect ``max_lines``."""
+    root = Path(sample_repo_path)
+    out = repo_tools.read_file(root, "main.py", max_lines=5)
+    assert "def main" in out or "main" in out
+    assert "   1 |" in out
+
+
+def test_search_code_finds_pattern(sample_repo_path: str) -> None:
+    """``search_code`` should return matching lines with paths."""
+    root = Path(sample_repo_path)
+    out = repo_tools.search_code(root, ".", r"def\s+add", max_results=10)
+    assert "utils.py" in out
+    assert "def add" in out
+
+
+def test_safe_resolve_rejects_traversal(sample_repo_path: str) -> None:
+    """Paths that escape the repo root must be rejected."""
+    root = Path(sample_repo_path)
+    out = repo_tools.read_file(root, "../../etc/passwd", max_lines=5)
+    assert "error" in out.lower()


### PR DESCRIPTION
## Summary
Delivers Phase 2 MVP: a usable CLI that analyzes a local repo and answers questions via supervisor → `repo_agent` → tools → LLM.

## Changes
- `adt ask` with `--repo`, `--verbose`, `--model` (Rich output)
- Repo tools: `read_repo_tree`, `read_file`, `search_code` (`.gitignore`-aware tree)
- `RepoAgent` + wiring via `build_runner_for_repo` / `Runner`
- Tests: unit, integration fixture `tests/fixtures/sample_repo/`, `@pytest.mark.live` for real API (excluded from default CI)
- README: install, usage, env vars, `pytest -m live`

## How to test
```bash
pip install -e ".[dev]"
export OPENAI_API_KEY=...   # or set in environment
adt ask "Summarize this repo" --repo .
pytest