### PR TITLE
feat(agent): add project agent with GitHub API integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,6 @@
 # Required for LLM-backed features (OpenAI-compatible API key)
 OPENAI_API_KEY=your-key-here
 
-# Optional: higher GitHub API rate limits for project agent (Phase 4+)
+# Optional: GitHub PAT for project_agent (read_issues / read_milestones).
+# Higher rate limits than anonymous API (~60 req/hr per IP without token).
 GITHUB_TOKEN=

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A context-oriented AI assistant CLI built with a simplified Model Context Protoc
 
 ## Status
 
-**Phase 3 — Research Agent:** In addition to repository analysis, `adt ask` can route to a **research agent** that searches **arXiv** and fetches public **web articles** (HTML/text). Use natural phrasing (“papers on …”, “arxiv …”) or force routing with `--agent`. See [docs/agents.md](docs/agents.md) for routing rules and tool details.
+**Phase 4 — Project Agent:** `adt ask` supports **local paths** or **`owner/repo`** for `--repo`. The **project agent** calls the **GitHub REST API** for issues and milestones and reads **local markdown** (e.g. `README.md`, `ROADMAP.md`). Use **`GITHUB_TOKEN`** or **`--token`** for higher rate limits and private repositories. See [docs/agents.md](docs/agents.md).
 
 ## Installation
 
@@ -29,11 +29,11 @@ make install
 
 ## Configuration
 
-Copy the example env file and set your OpenAI API key:
+Copy the example env file and set your keys:
 
 ```bash
 cp .env.example .env
-# Edit .env: OPENAI_API_KEY=...
+# Edit .env: OPENAI_API_KEY=..., optional GITHUB_TOKEN=...
 ```
 
 `adt` reads `OPENAI_API_KEY` from the process environment. Load `.env` with your shell or a tool such as [direnv](https://direnv.net/) if you use one.
@@ -43,40 +43,46 @@ cp .env.example .env
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `OPENAI_API_KEY` | Yes, for `ask` | OpenAI API key for chat completions. |
-| `GITHUB_TOKEN` | No | Reserved for future GitHub-backed agents (see `.env.example`). |
+| `GITHUB_TOKEN` | No | GitHub PAT for `read_issues` / `read_milestones` (higher rate limits, private repos). |
 | `ADT_LIVE_MODEL` | No | Optional model override for `pytest -m live` (default `gpt-4o-mini`). |
 
 ## Usage
 
-### Ask about a repository
+### Local repository (code analysis)
 
 ```bash
 adt ask "What does this project do?" --repo .
 ```
 
-### Ask about papers and articles (research agent)
+### GitHub project (`owner/repo`)
 
-The supervisor sends research-like questions to `research_agent`, which can call **arXiv** and **fetch** public URLs:
+If `--repo` is a slug like `octocat/Hello-World` (and that path is **not** an existing folder), the CLI uses the **current working directory** as the **markdown root** for `read_markdown`, and sets the **default GitHub** target for the session context:
+
+```bash
+cd ~/my-clone   # optional: where ROADMAP.md / README.md live
+adt ask "Summarize open issues" --repo octocat/Hello-World
+adt ask "What milestones are open?" --repo myorg/my-repo --token ghp_xxx
+```
+
+Without a token, unauthenticated calls are limited to about **60 requests/hour** per IP; the tools return a clear message when GitHub responds with **403** rate-limit errors.
+
+### Research (arXiv / web)
 
 ```bash
 adt ask "Recent papers on retrieval augmented generation" --repo .
-adt ask "Summarize https://example.com/article" --repo .
 ```
-
-Research answers are rendered as **Rich Markdown** (cyan panel) so titles and links are easier to scan.
 
 ### Force a specific agent
 
-Skip supervisor routing when you know which agent you want:
-
 ```bash
 adt ask "Explain src layout" --repo . --agent repo_agent
-adt ask "Find arxiv papers on graph neural networks" --repo . --agent research_agent
+adt ask "List issues" --repo myorg/repo --agent project_agent
 ```
 
 ### Options
 
-- `--repo`, `-r` — repository root (default: current directory; must exist). Used for repo tools and for `repo_agent` / `project_agent` context; `research_agent` ignores repo content in the prompt.
+- `--repo`, `-r` — **Local directory** (must exist) **or** **`owner/repo`** GitHub slug. Slug form uses `cwd` as the markdown root.
+- `--token` — GitHub PAT for this run (overrides `GITHUB_TOKEN` when set).
 - `--agent`, `-a` — `repo_agent`, `research_agent`, or `project_agent`.
 - `--verbose`, `-v` — debug logging, last token usage, and a truncated context summary.
 - `--model`, `-m` — OpenAI model name (default: `gpt-4o-mini`).
@@ -92,7 +98,7 @@ adt info
 
 ### Example session (shape of output)
 
-With a valid key you will see an **Agent:** line, then an **Answer** panel (green for repo-style answers, cyan Markdown for research), then **Tools used** (for example `read_repo_tree`, `search_papers`, `fetch_article`). With `--verbose`, extra debug lines follow.
+You will see an **Agent:** line, an **Answer** panel (green text, cyan Markdown for research, magenta Markdown for project), and **Tools used** (e.g. `read_issues`, `read_milestones`, `read_markdown`, `read_repo_tree`). With `--verbose`, extra debug lines follow.
 
 ## Development
 
@@ -103,10 +109,10 @@ make test      # pytest with coverage (excludes live LLM tests by default)
 make typecheck # mypy src/
 ```
 
-Default pytest runs exclude tests marked `@pytest.mark.live` (real API calls). To exercise live OpenAI (and real arXiv) locally:
+Default pytest runs exclude tests marked `@pytest.mark.live`. For live OpenAI (and real GitHub when tests call the network):
 
 ```bash
-export OPENAI_API_KEY=...   # Windows PowerShell: $env:OPENAI_API_KEY="..."
+export OPENAI_API_KEY=...
 pytest -m live
 ```
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -2,19 +2,24 @@
 
 This document summarizes built-in agents, their tools, and how routing works.
 
+## `--repo`: local path vs `owner/repo`
+
+- **Existing directory:** used as the root for **repo tools** (`repo_agent`) and **markdown reads** (`project_agent`). `QueryRequest.repo_path` is that directory; no default GitHub slug is implied.
+- **`owner/repo` slug** (only when that string is **not** an existing path): `repo_path` is set to the **current working directory** (markdown root), and `github_owner` / `github_repo` are filled for session hints. The runner defaults ambiguous queries to **`project_agent`** (see below).
+
 ## Supervisor routing
 
 The supervisor inspects the user query (lowercased) with simple substring rules, in order:
 
-1. **Project** — keywords such as `issue`, `milestone`, `roadmap`, `project`, `sprint`, `backlog` → `project_agent` (stub until Phase 4).
+1. **Project** — keywords such as `issue`, `issues`, `milestone`, `roadmap`, `project`, `sprint`, `backlog`, `github`, `epic`, `ticket`, `release`, `kanban`, `board`, `assignee`, `pull request`, `triaged` → `project_agent`.
 2. **Research** — keywords such as `paper`, `papers`, `arxiv`, `article`, `research`, `literature`, `survey`, `publication`, `journal`, `preprint`, `doi`, and the phrase `literature review` → `research_agent`.
-3. **Repository** — keywords such as `repo`, `code`, `codebase`, `architecture`, `explain`, `file`, `function`, `implementation`, and **`search`** → `repo_agent`. Including `search` under the repo bucket avoids sending generic “search the codebase” questions to the research agent.
-4. **Default** — if nothing matches, the query is handled by **`repo_agent`**.
+3. **Repository** — keywords such as `repo`, `code`, `codebase`, `architecture`, `explain`, `file`, `function`, `implementation`, and **`search`** → `repo_agent`.
+4. **Default** — if nothing matches: **`project_agent`** when `github_owner` / `github_repo` are set (remote `--repo`); otherwise **`repo_agent`**.
 
 You can bypass routing with:
 
 ```bash
-adt ask "your question" --repo . --agent research_agent
+adt ask "your question" --repo . --agent project_agent
 ```
 
 Valid values: `repo_agent`, `research_agent`, `project_agent`.
@@ -23,25 +28,31 @@ Valid values: `repo_agent`, `research_agent`, `project_agent`.
 
 **Purpose:** Understand a local checkout (layout, files, symbols).
 
-**Tools:**
+**Tools:** `read_repo_tree`, `read_file`, `search_code`.
 
-- `read_repo_tree` — directory tree respecting `.gitignore`.
-- `read_file` — bounded read of a text file.
-- `search_code` — regex search across text files.
-
-**Context:** The runner attaches repository-derived context for this agent (unless you force another agent).
+**Context:** Repository-derived context from `repo_path`.
 
 ## `research_agent`
 
-**Purpose:** Discover academic papers and read public web articles to support technical study.
+**Purpose:** Discover academic papers and read public web articles.
 
 **Tools:**
 
-- `search_papers` — queries the public **arXiv Atom API** (`http://export.arxiv.org/api/query`) with `search_query=all:{query}` and returns titles, authors, abstract snippets, and abstract URLs. No API key is required. Results are clamped to at most 50 items per call; the CLI uses a descriptive `User-Agent` string.
-- `fetch_article` — downloads an `http` or `https` URL with `httpx`, enforces a response size cap, and extracts visible text from HTML (scripts/styles skipped) or returns plain text bodies. **Local and non-global hosts are rejected** (basic SSRF mitigation).
+- `search_papers` — arXiv Atom API (`http://export.arxiv.org/api/query`).
+- `fetch_article` — public HTTP(S) pages with basic SSRF blocking.
 
-**Context:** The runner does **not** load the repository tree for `research_agent`, even if `--repo` is set, so prompts stay focused on external sources. Use `--agent repo_agent` (or a repo-oriented question) when you need both codebase and papers in one session.
+**Context:** Empty repository blob; external sources only.
 
 ## `project_agent`
 
-**Purpose:** Placeholder for GitHub-centric workflows (Phase 4+). No tools yet.
+**Purpose:** Roadmap and delivery status via **GitHub** and **local markdown**.
+
+**Tools:**
+
+- `read_issues` — `GET /repos/{owner}/{repo}/issues` (pull requests filtered out). Optional `state` (`open` / `closed` / `all`), `labels`, `max_results`.
+- `read_milestones` — `GET /repos/{owner}/{repo}/milestones`.
+- `read_markdown` — read `.md` / `.markdown` under the session markdown root; strips optional YAML front matter (`---` … `---`).
+
+**GitHub authentication:** Handlers receive a token from the CLI (`--token`) or environment **`GITHUB_TOKEN`**. Without a token, expect about **60 requests/hour** per IP; **403** responses include rate-limit hints when GitHub provides headers.
+
+**Context:** If a GitHub slug was passed on the CLI, the user message includes the default `owner/repo`. If only a local path was used, the runner adds repo tree context plus the markdown root path. Remote slug sessions skip the full tree (only short session hints) to avoid dumping unrelated `cwd` files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentic-dev-tool"
-version = "0.4.0"
+version = "0.5.0"
 description = "Context-oriented AI assistant CLI with a simplified MCP-style tool layer."
 readme = "README.md"
 license = { text = "MIT" }

--- a/src/adt/__init__.py
+++ b/src/adt/__init__.py
@@ -1,3 +1,3 @@
 """Agentic Dev Tool — context-oriented AI assistant CLI."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/src/adt/agents/project_agent.py
+++ b/src/adt/agents/project_agent.py
@@ -1,31 +1,71 @@
-"""Project and issue management agent (stub for Phase 1)."""
+"""Project agent with GitHub issues, milestones, and local markdown tools."""
 
 from __future__ import annotations
 
 from adt.agents.base import BaseAgent
+from adt.mcp.context import ContextBuilder
 from adt.models.schemas import AgentResponse, QueryRequest
+
+_PROJECT_SYSTEM_PROMPT = """
+You are a technical project manager helping with delivery status and planning.
+
+## Workflow
+1. When the user asks about issues, triage, or bugs, call read_issues with the
+   correct owner and repo (use the session default if provided in context).
+2. For timelines, releases, or planning buckets, call read_milestones.
+3. For roadmap or documentation questions, use read_markdown on paths such as
+   README.md or ROADMAP.md relative to the local markdown root.
+
+## Tool usage
+- read_issues excludes pull requests; mention that distinction when listing work.
+- Pass labels as a comma-separated string when filtering (GitHub API format).
+- If GitHub returns rate-limit errors, explain that setting GITHUB_TOKEN or
+  using the CLI --token flag increases limits.
+
+## Response format
+- Summaries first: counts, themes, blockers, and next steps.
+- Then bullet lists with issue numbers, titles, and links when present in tool
+  output.
+
+## Quality bar
+- Do not invent issue numbers or milestone titles; only use tool output.
+- If tools fail, say what you attempted and what the user can fix (token, slug).
+""".strip()
 
 
 class ProjectAgent(BaseAgent):
-    """GitHub-centric project insights; Phase 4 adds API-backed tools."""
+    """Agent for GitHub project data and local markdown roadmaps."""
 
     @property
     def system_prompt(self) -> str:
-        """Return a short stub prompt until GitHub tools land in Phase 4."""
-        return (
-            "You are a technical project manager. "
-            "Summarize issues and milestones when tools exist."
-        )
+        """Return instructions for issues, milestones, and markdown roadmaps."""
+        return _PROJECT_SYSTEM_PROMPT
 
     @property
     def tools(self) -> list[str]:
-        """No registered tools yet for this agent."""
-        return []
+        """Tool names registered for this agent in :mod:`adt.bootstrap`."""
+        return ["read_issues", "read_milestones", "read_markdown"]
 
     def handle(self, request: QueryRequest, context: str) -> AgentResponse:
-        """Echo the query as a stub response for tests and future orchestration."""
+        """Describe tools and context preview without invoking the LLM.
+
+        The interactive ``adt ask`` path uses :class:`~adt.core.runner.Runner`.
+
+        Args:
+            request: User query plus optional GitHub and path metadata.
+            context: Optional caller-provided context string.
+
+        Returns:
+            Short preview listing project tool names.
+        """
+        builder = ContextBuilder()
+        built = builder.build_from_text(context or "")
         return AgentResponse(
-            answer=f"(stub project_agent) Query: {request.query!r}",
-            tools_used=[],
-            context_summary=context[:500],
+            answer=(
+                "project_agent: use `adt ask` (Runner) for LLM-backed answers. "
+                f"Context preview length: {len(built)} characters."
+            ),
+            tools_used=list(self.tools),
+            context_summary=built[:400],
+            routed_agent=self.name,
         )

--- a/src/adt/bootstrap.py
+++ b/src/adt/bootstrap.py
@@ -14,6 +14,7 @@ from adt.core.supervisor import Supervisor
 from adt.mcp.context import ContextBuilder
 from adt.mcp.executor import ExecutionController
 from adt.mcp.registry import ToolDefinition, ToolRegistry
+from adt.tools import project as project_tools
 from adt.tools import repo as repo_tools
 from adt.tools import research as research_tools
 
@@ -205,27 +206,188 @@ def register_research_tools(registry: ToolRegistry) -> None:
     )
 
 
-def build_runner_for_repo(
-    repo_root: Path,
+def register_project_tools(
+    registry: ToolRegistry,
+    markdown_root: Path,
+    *,
+    token: str | None = None,
+) -> None:
+    """Register GitHub and local markdown tools for ``project_agent``.
+
+    Handlers for issues and milestones pass through ``token`` for authenticated
+    GitHub API access (higher rate limits). ``read_markdown`` is confined to
+    ``markdown_root``.
+
+    Args:
+        registry: Registry without conflicting tool names.
+        markdown_root: Base path for :func:`~adt.tools.project.read_markdown`.
+        token: Optional GitHub PAT (or ``GITHUB_TOKEN`` supplied by the caller).
+    """
+    root = markdown_root.resolve()
+
+    def read_issues(
+        owner: str,
+        repo: str,
+        state: str = "open",
+        labels: str = "",
+        max_results: int = 30,
+    ) -> str:
+        """List issues via :func:`adt.tools.project.read_issues` with shared token."""
+        return project_tools.read_issues(
+            owner,
+            repo,
+            state=state,
+            labels=labels,
+            max_results=max_results,
+            token=token,
+        )
+
+    def read_milestones(
+        owner: str,
+        repo: str,
+        state: str = "open",
+        max_results: int = 20,
+    ) -> str:
+        """List milestones via :func:`adt.tools.project.read_milestones`."""
+        return project_tools.read_milestones(
+            owner,
+            repo,
+            state=state,
+            max_results=max_results,
+            token=token,
+        )
+
+    def read_markdown(path: str, max_chars: int = 120_000) -> str:
+        """Read markdown under the configured root."""
+        return project_tools.read_markdown(root, path, max_chars=max_chars)
+
+    registry.register(
+        ToolDefinition(
+            name="read_issues",
+            description=(
+                "List GitHub issues for a repository (pull requests excluded). "
+                "Unauthenticated calls are rate-limited (~60/hour per IP); "
+                "prefer a token for private repos or heavier use."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "owner": {
+                        "type": "string",
+                        "description": "GitHub user or organization login.",
+                    },
+                    "repo": {
+                        "type": "string",
+                        "description": "Repository name.",
+                    },
+                    "state": {
+                        "type": "string",
+                        "description": "open, closed, or all (default open).",
+                        "enum": ["open", "closed", "all"],
+                    },
+                    "labels": {
+                        "type": "string",
+                        "description": "Comma-separated label filters (optional).",
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Max issues to return (1–100, default 30).",
+                        "minimum": 1,
+                        "maximum": 100,
+                    },
+                },
+                "required": ["owner", "repo"],
+                "additionalProperties": False,
+            },
+            allowed_agents=["project_agent"],
+            handler=read_issues,
+        ),
+    )
+    registry.register(
+        ToolDefinition(
+            name="read_milestones",
+            description=(
+                "List GitHub milestones for a repository with open/closed counts."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "owner": {"type": "string", "description": "Owner login."},
+                    "repo": {"type": "string", "description": "Repository name."},
+                    "state": {
+                        "type": "string",
+                        "description": "open, closed, or all (default open).",
+                        "enum": ["open", "closed", "all"],
+                    },
+                    "max_results": {
+                        "type": "integer",
+                        "description": "Max milestones (1–50, default 20).",
+                        "minimum": 1,
+                        "maximum": 50,
+                    },
+                },
+                "required": ["owner", "repo"],
+                "additionalProperties": False,
+            },
+            allowed_agents=["project_agent"],
+            handler=read_milestones,
+        ),
+    )
+    registry.register(
+        ToolDefinition(
+            name="read_markdown",
+            description=(
+                "Read a local .md or .markdown file relative to the session root; "
+                "YAML front matter is stripped when present."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "path": {
+                        "type": "string",
+                        "description": "Relative path to the markdown file.",
+                    },
+                    "max_chars": {
+                        "type": "integer",
+                        "description": "Max characters of body text (default 120000).",
+                        "minimum": 1000,
+                        "maximum": 500000,
+                    },
+                },
+                "required": ["path"],
+                "additionalProperties": False,
+            },
+            allowed_agents=["project_agent"],
+            handler=read_markdown,
+        ),
+    )
+
+
+def build_runner(
+    local_root: Path,
     *,
     model: str = "gpt-4o-mini",
     api_key: str | None = None,
+    github_token: str | None = None,
     max_tool_iterations: int = 5,
 ) -> Runner:
-    """Construct a :class:`~adt.core.runner.Runner` scoped to one repository path.
+    """Construct a :class:`~adt.core.runner.Runner` for the full agent/tool set.
 
     Args:
-        repo_root: Local repository directory for tools and context.
+        local_root: Directory for repo tools and project_agent markdown reads.
         model: OpenAI chat model name.
         api_key: Optional API key (falls back to ``OPENAI_API_KEY`` in the client).
+        github_token: Optional token forwarded to GitHub REST tools.
         max_tool_iterations: Upper bound on LLM/tool round-trips.
 
     Returns:
-        A fully wired runner with repo and research tools registered.
+        A runner with repo, research, and project tools registered.
     """
     registry = ToolRegistry()
-    register_repo_tools(registry, repo_root)
+    root = local_root.resolve()
+    register_repo_tools(registry, root)
     register_research_tools(registry)
+    register_project_tools(registry, root, token=github_token)
     supervisor = Supervisor()
     llm = LLMClient(model=model, api_key=api_key)
     context = ContextBuilder()
@@ -242,5 +404,23 @@ def build_runner_for_repo(
         executor,
         registry,
         agents,
+        max_tool_iterations=max_tool_iterations,
+    )
+
+
+def build_runner_for_repo(
+    repo_root: Path,
+    *,
+    model: str = "gpt-4o-mini",
+    api_key: str | None = None,
+    github_token: str | None = None,
+    max_tool_iterations: int = 5,
+) -> Runner:
+    """Backward-compatible alias for :func:`build_runner` with a repository path."""
+    return build_runner(
+        repo_root,
+        model=model,
+        api_key=api_key,
+        github_token=github_token,
         max_tool_iterations=max_tool_iterations,
     )

--- a/src/adt/cli/app.py
+++ b/src/adt/cli/app.py
@@ -1,11 +1,10 @@
-"""Typer CLI entry point including the ``ask`` command (repo and research agents)."""
+"""Typer CLI entry point including the ``ask`` command (all agents)."""
 
 from __future__ import annotations
 
 import logging
 import os
 from importlib import metadata
-from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -13,8 +12,9 @@ from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
 
-from adt.bootstrap import build_runner_for_repo
+from adt.bootstrap import build_runner
 from adt.models.schemas import QueryRequest
+from adt.repo_spec import resolve_repo_target
 
 app = typer.Typer(help="Agentic Dev Tool CLI", add_completion=False)
 console = Console()
@@ -27,7 +27,7 @@ def _version_string() -> str:
     try:
         return metadata.version("agentic-dev-tool")
     except metadata.PackageNotFoundError:
-        return "0.4.0-dev"
+        return "0.5.0-dev"
 
 
 def _format_ask_panel(agent_name: str, answer: str) -> None:
@@ -38,6 +38,16 @@ def _format_ask_panel(agent_name: str, answer: str) -> None:
                 Markdown(answer),
                 title="Answer",
                 border_style="cyan",
+                title_align="left",
+            ),
+        )
+        return
+    if agent_name == "project_agent":
+        console.print(
+            Panel(
+                Markdown(answer),
+                title="Answer",
+                border_style="magenta",
                 title_align="left",
             ),
         )
@@ -55,8 +65,8 @@ def version_cmd() -> None:
 def info_cmd() -> None:
     """Print short project status and feature summary."""
     typer.echo(
-        'adt — Phase 3. Use: adt ask "question" --repo . '
-        "or research queries (arXiv). Optional: --agent research_agent.",
+        "adt — Phase 4. ask: local path or owner/repo; GitHub tools for "
+        "project_agent; --token or GITHUB_TOKEN for API limits.",
     )
 
 
@@ -69,17 +79,23 @@ def ask_cmd(
         ),
     ],
     repo: Annotated[
-        Path,
+        str,
         typer.Option(
             "--repo",
             "-r",
-            help="Path to the repository root (for context and repo tools).",
-            exists=True,
-            file_okay=False,
-            dir_okay=True,
-            resolve_path=True,
+            help=(
+                "Local directory or GitHub slug owner/repo (markdown root uses cwd "
+                "when slug is used)."
+            ),
         ),
-    ] = Path("."),
+    ] = ".",
+    token: Annotated[
+        str | None,
+        typer.Option(
+            "--token",
+            help="GitHub PAT for read_issues / read_milestones (or set GITHUB_TOKEN).",
+        ),
+    ] = None,
     agent: Annotated[
         str | None,
         typer.Option(
@@ -122,15 +138,27 @@ def ask_cmd(
         )
         raise typer.Exit(code=1)
 
-    repo_path = repo.resolve()
-    runner = build_runner_for_repo(
-        repo_path,
+    try:
+        target = resolve_repo_target(repo)
+    except ValueError as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+    github_token = token.strip() if token else None
+    if not github_token:
+        env_gh = os.environ.get("GITHUB_TOKEN")
+        github_token = env_gh.strip() if env_gh else None
+
+    runner = build_runner(
+        target.local_root,
         model=model,
         api_key=api_key,
+        github_token=github_token,
     )
     request = QueryRequest(
         query=query,
-        repo_path=str(repo_path),
+        repo_path=str(target.local_root),
+        github_owner=target.github_owner,
+        github_repo=target.github_repo,
         force_agent=agent,
     )
     response = runner.run(request)

--- a/src/adt/core/runner.py
+++ b/src/adt/core/runner.py
@@ -83,10 +83,32 @@ class Runner:
             routed = self._supervisor.route(request)
         agent = self._agents[routed.agent_name]
 
+        req = routed.request
         if routed.agent_name == "research_agent":
             raw_context = self._context.build_from_text("")
-        elif routed.request.repo_path:
-            raw_context = self._context.build_from_repo(routed.request.repo_path)
+        elif routed.agent_name == "project_agent":
+            parts: list[str] = []
+            if req.github_owner and req.github_repo:
+                parts.append(
+                    f"Default GitHub repository: {req.github_owner}/{req.github_repo}. "
+                    "Use these owner and repo values in read_issues and "
+                    "read_milestones unless the user specifies another repository."
+                )
+            if req.repo_path:
+                parts.append(
+                    "Local markdown root for read_markdown (relative paths): "
+                    f"{req.repo_path}"
+                )
+            meta = "\n".join(parts)
+            if req.github_owner and req.github_repo:
+                raw_context = self._context.build_from_text(meta)
+            elif req.repo_path:
+                repo_blob = self._context.build_from_repo(req.repo_path)
+                raw_context = f"{meta}\n\n{repo_blob}" if meta else repo_blob
+            else:
+                raw_context = self._context.build_from_text(meta)
+        elif req.repo_path:
+            raw_context = self._context.build_from_repo(req.repo_path)
         else:
             raw_context = self._context.build_from_text("")
 

--- a/src/adt/core/supervisor.py
+++ b/src/adt/core/supervisor.py
@@ -6,11 +6,22 @@ from adt.models.schemas import QueryRequest, RoutedRequest
 
 _PROJECT_KEYWORDS = (
     "issue",
+    "issues",
     "milestone",
+    "milestones",
     "roadmap",
     "project",
     "sprint",
     "backlog",
+    "github",
+    "epic",
+    "ticket",
+    "release",
+    "kanban",
+    "board",
+    "assignee",
+    "pull request",
+    "triaged",
 )
 _RESEARCH_KEYWORDS = (
     "paper",
@@ -47,13 +58,19 @@ class Supervisor:
     def route(self, request: QueryRequest) -> RoutedRequest:
         """Return the agent name and a possibly enriched ``QueryRequest``.
 
-        Precedence: project keywords, then research, then repository, then default
-        ``repo_agent``. Matching is case-insensitive via substring search. The word
-        ``search`` maps to the repository agent so that codebase queries are not
-        misrouted to research.
+        Precedence: project keywords, then research, then repository, then default.
+        The default is ``repo_agent`` for local sessions and ``project_agent`` when
+        ``github_owner`` / ``github_repo`` are set (``--repo owner/repo``). The word
+        ``search`` maps to the repository agent so codebase queries are not sent to
+        research.
         """
         text = request.query.lower()
         enriched = request.model_copy(deep=True)
+        default_agent = (
+            "project_agent"
+            if (enriched.github_owner and enriched.github_repo)
+            else "repo_agent"
+        )
 
         if any(k in text for k in _PROJECT_KEYWORDS):
             enriched.options = {**enriched.options, "route": "project_keywords"}
@@ -68,4 +85,4 @@ class Supervisor:
             return RoutedRequest(agent_name="repo_agent", request=enriched)
 
         enriched.options = {**enriched.options, "route": "default"}
-        return RoutedRequest(agent_name="repo_agent", request=enriched)
+        return RoutedRequest(agent_name=default_agent, request=enriched)

--- a/src/adt/models/schemas.py
+++ b/src/adt/models/schemas.py
@@ -17,7 +17,18 @@ class QueryRequest(BaseModel):
     query: str = Field(..., description="Natural language question or instruction.")
     repo_path: str | None = Field(
         default=None,
-        description="Optional filesystem path to a repository root.",
+        description=(
+            "Local directory: repository root for repo tools and markdown root "
+            "for project_agent."
+        ),
+    )
+    github_owner: str | None = Field(
+        default=None,
+        description="With github_repo, default GitHub API owner login.",
+    )
+    github_repo: str | None = Field(
+        default=None,
+        description="With github_owner, default GitHub API repository name.",
     )
     options: dict[str, Any] = Field(
         default_factory=dict,
@@ -30,6 +41,16 @@ class QueryRequest(BaseModel):
             "(e.g. research_agent, repo_agent)."
         ),
     )
+
+    @model_validator(mode="after")
+    def github_owner_repo_pair(self) -> QueryRequest:
+        """Require ``github_owner`` and ``github_repo`` to be set together."""
+        has_o = self.github_owner is not None
+        has_r = self.github_repo is not None
+        if has_o ^ has_r:
+            msg = "github_owner and github_repo must both be set or both omitted."
+            raise ValueError(msg)
+        return self
 
 
 class ToolCall(BaseModel):

--- a/src/adt/repo_spec.py
+++ b/src/adt/repo_spec.py
@@ -1,0 +1,60 @@
+"""Parse ``--repo`` values as a local directory or ``owner/repo`` GitHub slug."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+_GITHUB_SLUG = re.compile(r"^[\w.-]+/[\w.-]+$")
+
+
+@dataclass(frozen=True)
+class ResolvedRepoTarget:
+    """Result of parsing ``--repo`` (local dir and optional ``owner/repo``)."""
+
+    local_root: Path
+    github_owner: str | None
+    github_repo: str | None
+
+
+def resolve_repo_target(value: str) -> ResolvedRepoTarget:
+    """Return a local root path and optional ``owner``/``repo`` for GitHub API tools.
+
+    If ``value`` is an existing directory, it is used as ``local_root`` and no
+    GitHub slug is set. If it matches ``owner/repo`` (and is not an existing
+    path), ``local_root`` defaults to the current working directory for
+    :func:`~adt.tools.project.read_markdown` and related local reads.
+
+    Args:
+        value: Raw ``--repo`` string from the CLI.
+
+    Returns:
+        Frozen dataclass with ``local_root`` and optional GitHub owner/repo.
+
+    Raises:
+        ValueError: When ``value`` is neither a directory nor a valid slug.
+    """
+    v = value.strip()
+    if not v:
+        msg = "Repository path or owner/repo slug is empty."
+        raise ValueError(msg)
+    expanded = Path(v).expanduser()
+    if expanded.exists() and expanded.is_dir():
+        return ResolvedRepoTarget(
+            local_root=expanded.resolve(),
+            github_owner=None,
+            github_repo=None,
+        )
+    if _GITHUB_SLUG.fullmatch(v):
+        owner, _, repo = v.partition("/")
+        return ResolvedRepoTarget(
+            local_root=Path.cwd().resolve(),
+            github_owner=owner,
+            github_repo=repo,
+        )
+    msg = (
+        f"Not a directory and not a valid owner/repo slug "
+        f"(expected e.g. myorg/my-repo): {value!r}"
+    )
+    raise ValueError(msg)

--- a/src/adt/tools/project.py
+++ b/src/adt/tools/project.py
@@ -1,1 +1,318 @@
-"""Project tools: issues, milestones, markdown (implemented in Phase 4)."""
+"""GitHub REST helpers and local markdown reading for the project agent."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+_GITHUB_API = "https://api.github.com"
+_DEFAULT_TIMEOUT = 30.0
+_MAX_ISSUES_CAP = 100
+_MAX_MILESTONES_CAP = 50
+
+
+def _safe_resolve_under(root: Path, relative: str) -> Path:
+    """Resolve ``relative`` under ``root``; raise ``ValueError`` on escape attempts."""
+    root = root.resolve()
+    candidate = (root / relative).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        msg = "Path escapes markdown root."
+        raise ValueError(msg) from exc
+    return candidate
+
+
+def _strip_optional_yaml_front_matter(text: str) -> str:
+    """Remove a leading YAML front matter block (``---`` … ``---``) when present."""
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        return text
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        return text
+    return "".join(lines[end + 1 :]).lstrip("\n")
+
+
+def _github_request_headers(token: str | None) -> dict[str, str]:
+    """Build headers for GitHub REST requests (API version + optional bearer token)."""
+    headers: dict[str, str] = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "agentic-dev-tool-project-agent",
+    }
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _format_rate_limit_hint(response: httpx.Response) -> str:
+    """Return a short human-readable rate-limit note from response headers."""
+    remaining = response.headers.get("x-ratelimit-remaining")
+    reset = response.headers.get("x-ratelimit-reset")
+    limit = response.headers.get("x-ratelimit-limit")
+    parts = []
+    if remaining is not None:
+        parts.append(f"remaining={remaining}")
+    if limit is not None:
+        parts.append(f"limit={limit}")
+    if reset is not None:
+        try:
+            ts = int(reset)
+            when = datetime.fromtimestamp(ts, tz=timezone.utc)
+            parts.append(f"resets_utc={when.isoformat()}")
+        except ValueError:
+            parts.append(f"reset={reset}")
+    return "; ".join(parts) if parts else ""
+
+
+def _github_error_body(response: httpx.Response) -> str:
+    """Extract a concise error string from a JSON error response when possible."""
+    try:
+        data = response.json()
+    except Exception:
+        return (response.text or "")[:500]
+    if isinstance(data, dict):
+        msg = data.get("message", "")
+        if isinstance(msg, str) and msg:
+            return msg
+    return (response.text or "")[:500]
+
+
+def read_issues(
+    owner: str,
+    repo: str,
+    *,
+    state: str = "open",
+    labels: str = "",
+    max_results: int = 30,
+    token: str | None = None,
+) -> str:
+    """List GitHub issues (excluding pull requests) for a repository.
+
+    Uses the public REST API. Unauthenticated requests are limited to roughly
+    60 requests per hour per IP; pass a token for higher limits.
+
+    Args:
+        owner: GitHub organization or user login.
+        repo: Repository name.
+        state: ``open``, ``closed``, or ``all``.
+        labels: Comma-separated label names to filter (GitHub ``labels`` param).
+        max_results: Maximum issues to return (capped at 100).
+        token: Optional ``GITHUB_TOKEN`` or PAT with ``repo`` scope for private repos.
+
+    Returns:
+        A text summary of issues, or an error description including rate-limit hints.
+    """
+    o = owner.strip()
+    r = repo.strip()
+    if not o or not r:
+        return "Error: owner and repo must be non-empty."
+    st = state.strip().lower()
+    if st not in ("open", "closed", "all"):
+        return "Error: state must be open, closed, or all."
+    n = max(1, min(_MAX_ISSUES_CAP, int(max_results)))
+    params: dict[str, str | int] = {
+        "state": st,
+        "per_page": n,
+        "page": 1,
+    }
+    labels_clean = labels.strip()
+    if labels_clean:
+        params["labels"] = labels_clean
+
+    url = f"{_GITHUB_API}/repos/{o}/{r}/issues"
+    try:
+        with httpx.Client(
+            timeout=_DEFAULT_TIMEOUT,
+            headers=_github_request_headers(token),
+        ) as client:
+            response = client.get(url, params=params)
+    except httpx.HTTPError as exc:
+        return f"Error: GitHub HTTP request failed: {exc}"
+
+    if response.status_code == 403:
+        hint = _format_rate_limit_hint(response)
+        body = _github_error_body(response)
+        return (
+            "Error: GitHub returned 403 (often rate limit or missing permissions). "
+            f"{body}. Headers: {hint}. "
+            "Set GITHUB_TOKEN or use --token for higher limits."
+        )
+    if response.status_code != 200:
+        return (
+            f"Error: GitHub issues API status {response.status_code}: "
+            f"{_github_error_body(response)}"
+        )
+
+    data = response.json()
+    if not isinstance(data, list):
+        return "Error: unexpected GitHub API response shape."
+
+    remaining_hint = _format_rate_limit_hint(response)
+    lines: list[str] = [
+        f"Issues for {o}/{r} (state={st}, showing up to {n}):",
+    ]
+    if remaining_hint:
+        lines.append(f"(API rate limit: {remaining_hint})")
+    count = 0
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        if "pull_request" in item:
+            continue
+        count += 1
+        num = item.get("number")
+        title = item.get("title") or ""
+        istate = item.get("state") or ""
+        user = (item.get("user") or {}) if isinstance(item.get("user"), dict) else {}
+        login = user.get("login", "")
+        html_url = item.get("html_url", "")
+        labels_raw = item.get("labels") or []
+        label_names: list[str] = []
+        if isinstance(labels_raw, list):
+            for lab in labels_raw:
+                if isinstance(lab, dict) and lab.get("name"):
+                    label_names.append(str(lab["name"]))
+        lab_line = ", ".join(label_names) if label_names else "(no labels)"
+        lines.append(
+            f"- #{num} [{istate}] {title}\n"
+            f"  author={login} labels={lab_line}\n"
+            f"  url={html_url}",
+        )
+    if count == 0:
+        lines.append("(No issues matched; note: pull requests are excluded.)")
+    return "\n".join(lines)
+
+
+def read_milestones(
+    owner: str,
+    repo: str,
+    *,
+    state: str = "open",
+    max_results: int = 20,
+    token: str | None = None,
+) -> str:
+    """List GitHub milestones for a repository.
+
+    Args:
+        owner: GitHub organization or user login.
+        repo: Repository name.
+        state: ``open``, ``closed``, or ``all``.
+        max_results: Maximum milestones (capped at 50).
+        token: Optional bearer token for private repos / higher rate limits.
+
+    Returns:
+        Text summary or an error string with rate-limit guidance when relevant.
+    """
+    o = owner.strip()
+    r = repo.strip()
+    if not o or not r:
+        return "Error: owner and repo must be non-empty."
+    st = state.strip().lower()
+    if st not in ("open", "closed", "all"):
+        return "Error: state must be open, closed, or all."
+    n = max(1, min(_MAX_MILESTONES_CAP, int(max_results)))
+    params: dict[str, str | int] = {
+        "state": st,
+        "per_page": n,
+        "page": 1,
+    }
+    url = f"{_GITHUB_API}/repos/{o}/{r}/milestones"
+    try:
+        with httpx.Client(
+            timeout=_DEFAULT_TIMEOUT,
+            headers=_github_request_headers(token),
+        ) as client:
+            response = client.get(url, params=params)
+    except httpx.HTTPError as exc:
+        return f"Error: GitHub HTTP request failed: {exc}"
+
+    if response.status_code == 403:
+        hint = _format_rate_limit_hint(response)
+        body = _github_error_body(response)
+        return (
+            "Error: GitHub returned 403 (often rate limit or missing permissions). "
+            f"{body}. Headers: {hint}. "
+            "Set GITHUB_TOKEN or use --token for higher limits."
+        )
+    if response.status_code != 200:
+        return (
+            f"Error: GitHub milestones API status {response.status_code}: "
+            f"{_github_error_body(response)}"
+        )
+
+    raw = response.json()
+    if not isinstance(raw, list):
+        return "Error: unexpected GitHub API response shape."
+
+    remaining_hint = _format_rate_limit_hint(response)
+    lines: list[str] = [
+        f"Milestones for {o}/{r} (state={st}, showing up to {n}):",
+    ]
+    if remaining_hint:
+        lines.append(f"(API rate limit: {remaining_hint})")
+    for ms in raw:
+        if not isinstance(ms, dict):
+            continue
+        title = ms.get("title") or ""
+        desc = (ms.get("description") or "").strip()
+        if len(desc) > 400:
+            desc = desc[:397] + "..."
+        ms_state = ms.get("state") or ""
+        open_issues = ms.get("open_issues")
+        closed_issues = ms.get("closed_issues")
+        due = ms.get("due_on") or "(no due date)"
+        html_url = ms.get("html_url", "")
+        lines.append(
+            f"- [{ms_state}] {title}\n"
+            f"  open_issues={open_issues} closed_issues={closed_issues} due={due}\n"
+            f"  url={html_url}\n"
+            f"  description: {desc or '(none)'}",
+        )
+    if len(lines) <= 2:
+        lines.append("(No milestones returned.)")
+    return "\n".join(lines)
+
+
+def read_markdown(root: Path, path: str, *, max_chars: int = 120_000) -> str:
+    """Read a markdown file under ``root`` and return its text (UTF-8).
+
+    Optional YAML front matter delimited by ``---`` lines is stripped from the
+    returned body. Only files ending in ``.md`` or ``.markdown`` are allowed.
+
+    Args:
+        root: Directory that bounds relative ``path`` resolution.
+        path: File path relative to ``root``.
+        max_chars: Maximum characters returned from the body after stripping.
+
+    Returns:
+        File contents (possibly truncated) or an error message.
+    """
+    rel = path.strip().replace("\\", "/")
+    if not rel or rel.startswith("/"):
+        return "Error: path must be a relative file path."
+    suffix = Path(rel).suffix.lower()
+    if suffix not in {".md", ".markdown"}:
+        return "Error: only .md and .markdown files are allowed."
+    try:
+        full = _safe_resolve_under(root, rel)
+    except ValueError as exc:
+        return f"Error: {exc}"
+    if not full.is_file():
+        return f"Error: not a file: {rel}"
+    try:
+        raw = full.read_text(encoding="utf-8")
+    except OSError as exc:
+        return f"Error: failed to read file: {exc}"
+    body = _strip_optional_yaml_front_matter(raw)
+    limit = max(1000, min(500_000, int(max_chars)))
+    if len(body) > limit:
+        body = body[: limit - 3] + "..."
+    return f"Markdown file {rel} ({len(body)} chars):\n\n{body}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 import pytest
 
-from adt.bootstrap import register_repo_tools, register_research_tools
+from adt.bootstrap import (
+    register_project_tools,
+    register_repo_tools,
+    register_research_tools,
+)
 from adt.mcp.registry import ToolRegistry
 
 
@@ -14,8 +18,10 @@ from adt.mcp.registry import ToolRegistry
 def tool_registry(sample_repo_path: str) -> ToolRegistry:
     """A tool registry with repo tools bound to the sample fixture repository."""
     reg = ToolRegistry()
-    register_repo_tools(reg, Path(sample_repo_path))
+    root = Path(sample_repo_path)
+    register_repo_tools(reg, root)
     register_research_tools(reg)
+    register_project_tools(reg, root, token=None)
     return reg
 
 

--- a/tests/integration/test_full_flow.py
+++ b/tests/integration/test_full_flow.py
@@ -14,6 +14,7 @@ from adt.mcp.context import ContextBuilder
 from adt.mcp.executor import ExecutionController
 from adt.models.schemas import LLMMessage, QueryRequest, ToolCall
 from tests.fake_llm import FakeLLM
+from tests.unit.test_tools_project import _mock_httpx_client_for_github_get
 from tests.unit.test_tools_research import _ARXIV_ATOM, _mock_httpx_client_for_get
 
 
@@ -111,6 +112,67 @@ def test_runner_research_search_papers_then_answer(
     assert res.answer == "Found relevant work."
     assert "search_papers" in res.tools_used
     assert res.routed_agent == "research_agent"
+
+
+@patch("adt.tools.project.httpx.Client")
+def test_runner_project_read_issues_then_answer(
+    mock_client_cls,
+    tool_registry,
+    sample_repo_path: str,
+) -> None:
+    """Project route runs ``read_issues`` (mocked GitHub) then returns model text."""
+    payload = [
+        {
+            "number": 7,
+            "title": "Fix bug",
+            "state": "open",
+            "user": {"login": "bot"},
+            "html_url": "https://github.com/o/r/issues/7",
+            "labels": [{"name": "bug"}],
+        },
+    ]
+    mock_client_cls.return_value = _mock_httpx_client_for_github_get(payload)
+    replies = [
+        LLMMessage(
+            role="assistant",
+            content="",
+            tool_calls=[
+                ToolCall(
+                    id="call_p1",
+                    name="read_issues",
+                    arguments={"owner": "o", "repo": "r", "state": "open"},
+                    agent="project_agent",
+                ),
+            ],
+        ),
+        LLMMessage(role="assistant", content="Issues summarized."),
+    ]
+    fake = FakeLLM(replies)
+    supervisor = Supervisor()
+    context = ContextBuilder()
+    executor = ExecutionController(tool_registry)
+    agents = {
+        "repo_agent": RepoAgent(),
+        "project_agent": ProjectAgent(),
+        "research_agent": ResearchAgent(),
+    }
+    runner = Runner(
+        supervisor,
+        fake,
+        context,
+        executor,
+        tool_registry,
+        agents,
+        max_tool_iterations=5,
+    )
+    req = QueryRequest(
+        query="summarize open issues in the backlog",
+        repo_path=sample_repo_path,
+    )
+    res = runner.run(req)
+    assert res.answer == "Issues summarized."
+    assert "read_issues" in res.tools_used
+    assert res.routed_agent == "project_agent"
 
 
 def test_runner_max_iterations_stops(

--- a/tests/unit/test_agents_base.py
+++ b/tests/unit/test_agents_base.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 
 from adt.agents.base import BaseAgent
+from adt.agents.project_agent import ProjectAgent
 from adt.agents.repo_agent import RepoAgent
 from adt.agents.research_agent import ResearchAgent
 from adt.models.schemas import AgentResponse, QueryRequest
@@ -31,4 +32,14 @@ def test_research_agent_name_and_handle() -> None:
     r = a.handle(QueryRequest(query="q"), context="ctx")
     assert isinstance(r, AgentResponse)
     assert "research_agent" in r.answer
+    assert r.tools_used
+
+
+def test_project_agent_name_and_handle() -> None:
+    """Project agent should expose a stable id and non-empty tool list."""
+    a = ProjectAgent()
+    assert a.name == "project_agent"
+    r = a.handle(QueryRequest(query="q"), context="ctx")
+    assert isinstance(r, AgentResponse)
+    assert "project_agent" in r.answer
     assert r.tools_used

--- a/tests/unit/test_cli_app.py
+++ b/tests/unit/test_cli_app.py
@@ -38,7 +38,7 @@ def test_cli_ask_requires_api_key(tmp_path) -> None:
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
-@patch("adt.cli.app.build_runner_for_repo")
+@patch("adt.cli.app.build_runner")
 def test_cli_ask_runs_runner(mock_build, tmp_path) -> None:
     """``ask`` should call ``build_runner_for_repo`` and print the model answer."""
     mock_runner = MagicMock()
@@ -65,7 +65,7 @@ def test_cli_ask_runs_runner(mock_build, tmp_path) -> None:
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
-@patch("adt.cli.app.build_runner_for_repo")
+@patch("adt.cli.app.build_runner")
 def test_cli_ask_accepts_force_agent(mock_build, tmp_path) -> None:
     """``--agent`` should be forwarded on :class:`~adt.models.schemas.QueryRequest`."""
     mock_runner = MagicMock()
@@ -96,7 +96,7 @@ def test_cli_ask_accepts_force_agent(mock_build, tmp_path) -> None:
     assert req.force_agent == "research_agent"
 
 
-@patch("adt.cli.app.build_runner_for_repo")
+@patch("adt.cli.app.build_runner")
 def test_cli_ask_rejects_invalid_agent(mock_build, tmp_path) -> None:
     """Unknown ``--agent`` values must exit before the runner is built."""
     runner = CliRunner()

--- a/tests/unit/test_project_agent.py
+++ b/tests/unit/test_project_agent.py
@@ -1,0 +1,27 @@
+"""Tests for :class:`~adt.agents.project_agent.ProjectAgent`."""
+
+from __future__ import annotations
+
+from adt.agents.project_agent import ProjectAgent
+from adt.models.schemas import QueryRequest
+
+
+def test_project_agent_tools_and_prompt() -> None:
+    """Declared tools and role should match the Phase 4 contract."""
+    agent = ProjectAgent()
+    assert agent.tools == ["read_issues", "read_milestones", "read_markdown"]
+    assert "project manager" in agent.system_prompt.lower()
+
+
+def test_project_agent_handle_lists_tools() -> None:
+    """``handle`` should reference Runner and list project tools."""
+    agent = ProjectAgent()
+    res = agent.handle(QueryRequest(query="milestones?"), context="")
+    assert "project_agent" in res.answer
+    assert "read_issues" in res.tools_used
+    assert res.routed_agent == "project_agent"
+
+
+def test_project_agent_name() -> None:
+    """Stable id should remain ``project_agent``."""
+    assert ProjectAgent().name == "project_agent"

--- a/tests/unit/test_query_request.py
+++ b/tests/unit/test_query_request.py
@@ -1,0 +1,25 @@
+"""Validation rules on :class:`~adt.models.schemas.QueryRequest`."""
+
+from __future__ import annotations
+
+import pytest
+
+from adt.models.schemas import QueryRequest
+
+
+def test_github_owner_and_repo_must_be_paired() -> None:
+    """``github_owner`` without ``github_repo`` must fail validation."""
+    with pytest.raises(ValueError, match="github_owner and github_repo"):
+        QueryRequest(query="x", github_owner="org", github_repo=None)
+
+
+def test_github_pair_accepted() -> None:
+    """Both GitHub fields may be set together."""
+    q = QueryRequest(
+        query="issues?",
+        repo_path=".",
+        github_owner="o",
+        github_repo="r",
+    )
+    assert q.github_owner == "o"
+    assert q.github_repo == "r"

--- a/tests/unit/test_repo_spec.py
+++ b/tests/unit/test_repo_spec.py
@@ -1,0 +1,34 @@
+"""Tests for :mod:`adt.repo_spec` CLI target parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from adt.repo_spec import resolve_repo_target
+
+
+def test_resolve_local_directory(tmp_path) -> None:
+    """Existing directories resolve as local roots without GitHub coordinates."""
+    d = tmp_path / "proj"
+    d.mkdir()
+    r = resolve_repo_target(str(d))
+    assert r.local_root == d.resolve()
+    assert r.github_owner is None
+    assert r.github_repo is None
+
+
+def test_resolve_github_slug(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """``owner/repo`` uses cwd as markdown root when the path is not a directory."""
+    monkeypatch.chdir(tmp_path)
+    r = resolve_repo_target("myorg/my-repo")
+    assert r.local_root == Path.cwd().resolve()
+    assert r.github_owner == "myorg"
+    assert r.github_repo == "my-repo"
+
+
+def test_resolve_invalid_raises() -> None:
+    """Missing paths and invalid slugs raise ``ValueError``."""
+    with pytest.raises(ValueError, match="Not a directory"):
+        resolve_repo_target("does-not-exist-dir-xyz123")

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -6,4 +6,4 @@ import adt
 
 
 def test_package_version() -> None:
-    assert adt.__version__ == "0.4.0"
+    assert adt.__version__ == "0.5.0"

--- a/tests/unit/test_supervisor.py
+++ b/tests/unit/test_supervisor.py
@@ -32,3 +32,18 @@ def test_route_agents(supervisor: Supervisor, query: str, expected: str) -> None
     out = supervisor.route(req)
     assert out.agent_name == expected
     assert "route" in out.request.options
+
+
+def test_default_route_github_slug_targets_project(
+    supervisor: Supervisor,
+) -> None:
+    """Remote ``--repo owner/repo`` defaults to ``project_agent``."""
+    req = QueryRequest(
+        query="hello there",
+        repo_path="C:\\fake\\cwd",
+        github_owner="acme",
+        github_repo="demo",
+    )
+    out = supervisor.route(req)
+    assert out.agent_name == "project_agent"
+    assert out.request.options.get("route") == "default"

--- a/tests/unit/test_tools_project.py
+++ b/tests/unit/test_tools_project.py
@@ -1,0 +1,112 @@
+"""Unit tests for GitHub and markdown project tools (mocked HTTP)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from adt.tools.project import read_issues, read_markdown, read_milestones
+
+
+def _mock_httpx_client_for_github_get(
+    json_payload: object,
+    *,
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+) -> MagicMock:
+    """Return a context-manager client whose ``get`` yields a configured response."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = status_code
+    mock_resp.json.return_value = json_payload
+    mock_resp.headers = headers or {"x-ratelimit-remaining": "59"}
+    mock_resp.text = ""
+    mock_client = MagicMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    return mock_client
+
+
+@patch("adt.tools.project.httpx.Client")
+def test_read_issues_parses_list(mock_cls: MagicMock) -> None:
+    """Issues list should exclude pull_request entries and include metadata."""
+    payload = [
+        {
+            "number": 2,
+            "title": "Real issue",
+            "state": "open",
+            "user": {"login": "alice"},
+            "html_url": "https://github.com/o/r/issues/2",
+            "labels": [{"name": "bug"}],
+        },
+        {
+            "number": 3,
+            "title": "A PR",
+            "state": "open",
+            "pull_request": {},
+            "user": {"login": "bob"},
+            "html_url": "https://github.com/o/r/pull/3",
+            "labels": [],
+        },
+    ]
+    mock_cls.return_value = _mock_httpx_client_for_github_get(payload)
+    out = read_issues("o", "r", state="open", max_results=10, token=None)
+    assert "Real issue" in out
+    assert "#2" in out
+    assert "A PR" not in out
+
+
+@patch("adt.tools.project.httpx.Client")
+def test_read_issues_rate_limit_403(mock_cls: MagicMock) -> None:
+    """403 responses should mention rate limits and token guidance."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 403
+    mock_resp.json.return_value = {"message": "API rate limit exceeded"}
+    mock_resp.headers = {
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": "1700000000",
+    }
+    mock_resp.text = ""
+    mock_client = MagicMock()
+    mock_client.get.return_value = mock_resp
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_cls.return_value = mock_client
+    out = read_issues("o", "r", token=None)
+    assert "403" in out or "rate" in out.lower()
+    assert "GITHUB_TOKEN" in out or "token" in out.lower()
+
+
+@patch("adt.tools.project.httpx.Client")
+def test_read_milestones_parses_list(mock_cls: MagicMock) -> None:
+    """Milestone payload should be formatted as text lines."""
+    payload = [
+        {
+            "title": "v1.0",
+            "state": "open",
+            "description": "First release",
+            "open_issues": 3,
+            "closed_issues": 1,
+            "due_on": "2026-12-01T00:00:00Z",
+            "html_url": "https://github.com/o/r/milestone/1",
+        },
+    ]
+    mock_cls.return_value = _mock_httpx_client_for_github_get(payload)
+    out = read_milestones("o", "r", state="open", token=None)
+    assert "v1.0" in out
+    assert "open_issues=3" in out
+
+
+def test_read_markdown_strips_front_matter(sample_repo_path: str) -> None:
+    """ROADMAP fixture should load and drop YAML front matter."""
+    root = Path(sample_repo_path)
+    out = read_markdown(root, "ROADMAP.md", max_chars=50_000)
+    assert "Phase A" in out
+    assert "title: Sample roadmap" not in out
+
+
+def test_read_markdown_rejects_non_md(sample_repo_path: str) -> None:
+    """Only markdown suffixes are allowed."""
+    root = Path(sample_repo_path)
+    out = read_markdown(root, "main.py")
+    assert "Error" in out


### PR DESCRIPTION
## Summary
Adds Phase 4 **project agent**: GitHub issues/milestones via REST API and local markdown reads, with CLI support for `owner/repo` and optional GitHub authentication.

## Changes
- Tools: `read_issues`, `read_milestones`, `read_markdown` (`src/adt/tools/project.py`) with rate-limit messaging on 403
- `ProjectAgent` + `register_project_tools`; `build_runner` / `build_runner_for_repo` with `github_token`
- `QueryRequest.github_owner` / `github_repo`; `resolve_repo_target` for `--repo` path vs slug
- Supervisor: expanded project keywords; default route `project_agent` when GitHub slug is set
- CLI: `--repo` local or `owner/repo`, `--token`, magenta Markdown panel for project answers
- Docs: README, `docs/agents.md`, `.env.example`; version **0.5.0**

## How to test
```bash
pip install -e ".[dev]"
export OPENAI_API_KEY=...
export GITHUB_TOKEN=...   # optional, higher limits
adt ask "Summarize open issues" --repo owner/repo
adt ask "What's in ROADMAP?" --repo .
pytest