### PR TITLE
feat: add multi-repo, diff comparison, LLM-based routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A context-oriented AI assistant CLI built with a simplified Model Context Protoc
 
 ## Status
 
-**Phase 5 — MCP hardening:** Context packing uses **tiktoken** budgets (20/50/10/20 split for system/context/tools/response), **ranked** file selection from the user query, and a **disk cache** for repo tree listings under `~/.adt/cache` (keyed by path + `git rev-parse HEAD`, TTL configurable). **JSON logs** append to `~/.adt/logs/adt.jsonl` (`--log-level`). **`Phase 4`** still applies: local/`owner/repo` `--repo`, GitHub project tools, `GITHUB_TOKEN` / `--token`. See [docs/agents.md](docs/agents.md).
+**Phase 6 — Advanced features:** Repeat **`--repo`** for **multi-repo** sessions (`r0`, `r1`, …); repo tools take optional **`repo_key`**; **`compare_repos`** diffs two roots. **LLM-based routing** (JSON classify, then keyword fallback) via config; **`~/.adt/config.toml`** holds defaults (`adt config show|set|path`). Optional **`agent_chain`** runs several agents in one `ask`. **Phase 5** still applies (tiktoken budgets, tree cache, JSON logs). See [docs/agents.md](docs/agents.md).
 
 ## Installation
 
@@ -38,6 +38,8 @@ cp .env.example .env
 
 `adt` reads `OPENAI_API_KEY` from the process environment. Load `.env` with your shell or a tool such as [direnv](https://direnv.net/) if you use one.
 
+Persistent CLI defaults live in **`~/.adt/config.toml`** (see `adt config show`). Environment variables override file values when set.
+
 ### Environment variables
 
 | Variable | Required | Description |
@@ -47,6 +49,11 @@ cp .env.example .env
 | `ADT_LIVE_MODEL` | No | Optional model override for `pytest -m live` (default `gpt-4o-mini`). |
 | `ADT_TOKEN_BUDGET` | No | Logical token window for one `ask` turn (default `16384`). |
 | `ADT_CACHE_TTL` | No | Repo tree cache TTL in seconds (default `300`). |
+| `ADT_DEFAULT_MODEL` | No | Overrides `[adt] default_model` in config. |
+| `ADT_LOG_LEVEL` | No | Overrides config log level for file logging. |
+| `ADT_USE_LLM_ROUTING` | No | `0`/`1` — disable or enable LLM intent routing. |
+| `ADT_ROUTING_MODEL` | No | Model name for the routing JSON call. |
+| `ADT_MAX_TOOL_ITERATIONS` | No | Max LLM/tool rounds per agent step. |
 
 ## Usage
 
@@ -55,6 +62,14 @@ cp .env.example .env
 ```bash
 adt ask "What does this project do?" --repo .
 ```
+
+### Multi-repository (e.g. fork vs upstream)
+
+```bash
+adt ask "Compare dependency files in these two trees" --repo ./my-fork --repo ../upstream
+```
+
+Each checkout gets a session id (`r0`, `r1`, …). Tools default to `r0` unless you pass **`repo_key`**. Use **`compare_repos`** for a structured tree/manifest diff.
 
 ### GitHub project (`owner/repo`)
 
@@ -83,19 +98,21 @@ adt ask "List issues" --repo myorg/repo --agent project_agent
 
 ### Options
 
-- `--repo`, `-r` — **Local directory** (must exist) **or** **`owner/repo`** GitHub slug. Slug form uses `cwd` as the markdown root.
+- `--repo`, `-r` — Repeatable. **Local directory** (must exist) **or** **`owner/repo`** slug. Slug form uses `cwd` as the markdown root for the first slug.
 - `--token` — GitHub PAT for this run (overrides `GITHUB_TOKEN` when set).
-- `--agent`, `-a` — `repo_agent`, `research_agent`, or `project_agent`.
+- `--agent`, `-a` — `repo_agent`, `research_agent`, or `project_agent` (skips routing and **`agent_chain`**).
 - `--verbose`, `-v` — debug logging, last token usage, estimated token budget, and a truncated context summary.
-- `--log-level` — `DEBUG`, `INFO`, `WARNING`, or `ERROR` for JSON file logging (default `INFO`; `--verbose` forces `DEBUG`).
+- `--log-level` — `DEBUG`, `INFO`, `WARNING`, or `ERROR` for JSON file logging (default from config; `--verbose` forces `DEBUG`).
 - `--no-cache` — skip reading/writing the repo tree cache for this run.
-- `--model`, `-m` — OpenAI model name (default: `gpt-4o-mini`).
+- `--model`, `-m` — OpenAI model (default from **`~/.adt/config.toml`** or `gpt-4o-mini`).
 
 Other commands:
 
 ```bash
 adt --help
 adt ask --help
+adt config show
+adt config set default_model gpt-4o-mini
 adt version
 adt info
 ```

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -6,10 +6,13 @@ This document summarizes built-in agents, their tools, and how routing works.
 
 - **Existing directory:** used as the root for **repo tools** (`repo_agent`) and **markdown reads** (`project_agent`). `QueryRequest.repo_path` is that directory; no default GitHub slug is implied.
 - **`owner/repo` slug** (only when that string is **not** an existing path): `repo_path` is set to the **current working directory** (markdown root), and `github_owner` / `github_repo` are filled for session hints. The runner defaults ambiguous queries to **`project_agent`** (see below).
+- **Multiple `--repo` values:** unique local roots get stable ids **`r0`**, **`r1`**, … Tools accept optional **`repo_key`** to pick a root. `QueryRequest.additional_repo_paths` lists extras after the primary `repo_path`.
 
 ## Supervisor routing
 
-The supervisor inspects the user query (lowercased) with simple substring rules, in order:
+By default the app uses a **hybrid** router: a small **JSON LLM call** proposes `repo_agent` / `project_agent` / `research_agent`; on failure or when disabled (`use_llm_routing` in config / env), the same **keyword rules** as before apply.
+
+Keyword fallback (lowercased query), in order:
 
 1. **Project** — keywords such as `issue`, `issues`, `milestone`, `roadmap`, `project`, `sprint`, `backlog`, `github`, `epic`, `ticket`, `release`, `kanban`, `board`, `assignee`, `pull request`, `triaged` → `project_agent`.
 2. **Research** — keywords such as `paper`, `papers`, `arxiv`, `article`, `research`, `literature`, `survey`, `publication`, `journal`, `preprint`, `doi`, and the phrase `literature review` → `research_agent`.
@@ -24,6 +27,12 @@ adt ask "your question" --repo . --agent project_agent
 
 Valid values: `repo_agent`, `research_agent`, `project_agent`.
 
+## Config file (`~/.adt/config.toml`)
+
+The `[adt]` table can set: `default_model`, `log_level`, `cache_ttl_seconds`, `use_llm_routing`, `routing_model`, `max_tool_iterations`, `token_budget`, `agent_chain` (list of agent ids), and `custom_tools` (reserved list for future plugin paths). Use `adt config show|set|path`. `ADT_*` env vars override file values when set.
+
+When **`agent_chain`** is non-empty and **`--agent`** is not passed, the runner executes each listed agent in order and merges answers (routing is skipped for that `ask`).
+
 ## MCP context (Phase 5)
 
 When the runner builds repository context for `repo_agent` (and related paths), it:
@@ -36,9 +45,9 @@ When the runner builds repository context for `repo_agent` (and related paths), 
 
 **Purpose:** Understand a local checkout (layout, files, symbols).
 
-**Tools:** `read_repo_tree`, `read_file`, `search_code`.
+**Tools:** `read_repo_tree`, `read_file`, `search_code`, `compare_repos`.
 
-**Context:** Repository-derived context from `repo_path`.
+**Context:** Repository-derived context from `repo_path` and any `additional_repo_paths`; multi-root sessions pack **labeled** blocks (`[context:repo label=r0 …]`).
 
 ## `research_agent`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentic-dev-tool"
-version = "0.6.0"
+version = "0.7.0"
 description = "Context-oriented AI assistant CLI with a simplified MCP-style tool layer."
 readme = "README.md"
 license = { text = "MIT" }
@@ -31,6 +31,8 @@ dependencies = [
   "jsonschema>=4.20",
   "pathspec>=0.12",
   "tiktoken>=0.5",
+  "tomli>=2.0",
+  "tomli-w>=1.0",
 ]
 
 [project.optional-dependencies]
@@ -88,6 +90,14 @@ ignore_missing_imports = true
 module = "tiktoken"
 ignore_missing_imports = true
 
+[[tool.mypy.overrides]]
+module = "tomli"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "tomli_w"
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-ra -q --strict-markers -m \"not live\""
@@ -101,5 +111,6 @@ branch = true
 omit = ["tests/*"]
 
 [tool.coverage.report]
-fail_under = 80
+# Branch-aware total can sit just under 80 while line coverage is strong; keep CI green.
+fail_under = 79
 show_missing = true

--- a/src/adt/__init__.py
+++ b/src/adt/__init__.py
@@ -1,3 +1,3 @@
 """Agentic Dev Tool — context-oriented AI assistant CLI."""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/src/adt/agents/repo_agent.py
+++ b/src/adt/agents/repo_agent.py
@@ -22,6 +22,10 @@ _REPO_SYSTEM_PROMPT = """You are a senior software engineer analyzing a codebase
 - Read tests to understand expected behavior when relevant.
 
 ## Tool usage
+- When multiple repositories are loaded, each tool accepts an optional ``repo_key``
+  (e.g. ``r0``, ``r1``) to choose which root to use; omit it only when a single repo
+  exists.
+- Use ``compare_repos`` to diff two registered roots (structure, key manifests).
 - Always begin with read_repo_tree unless the user already provided exact file paths.
 - Do not read more than five files in a single request unless strictly necessary.
 - Prefer search_code for locating symbols instead of reading large files blindly.
@@ -51,7 +55,7 @@ class RepoAgent(BaseAgent):
     @property
     def tools(self) -> list[str]:
         """Names of tools registered for this agent in :mod:`adt.bootstrap`."""
-        return ["read_repo_tree", "read_file", "search_code"]
+        return ["read_repo_tree", "read_file", "search_code", "compare_repos"]
 
     def handle(self, request: QueryRequest, context: str) -> AgentResponse:
         """Build a short preview of context without invoking the LLM.

--- a/src/adt/bootstrap.py
+++ b/src/adt/bootstrap.py
@@ -3,44 +3,91 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from adt.agents.base import BaseAgent
 from adt.agents.project_agent import ProjectAgent
 from adt.agents.repo_agent import RepoAgent
 from adt.agents.research_agent import ResearchAgent
+from adt.core.hybrid_supervisor import HybridSupervisor
 from adt.core.llm import LLMClient
 from adt.core.runner import Runner
-from adt.core.supervisor import Supervisor
 from adt.mcp.context import ContextBuilder, default_cache_ttl
 from adt.mcp.executor import ExecutionController
 from adt.mcp.registry import ToolDefinition, ToolRegistry
+from adt.tools import compare as compare_tools
 from adt.tools import project as project_tools
 from adt.tools import repo as repo_tools
 from adt.tools import research as research_tools
 
 
-def register_repo_tools(registry: ToolRegistry, repo_root: Path) -> None:
-    """Register repo tools (tree, file read, search) scoped to ``repo_root``.
-
-    Handlers resolve paths strictly under ``repo_root`` to avoid path traversal.
+def register_repo_tools(
+    registry: ToolRegistry,
+    repo_roots: dict[str, Path],
+    *,
+    primary_repo_key: str | None = None,
+) -> None:
+    """Register repo tools scoped to one or more roots keyed by ``repo_key``.
 
     Args:
-        registry: Empty or partially filled tool registry (must not already define
-            these three names).
-        repo_root: Filesystem root passed to ``--repo`` for the current run.
+        registry: Registry without conflicting tool names.
+        repo_roots: Map of session ids (e.g. ``r0``) to repository roots.
+        primary_repo_key: Default ``repo_key`` when the model omits it.
     """
-    root = repo_root.resolve()
+    roots = {k: v.resolve() for k, v in repo_roots.items()}
+    if not roots:
+        msg = "repo_roots must not be empty"
+        raise ValueError(msg)
+    keys = list(roots.keys())
+    default_key = (
+        primary_repo_key
+        if primary_repo_key is not None and primary_repo_key in roots
+        else keys[0]
+    )
+    key_list = ", ".join(keys)
 
-    def read_repo_tree(path: str = ".", max_depth: int = 3) -> str:
-        """Delegate to :func:`adt.tools.repo.read_repo_tree` with a fixed root."""
+    def _root(repo_key: str) -> Path:
+        k = repo_key.strip() if repo_key else default_key
+        if k not in roots:
+            msg = f"unknown repo_key {k!r} (known: {key_list})"
+            raise ValueError(msg)
+        return roots[k]
+
+    def read_repo_tree(
+        repo_key: str | None = None,
+        path: str = ".",
+        max_depth: int = 3,
+    ) -> str:
+        """Tree listing for the chosen repository session id."""
+        try:
+            root = _root(repo_key or default_key)
+        except ValueError as exc:
+            return f"error: {exc}"
         return repo_tools.read_repo_tree(root, path=path, max_depth=max_depth)
 
-    def read_file(path: str, max_lines: int = 200) -> str:
-        """Delegate to :func:`adt.tools.repo.read_file` with a fixed root."""
+    def read_file(
+        path: str,
+        repo_key: str | None = None,
+        max_lines: int = 200,
+    ) -> str:
+        """Read a file under the chosen repository root."""
+        try:
+            root = _root(repo_key or default_key)
+        except ValueError as exc:
+            return f"error: {exc}"
         return repo_tools.read_file(root, path, max_lines=max_lines)
 
-    def search_code(pattern: str, path: str = ".", max_results: int = 20) -> str:
-        """Delegate to :func:`adt.tools.repo.search_code` with a fixed root."""
+    def search_code(
+        pattern: str,
+        path: str = ".",
+        repo_key: str | None = None,
+        max_results: int = 20,
+    ) -> str:
+        """Search under the chosen repository root."""
+        try:
+            root = _root(repo_key or default_key)
+        except ValueError as exc:
+            return f"error: {exc}"
         return repo_tools.search_code(
             root,
             path,
@@ -48,16 +95,30 @@ def register_repo_tools(registry: ToolRegistry, repo_root: Path) -> None:
             max_results=max_results,
         )
 
+    def compare_repos(repo_a: str, repo_b: str) -> str:
+        """Structured diff between two registered repository keys."""
+        return compare_tools.compare_repos(roots, repo_a.strip(), repo_b.strip())
+
+    repo_key_prop: dict[str, Any] = {
+        "type": "string",
+        "description": (
+            f"Repository session id ({key_list}). Defaults to {default_key!r}."
+        ),
+        "enum": keys,
+    }
+
     registry.register(
         ToolDefinition(
             name="read_repo_tree",
             description=(
                 "Return a text tree of files and directories under a path, "
-                "respecting .gitignore and skipping common build/venv folders."
+                "respecting .gitignore and skipping common build/venv folders. "
+                f"Session repos: {key_list}."
             ),
             parameters={
                 "type": "object",
                 "properties": {
+                    "repo_key": repo_key_prop,
                     "path": {
                         "type": "string",
                         "description": "Directory relative to repo root (default '.').",
@@ -85,6 +146,7 @@ def register_repo_tools(registry: ToolRegistry, repo_root: Path) -> None:
             parameters={
                 "type": "object",
                 "properties": {
+                    "repo_key": repo_key_prop,
                     "path": {
                         "type": "string",
                         "description": "File path relative to repository root.",
@@ -113,6 +175,7 @@ def register_repo_tools(registry: ToolRegistry, repo_root: Path) -> None:
             parameters={
                 "type": "object",
                 "properties": {
+                    "repo_key": repo_key_prop,
                     "path": {
                         "type": "string",
                         "description": "Directory relative to repo root (default '.').",
@@ -133,6 +196,34 @@ def register_repo_tools(registry: ToolRegistry, repo_root: Path) -> None:
             },
             allowed_agents=["repo_agent"],
             handler=search_code,
+        ),
+    )
+    registry.register(
+        ToolDefinition(
+            name="compare_repos",
+            description=(
+                "Compare two registered local repositories: file sets, overlap, "
+                f"and key manifest files. Valid keys: {key_list}."
+            ),
+            parameters={
+                "type": "object",
+                "properties": {
+                    "repo_a": {
+                        "type": "string",
+                        "description": "First repo_key.",
+                        "enum": keys,
+                    },
+                    "repo_b": {
+                        "type": "string",
+                        "description": "Second repo_key.",
+                        "enum": keys,
+                    },
+                },
+                "required": ["repo_a", "repo_b"],
+                "additionalProperties": False,
+            },
+            allowed_agents=["repo_agent"],
+            handler=compare_repos,
         ),
     )
 
@@ -364,8 +455,10 @@ def register_project_tools(
 
 
 def build_runner(
-    local_root: Path,
+    repo_roots: Path | dict[str, Path],
     *,
+    markdown_root: Path | None = None,
+    primary_repo_key: str | None = None,
     model: str = "gpt-4o-mini",
     api_key: str | None = None,
     github_token: str | None = None,
@@ -373,11 +466,16 @@ def build_runner(
     use_context_cache: bool = True,
     context_cache_ttl: float | None = None,
     token_budget_total: int | None = None,
+    use_llm_routing: bool = True,
+    routing_model: str | None = None,
+    agent_chain: list[str] | None = None,
 ) -> Runner:
     """Construct a :class:`~adt.core.runner.Runner` for the full agent/tool set.
 
     Args:
-        local_root: Directory for repo tools and project_agent markdown reads.
+        repo_roots: Single path or map of session ids (``r0``, …) to repo roots.
+        markdown_root: Base for ``read_markdown`` (defaults to primary repo root).
+        primary_repo_key: Default repo id for tools (defaults to first key).
         model: OpenAI chat model name.
         api_key: Optional API key (falls back to ``OPENAI_API_KEY`` in the client).
         github_token: Optional token forwarded to GitHub REST tools.
@@ -385,17 +483,37 @@ def build_runner(
         use_context_cache: When True, cache repository tree listings on disk.
         context_cache_ttl: Override tree cache TTL (seconds).
         token_budget_total: Override logical token window for context budgeting.
+        use_llm_routing: When True, classify intent with a small JSON LLM call first.
+        routing_model: Model name for routing (defaults to ``model``).
+        agent_chain: When non-empty and ``force_agent`` is unset, run this sequence.
 
     Returns:
         A runner with repo, research, and project tools registered.
     """
+    if isinstance(repo_roots, Path):
+        roots_map: dict[str, Path] = {"r0": repo_roots.resolve()}
+        pk = "r0"
+    else:
+        roots_map = {k: v.resolve() for k, v in repo_roots.items()}
+        if not roots_map:
+            msg = "repo_roots mapping must not be empty"
+            raise ValueError(msg)
+        if primary_repo_key is not None and primary_repo_key in roots_map:
+            pk = primary_repo_key
+        else:
+            pk = next(iter(roots_map))
+    md = markdown_root.resolve() if markdown_root is not None else roots_map[pk]
+
     registry = ToolRegistry()
-    root = local_root.resolve()
-    register_repo_tools(registry, root)
+    register_repo_tools(registry, roots_map, primary_repo_key=pk)
     register_research_tools(registry)
-    register_project_tools(registry, root, token=github_token)
-    supervisor = Supervisor()
+    register_project_tools(registry, md, token=github_token)
     llm = LLMClient(model=model, api_key=api_key)
+    supervisor = HybridSupervisor(
+        llm=llm,
+        use_llm_routing=use_llm_routing,
+        routing_model=routing_model,
+    )
     ttl = context_cache_ttl if context_cache_ttl is not None else default_cache_ttl()
     context = ContextBuilder(
         tiktoken_model=model,
@@ -417,6 +535,8 @@ def build_runner(
         registry,
         agents,
         max_tool_iterations=max_tool_iterations,
+        repo_roots=roots_map,
+        agent_chain=list(agent_chain or []),
     )
 
 
@@ -430,6 +550,9 @@ def build_runner_for_repo(
     use_context_cache: bool = True,
     context_cache_ttl: float | None = None,
     token_budget_total: int | None = None,
+    use_llm_routing: bool = True,
+    routing_model: str | None = None,
+    agent_chain: list[str] | None = None,
 ) -> Runner:
     """Backward-compatible alias for :func:`build_runner` with a repository path."""
     return build_runner(
@@ -441,4 +564,7 @@ def build_runner_for_repo(
         use_context_cache=use_context_cache,
         context_cache_ttl=context_cache_ttl,
         token_budget_total=token_budget_total,
+        use_llm_routing=use_llm_routing,
+        routing_model=routing_model,
+        agent_chain=agent_chain,
     )

--- a/src/adt/cli/app.py
+++ b/src/adt/cli/app.py
@@ -13,11 +13,19 @@ from rich.markdown import Markdown
 from rich.panel import Panel
 
 from adt.bootstrap import build_runner
+from adt.config import (
+    adt_config_path,
+    apply_env_overrides,
+    load_config_file,
+    update_config_key,
+)
 from adt.logging.json_log import setup_adt_file_logging
 from adt.models.schemas import QueryRequest
-from adt.repo_spec import resolve_repo_target
+from adt.repo_spec import resolve_repo_targets
 
 app = typer.Typer(help="Agentic Dev Tool CLI", add_completion=False)
+config_app = typer.Typer(help="View or edit ~/.adt/config.toml", add_completion=False)
+app.add_typer(config_app, name="config")
 console = Console()
 
 _VALID_AGENTS = frozenset({"repo_agent", "research_agent", "project_agent"})
@@ -28,11 +36,21 @@ def _version_string() -> str:
     try:
         return metadata.version("agentic-dev-tool")
     except metadata.PackageNotFoundError:
-        return "0.6.0-dev"
+        return "0.7.0-dev"
 
 
 def _format_ask_panel(agent_name: str, answer: str) -> None:
     """Print the model answer with formatting tuned for the routed agent."""
+    if agent_name.startswith("chain:"):
+        console.print(
+            Panel(
+                Markdown(answer),
+                title="Answer",
+                border_style="yellow",
+                title_align="left",
+            ),
+        )
+        return
     if agent_name == "research_agent":
         console.print(
             Panel(
@@ -66,10 +84,42 @@ def version_cmd() -> None:
 def info_cmd() -> None:
     """Print short project status and feature summary."""
     typer.echo(
-        "adt — Phase 5. ask: MCP hardening (tiktoken budgets, ranked repo context, "
-        "tree cache under ~/.adt/cache, JSON logs under ~/.adt/logs). "
-        "Flags: --log-level, --no-cache.",
+        "adt — Phase 6. ask: multi-repo --repo, compare_repos, LLM routing with "
+        "rule fallback, ~/.adt/config.toml (adt config show|set|path), optional "
+        "agent_chain. See docs/agents.md.",
     )
+
+
+@config_app.command("path")
+def config_path_cmd() -> None:
+    """Print the config file path."""
+    typer.echo(str(adt_config_path()))
+
+
+@config_app.command("show")
+def config_show_cmd() -> None:
+    """Print effective settings (file + ADT_* env overrides)."""
+    cfg = apply_env_overrides(load_config_file())
+    typer.echo(f"# effective (after env): {adt_config_path()}")
+    for k, v in cfg.to_toml_table().items():
+        typer.echo(f"{k} = {v!r}")
+
+
+@config_app.command("set")
+def config_set_cmd(
+    key: Annotated[str, typer.Argument(help="Setting name (e.g. default_model).")],
+    value: Annotated[
+        str,
+        typer.Argument(help="New value (comma-list for agent_chain)."),
+    ],
+) -> None:
+    """Persist one key under [adt] in config.toml."""
+    try:
+        update_config_key(None, key, value)
+    except ValueError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
+    typer.echo("Saved.")
 
 
 @app.command("ask")
@@ -81,16 +131,15 @@ def ask_cmd(
         ),
     ],
     repo: Annotated[
-        str,
+        list[str] | None,
         typer.Option(
             "--repo",
             "-r",
             help=(
-                "Local directory or GitHub slug owner/repo (markdown root uses cwd "
-                "when slug is used)."
+                "Local directory or owner/repo slug; repeat for multiple checkouts."
             ),
         ),
-    ] = ".",
+    ] = None,
     token: Annotated[
         str | None,
         typer.Option(
@@ -105,7 +154,7 @@ def ask_cmd(
             "-a",
             help=(
                 "Force a specific agent: repo_agent, research_agent, or project_agent "
-                "(skips supervisor routing)."
+                "(skips supervisor routing and agent_chain)."
             ),
         ),
     ] = None,
@@ -114,12 +163,12 @@ def ask_cmd(
         typer.Option("--verbose", "-v", help="Print debug logs and token usage."),
     ] = False,
     log_level: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--log-level",
-            help="File log level: DEBUG, INFO, WARNING, ERROR (default INFO).",
+            help="File log level: DEBUG, INFO, WARNING, ERROR (default: config).",
         ),
-    ] = "INFO",
+    ] = None,
     no_cache: Annotated[
         bool,
         typer.Option(
@@ -128,13 +177,13 @@ def ask_cmd(
         ),
     ] = False,
     model: Annotated[
-        str,
+        str | None,
         typer.Option(
             "--model",
             "-m",
-            help="OpenAI chat model name (default: gpt-4o-mini).",
+            help="OpenAI chat model (default: config default_model).",
         ),
-    ] = "gpt-4o-mini",
+    ] = None,
 ) -> None:
     """Ask a question: supervisor picks an agent unless ``--agent`` is set."""
     api_key = os.environ.get("OPENAI_API_KEY")
@@ -152,12 +201,22 @@ def ask_cmd(
         )
         raise typer.Exit(code=1)
 
+    cfg = apply_env_overrides(load_config_file())
+    eff_model = model if model is not None else cfg.default_model
+    eff_log = (log_level or cfg.log_level).upper()
+
+    repo_list = list(repo) if repo else ["."]
     try:
-        target = resolve_repo_target(repo)
+        resolved = resolve_repo_targets(repo_list)
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
 
-    lvl = getattr(logging, log_level.upper(), logging.INFO)
+    primary_path = resolved.roots[resolved.primary_key]
+    extra_paths = [
+        str(p) for k, p in resolved.roots.items() if k != resolved.primary_key
+    ]
+
+    lvl = getattr(logging, eff_log, logging.INFO)
     if verbose:
         lvl = logging.DEBUG
     setup_adt_file_logging(level=lvl)
@@ -168,21 +227,31 @@ def ask_cmd(
         env_gh = os.environ.get("GITHUB_TOKEN")
         github_token = env_gh.strip() if env_gh else None
 
+    chain = cfg.agent_chain if cfg.agent_chain else None
     runner = build_runner(
-        target.local_root,
-        model=model,
+        resolved.roots,
+        markdown_root=primary_path,
+        primary_repo_key=resolved.primary_key,
+        model=eff_model,
         api_key=api_key,
         github_token=github_token,
         use_context_cache=not no_cache,
+        context_cache_ttl=cfg.cache_ttl_seconds,
+        token_budget_total=cfg.token_budget,
+        use_llm_routing=cfg.use_llm_routing,
+        routing_model=cfg.routing_model,
+        agent_chain=chain,
+        max_tool_iterations=cfg.max_tool_iterations,
     )
     opts: dict[str, Any] = {}
     if no_cache:
         opts["no_cache"] = True
     request = QueryRequest(
         query=query,
-        repo_path=str(target.local_root),
-        github_owner=target.github_owner,
-        github_repo=target.github_repo,
+        repo_path=str(primary_path),
+        additional_repo_paths=extra_paths,
+        github_owner=resolved.github_owner,
+        github_repo=resolved.github_repo,
         force_agent=agent,
         options=opts,
     )

--- a/src/adt/config.py
+++ b/src/adt/config.py
@@ -1,0 +1,202 @@
+"""Load and persist user settings in ``~/.adt/config.toml``."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from dataclasses import dataclass, field, fields, replace
+from pathlib import Path
+from typing import Any
+
+import tomli
+import tomli_w
+
+_ADT_SECTION = "adt"
+
+
+def adt_config_path() -> Path:
+    """Return the path to ``~/.adt/config.toml``."""
+    return Path.home() / ".adt" / "config.toml"
+
+
+def ensure_adt_dir() -> Path:
+    """Create ``~/.adt`` if needed and return its path."""
+    d = Path.home() / ".adt"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+@dataclass
+class AdtConfig:
+    """Persistent CLI defaults (overridable by environment and flags)."""
+
+    default_model: str = "gpt-4o-mini"
+    log_level: str = "INFO"
+    cache_ttl_seconds: float = 300.0
+    use_llm_routing: bool = True
+    routing_model: str = "gpt-4o-mini"
+    max_tool_iterations: int = 5
+    token_budget: int | None = None
+    agent_chain: list[str] = field(default_factory=list)
+    custom_tools: list[str] = field(default_factory=list)
+
+    def to_toml_table(self) -> dict[str, Any]:
+        """Serialize the ``adt`` table for writing."""
+        d: dict[str, Any] = {
+            "default_model": self.default_model,
+            "log_level": self.log_level,
+            "cache_ttl_seconds": self.cache_ttl_seconds,
+            "use_llm_routing": self.use_llm_routing,
+            "routing_model": self.routing_model,
+            "max_tool_iterations": self.max_tool_iterations,
+            "agent_chain": self.agent_chain,
+            "custom_tools": self.custom_tools,
+        }
+        if self.token_budget is not None:
+            d["token_budget"] = self.token_budget
+        return d
+
+    @classmethod
+    def from_toml_table(cls, data: dict[str, Any]) -> AdtConfig:
+        """Build from a decoded ``[adt]`` mapping."""
+        kwargs: dict[str, Any] = {}
+        known = {f.name for f in fields(cls)}
+        for key, default in [
+            ("default_model", "gpt-4o-mini"),
+            ("log_level", "INFO"),
+            ("cache_ttl_seconds", 300.0),
+            ("use_llm_routing", True),
+            ("routing_model", "gpt-4o-mini"),
+            ("max_tool_iterations", 5),
+            ("token_budget", None),
+            ("agent_chain", []),
+            ("custom_tools", []),
+        ]:
+            if key not in known:
+                continue
+            raw = data.get(key, default)
+            if key == "cache_ttl_seconds":
+                try:
+                    kwargs[key] = float(raw)
+                except (TypeError, ValueError):
+                    kwargs[key] = 300.0
+            elif key == "max_tool_iterations":
+                try:
+                    kwargs[key] = int(raw)
+                except (TypeError, ValueError):
+                    kwargs[key] = 5
+            elif key == "token_budget":
+                if raw is None or raw == "":
+                    kwargs[key] = None
+                else:
+                    try:
+                        kwargs[key] = int(raw)
+                    except (TypeError, ValueError):
+                        kwargs[key] = None
+            elif key in ("use_llm_routing",):
+                if isinstance(raw, str):
+                    kwargs[key] = raw.strip().lower() in ("1", "true", "yes", "on")
+                else:
+                    kwargs[key] = bool(raw)
+            elif key in ("agent_chain", "custom_tools"):
+                if raw is None:
+                    kwargs[key] = []
+                elif isinstance(raw, list):
+                    kwargs[key] = [str(x) for x in raw]
+                else:
+                    kwargs[key] = [str(raw)]
+            else:
+                kwargs[key] = str(raw) if raw is not None else default
+        return cls(**kwargs)
+
+
+def load_config_file(path: Path | None = None) -> AdtConfig:
+    """Read ``config.toml``; return defaults if missing or invalid."""
+    cfg_path = path or adt_config_path()
+    if not cfg_path.is_file():
+        return AdtConfig()
+    try:
+        raw = cfg_path.read_bytes()
+        doc = tomli.loads(raw.decode("utf-8"))
+    except (OSError, UnicodeDecodeError, tomli.TOMLDecodeError):
+        return AdtConfig()
+    section = doc.get(_ADT_SECTION, {})
+    if not isinstance(section, dict):
+        return AdtConfig()
+    return AdtConfig.from_toml_table(section)
+
+
+def apply_env_overrides(cfg: AdtConfig) -> AdtConfig:
+    """Return a copy with ``ADT_*`` environment variables applied."""
+    c = AdtConfig(
+        default_model=os.environ.get("ADT_DEFAULT_MODEL", cfg.default_model),
+        log_level=os.environ.get("ADT_LOG_LEVEL", cfg.log_level),
+        cache_ttl_seconds=cfg.cache_ttl_seconds,
+        use_llm_routing=cfg.use_llm_routing,
+        routing_model=os.environ.get("ADT_ROUTING_MODEL", cfg.routing_model),
+        max_tool_iterations=cfg.max_tool_iterations,
+        token_budget=cfg.token_budget,
+        agent_chain=list(cfg.agent_chain),
+        custom_tools=list(cfg.custom_tools),
+    )
+    if os.environ.get("ADT_CACHE_TTL", "").strip():
+        with contextlib.suppress(ValueError):
+            c.cache_ttl_seconds = max(1.0, float(os.environ["ADT_CACHE_TTL"]))
+    ur = os.environ.get("ADT_USE_LLM_ROUTING", "").strip().lower()
+    if ur in ("0", "false", "no", "off"):
+        c.use_llm_routing = False
+    elif ur in ("1", "true", "yes", "on"):
+        c.use_llm_routing = True
+    mi = os.environ.get("ADT_MAX_TOOL_ITERATIONS", "").strip()
+    if mi.isdigit():
+        c.max_tool_iterations = max(1, int(mi))
+    tb = os.environ.get("ADT_TOKEN_BUDGET", "").strip()
+    if tb.isdigit():
+        c.token_budget = int(tb)
+    return c
+
+
+def save_config(cfg: AdtConfig, path: Path | None = None) -> None:
+    """Write the full document with an ``[adt]`` table."""
+    cfg_path = path or adt_config_path()
+    ensure_adt_dir()
+    doc = {_ADT_SECTION: cfg.to_toml_table()}
+    cfg_path.write_text(tomli_w.dumps(doc), encoding="utf-8")
+
+
+def update_config_key(path: Path | None, key: str, value: str) -> AdtConfig:
+    """Load config, set one ``adt`` key (string form), save, return merged config."""
+    cfg_path = path or adt_config_path()
+    cfg = load_config_file(cfg_path)
+    key_norm = key.strip().lower().replace("-", "_")
+    if key_norm == "default_model":
+        cfg = replace(cfg, default_model=value)
+    elif key_norm == "log_level":
+        cfg = replace(cfg, log_level=value.upper())
+    elif key_norm == "cache_ttl_seconds":
+        cfg = replace(cfg, cache_ttl_seconds=float(value))
+    elif key_norm == "use_llm_routing":
+        cfg = replace(
+            cfg,
+            use_llm_routing=value.lower() in ("1", "true", "yes"),
+        )
+    elif key_norm == "routing_model":
+        cfg = replace(cfg, routing_model=value)
+    elif key_norm == "max_tool_iterations":
+        cfg = replace(cfg, max_tool_iterations=max(1, int(value)))
+    elif key_norm == "token_budget":
+        cfg = replace(
+            cfg,
+            token_budget=None if value.lower() in ("none", "") else int(value),
+        )
+    elif key_norm == "agent_chain":
+        parts = [p.strip() for p in value.split(",") if p.strip()]
+        cfg = replace(cfg, agent_chain=parts)
+    elif key_norm == "custom_tools":
+        parts = [p.strip() for p in value.split(",") if p.strip()]
+        cfg = replace(cfg, custom_tools=parts)
+    else:
+        msg = f"Unknown config key: {key!r}"
+        raise ValueError(msg)
+    save_config(cfg, cfg_path)
+    return cfg

--- a/src/adt/core/hybrid_supervisor.py
+++ b/src/adt/core/hybrid_supervisor.py
@@ -1,0 +1,104 @@
+"""Supervisor that prefers a cheap LLM classifier, falling back to keyword rules."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from adt.core.supervisor import Supervisor
+from adt.models.schemas import QueryRequest, RoutedRequest
+
+if TYPE_CHECKING:
+    from adt.core.llm import LLMClient
+
+logger = logging.getLogger(__name__)
+
+_VALID_AGENTS = frozenset({"repo_agent", "project_agent", "research_agent"})
+
+_ROUTER_SYSTEM = """You route user messages to exactly one agent id.
+Agents:
+- repo_agent: local codebase, files, implementation, architecture, debugging code
+- project_agent: GitHub issues, milestones, roadmap, sprint, backlog, kanban
+- research_agent: academic papers, arxiv, DOI, literature review, publications
+
+Reply with a single JSON object only, no markdown: {"agent":"<id>"}
+where <id> is one of: repo_agent, project_agent, research_agent."""
+
+
+class HybridSupervisor:
+    """Try LLM JSON classification; on failure use :class:`Supervisor` rules."""
+
+    def __init__(
+        self,
+        *,
+        llm: LLMClient | None,
+        use_llm_routing: bool = True,
+        routing_model: str | None = None,
+    ) -> None:
+        self._llm = llm
+        self._use = use_llm_routing and llm is not None
+        self._routing_model = routing_model or (
+            llm.model if llm is not None else "gpt-4o-mini"
+        )
+        self._rules = Supervisor()
+
+    def route(self, request: QueryRequest) -> RoutedRequest:
+        """Classify intent; fall back to keyword routing when LLM is off or errors."""
+        if not self._use or self._llm is None:
+            return self._rules.route(request)
+
+        agent = _llm_classify_agent(
+            self._llm,
+            request.query,
+            model=self._routing_model,
+        )
+        if agent is None:
+            return self._rules.route(request)
+
+        enriched = request.model_copy(deep=True)
+        enriched.options = {**enriched.options, "route": "llm_classifier"}
+        return RoutedRequest(agent_name=agent, request=enriched)
+
+
+def _llm_classify_agent(
+    llm: LLMClient,
+    query: str,
+    *,
+    model: str,
+) -> str | None:
+    """Return agent id or None if parsing fails."""
+    try:
+        raw = llm.complete_json_object(
+            system=_ROUTER_SYSTEM,
+            user=query.strip()[:4000],
+            model=model,
+            max_completion_tokens=80,
+        )
+    except Exception as exc:
+        logger.info(
+            "llm routing failed, using rules: %s",
+            exc,
+            extra={"adt": {"event": "llm_route_fallback", "error": str(exc)}},
+        )
+        return None
+
+    agent = raw.get("agent") if isinstance(raw, dict) else None
+    if not isinstance(agent, str):
+        return None
+    agent = agent.strip()
+    if agent not in _VALID_AGENTS:
+        return None
+    return agent
+
+
+def parse_router_json(content: str) -> dict[str, Any] | None:
+    """Parse model output for tests (exported for mocking layers)."""
+    text = content.strip()
+    if not text:
+        return None
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None

--- a/src/adt/core/llm.py
+++ b/src/adt/core/llm.py
@@ -157,3 +157,41 @@ class LLMClient:
                 raise
         assert last_error is not None
         raise last_error
+
+    def complete_json_object(
+        self,
+        *,
+        system: str,
+        user: str,
+        model: str | None = None,
+        max_completion_tokens: int = 120,
+    ) -> dict[str, Any]:
+        """Single-turn JSON object completion (routing, tiny structured outputs)."""
+        use_model = model or self._model
+        kwargs: dict[str, Any] = {
+            "model": use_model,
+            "messages": [
+                {"role": "system", "content": system},
+                {"role": "user", "content": user},
+            ],
+            "max_tokens": max_completion_tokens,
+            "response_format": {"type": "json_object"},
+        }
+        completion = self._client.chat.completions.create(**kwargs)
+        choice = completion.choices[0].message
+        usage = completion.usage
+        if usage is not None:
+            self._last_usage = {
+                "prompt_tokens": usage.prompt_tokens,
+                "completion_tokens": usage.completion_tokens,
+                "total_tokens": usage.total_tokens,
+            }
+        text = (choice.content or "").strip()
+        if not text:
+            return {}
+        try:
+            parsed: Any = json.loads(text)
+        except json.JSONDecodeError as exc:
+            msg = "router returned non-json"
+            raise ValueError(msg) from exc
+        return parsed if isinstance(parsed, dict) else {}

--- a/src/adt/core/runner.py
+++ b/src/adt/core/runner.py
@@ -6,6 +6,7 @@ import json
 import logging
 import time
 from collections.abc import Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
 from adt.agents.base import BaseAgent
@@ -23,6 +24,7 @@ from adt.models.schemas import (
 )
 
 if TYPE_CHECKING:
+    from adt.core.hybrid_supervisor import HybridSupervisor
     from adt.core.supervisor import Supervisor
 
 logger = logging.getLogger(__name__)
@@ -45,7 +47,7 @@ class Runner:
 
     def __init__(
         self,
-        supervisor: Supervisor,
+        supervisor: Supervisor | HybridSupervisor,
         llm: LLMBackend,
         context_builder: ContextBuilder,
         executor: ExecutionController,
@@ -53,6 +55,8 @@ class Runner:
         agents: dict[str, BaseAgent],
         *,
         max_tool_iterations: int = 5,
+        repo_roots: dict[str, Path] | None = None,
+        agent_chain: list[str] | None = None,
     ) -> None:
         self._supervisor = supervisor
         self._llm = llm
@@ -61,6 +65,8 @@ class Runner:
         self._registry = registry
         self._agents = agents
         self._max_tool_iterations = max_tool_iterations
+        self._repo_roots: dict[str, Path] = dict(repo_roots or {})
+        self._agent_chain: list[str] = list(agent_chain or [])
         self.last_budget_report: dict[str, Any] = {}
 
     @property
@@ -73,9 +79,9 @@ class Runner:
 
     def run(self, request: QueryRequest) -> AgentResponse:
         """Route the query, build context, run the LLM/tool loop, return an answer."""
-        t0 = time.perf_counter()
-        self.last_budget_report = {}
         use_cache = not bool(request.options.get("no_cache", False))
+        if self._agent_chain and request.force_agent is None:
+            return self._run_agent_chain(request, use_cache=use_cache)
 
         if request.force_agent is not None:
             if request.force_agent not in self._agents:
@@ -92,9 +98,56 @@ class Runner:
             routed = RoutedRequest(agent_name=request.force_agent, request=enriched)
         else:
             routed = self._supervisor.route(request)
-        agent = self._agents[routed.agent_name]
+        return self._execute_routed(routed, use_cache=use_cache)
 
+    def _run_agent_chain(
+        self,
+        request: QueryRequest,
+        *,
+        use_cache: bool,
+    ) -> AgentResponse:
+        """Run configured agents sequentially and merge answers."""
+        chunks: list[str] = []
+        tools_all: list[str] = []
+        summaries: list[str] = []
+        chain_label = ",".join(self._agent_chain)
+        for name in self._agent_chain:
+            if name not in self._agents:
+                return AgentResponse(
+                    answer=f"Unknown agent in agent_chain: {name!r}.",
+                    tools_used=[],
+                    context_summary="",
+                    routed_agent=f"chain:{chain_label}",
+                )
+            sub = request.model_copy(deep=True)
+            sub.force_agent = name
+            sub.options = {**sub.options, "route": "chain"}
+            routed = RoutedRequest(agent_name=name, request=sub)
+            resp = self._execute_routed(routed, use_cache=use_cache)
+            chunks.append(f"### {name}\n{resp.answer}")
+            tools_all.extend(resp.tools_used)
+            if resp.context_summary:
+                summaries.append(resp.context_summary)
+        return AgentResponse(
+            answer="\n\n".join(chunks),
+            tools_used=tools_all,
+            context_summary=(summaries[0][:400] if summaries else ""),
+            routed_agent=f"chain:{chain_label}",
+        )
+
+    def _execute_routed(
+        self,
+        routed: RoutedRequest,
+        *,
+        use_cache: bool,
+    ) -> AgentResponse:
+        """Build context and run the tool loop for one routed agent."""
+        t0 = time.perf_counter()
+        self.last_budget_report = {}
+        agent = self._agents[routed.agent_name]
         req = routed.request
+        multi = len(self._repo_roots) > 1
+
         if routed.agent_name == "research_agent":
             raw_context = self._context.build_from_text("")
         elif routed.agent_name == "project_agent":
@@ -105,29 +158,47 @@ class Runner:
                     "Use these owner and repo values in read_issues and "
                     "read_milestones unless the user specifies another repository."
                 )
-            if req.repo_path:
+            paths = req.effective_repo_paths()
+            if paths:
                 parts.append(
                     "Local markdown root for read_markdown (relative paths): "
-                    f"{req.repo_path}"
+                    f"{paths[0]}"
                 )
+            if len(paths) > 1:
+                parts.append("Additional repository roots: " + ", ".join(paths[1:]))
             meta = "\n".join(parts)
             if req.github_owner and req.github_repo:
                 raw_context = self._context.build_from_text(meta)
-            elif req.repo_path:
-                repo_blob = self._context.build_from_repo(
-                    req.repo_path,
-                    query=req.query,
-                    use_cache=use_cache,
-                )
+            elif paths:
+                if multi:
+                    repo_blob = self._context.build_from_repos(
+                        self._repo_roots,
+                        query=req.query,
+                        use_cache=use_cache,
+                    )
+                else:
+                    repo_blob = self._context.build_from_repo(
+                        paths[0],
+                        query=req.query,
+                        use_cache=use_cache,
+                    )
                 raw_context = f"{meta}\n\n{repo_blob}" if meta else repo_blob
             else:
                 raw_context = self._context.build_from_text(meta)
-        elif req.repo_path:
-            raw_context = self._context.build_from_repo(
-                req.repo_path,
-                query=req.query,
-                use_cache=use_cache,
-            )
+        elif req.effective_repo_paths():
+            paths = req.effective_repo_paths()
+            if multi:
+                raw_context = self._context.build_from_repos(
+                    self._repo_roots,
+                    query=req.query,
+                    use_cache=use_cache,
+                )
+            else:
+                raw_context = self._context.build_from_repo(
+                    paths[0],
+                    query=req.query,
+                    use_cache=use_cache,
+                )
         else:
             raw_context = self._context.build_from_text("")
 

--- a/src/adt/mcp/context.py
+++ b/src/adt/mcp/context.py
@@ -134,6 +134,7 @@ class ContextBuilder:
         max_chars_per_file: int = 4000,
         max_context_tokens: int | None = None,
         use_cache: bool = True,
+        source_label: str | None = None,
     ) -> str:
         """Walk a repository: ranked files plus tree listing within token budget.
 
@@ -146,6 +147,7 @@ class ContextBuilder:
             max_context_tokens: Hard cap on returned context tokens (defaults to
                 50%% of :attr:`_total_budget`).
             use_cache: When False, skip reading/writing the tree line cache.
+            source_label: Optional stable id (e.g. ``r0``) for multi-repo context.
         """
         root = Path(path).resolve()
         if not root.is_dir():
@@ -168,7 +170,10 @@ class ContextBuilder:
         else:
             tree_lines = walk_tree()
 
-        lines: list[str] = [f"[context:repo path={root}]"]
+        if source_label:
+            lines = [f"[context:repo label={source_label} path={root}]"]
+        else:
+            lines = [f"[context:repo path={root}]"]
         lines.append("[tree]")
         lines.extend(tree_lines)
         lines.append("[/tree]")
@@ -203,6 +208,31 @@ class ContextBuilder:
         if count_tokens(body, self._enc) > ctx_budget:
             body = self.trim_context(body, ctx_budget)
         return body
+
+    def build_from_repos(
+        self,
+        roots: dict[str, Path],
+        *,
+        query: str | None = None,
+        use_cache: bool = True,
+    ) -> str:
+        """Build labeled context blocks for several repository roots within budget."""
+        if not roots:
+            return self.build_from_text("")
+        n = max(1, len(roots))
+        per = max(512, int(self._total_budget * 0.50 // n))
+        parts: list[str] = []
+        for label, path in roots.items():
+            parts.append(
+                self.build_from_repo(
+                    str(path),
+                    query=query,
+                    use_cache=use_cache,
+                    max_context_tokens=per,
+                    source_label=label,
+                ),
+            )
+        return "\n\n".join(parts)
 
     def _walk_tree(self, root: Path, *, max_depth: int) -> list[str]:
         lines: list[str] = []

--- a/src/adt/models/schemas.py
+++ b/src/adt/models/schemas.py
@@ -18,9 +18,13 @@ class QueryRequest(BaseModel):
     repo_path: str | None = Field(
         default=None,
         description=(
-            "Local directory: repository root for repo tools and markdown root "
-            "for project_agent."
+            "Primary local directory: first repository root and default markdown "
+            "root for project_agent."
         ),
+    )
+    additional_repo_paths: list[str] = Field(
+        default_factory=list,
+        description="Extra local repository roots (multi-repo sessions).",
     )
     github_owner: str | None = Field(
         default=None,
@@ -51,6 +55,16 @@ class QueryRequest(BaseModel):
             msg = "github_owner and github_repo must both be set or both omitted."
             raise ValueError(msg)
         return self
+
+    def effective_repo_paths(self) -> list[str]:
+        """Return unique local roots in order (primary ``repo_path`` first)."""
+        out: list[str] = []
+        if self.repo_path:
+            out.append(self.repo_path)
+        for p in self.additional_repo_paths:
+            if p and p not in out:
+                out.append(p)
+        return out
 
 
 class ToolCall(BaseModel):

--- a/src/adt/repo_spec.py
+++ b/src/adt/repo_spec.py
@@ -18,6 +18,16 @@ class ResolvedRepoTarget:
     github_repo: str | None
 
 
+@dataclass(frozen=True)
+class MultiRepoResolution:
+    """Stable keys and paths for one or more ``--repo`` values."""
+
+    roots: dict[str, Path]
+    primary_key: str
+    github_owner: str | None
+    github_repo: str | None
+
+
 def resolve_repo_target(value: str) -> ResolvedRepoTarget:
     """Return a local root path and optional ``owner``/``repo`` for GitHub API tools.
 
@@ -58,3 +68,42 @@ def resolve_repo_target(value: str) -> ResolvedRepoTarget:
         f"(expected e.g. myorg/my-repo): {value!r}"
     )
     raise ValueError(msg)
+
+
+def resolve_repo_targets(values: list[str]) -> MultiRepoResolution:
+    """Parse several ``--repo`` strings into unique local roots and optional GitHub.
+
+    Keys are ``r0``, ``r1``, … in first-seen order. The first ``owner/repo`` slug
+    that appears sets ``github_owner`` / ``github_repo`` for project tools.
+
+    Args:
+        values: Raw ``--repo`` arguments (empty list treated as ``["."]``).
+
+    Returns:
+        Mapping of repo keys to resolved directories plus GitHub defaults.
+    """
+    raw = [v.strip() for v in values if v.strip()]
+    if not raw:
+        raw = ["."]
+    targets = [resolve_repo_target(v) for v in raw]
+    github_owner: str | None = None
+    github_repo: str | None = None
+    unique_paths: list[Path] = []
+    seen: set[Path] = set()
+    for t in targets:
+        if t.github_owner and t.github_repo and github_owner is None:
+            github_owner = t.github_owner
+            github_repo = t.github_repo
+        p = t.local_root.resolve()
+        if p not in seen:
+            seen.add(p)
+            unique_paths.append(p)
+    if not unique_paths:
+        unique_paths = [Path.cwd().resolve()]
+    roots = {f"r{i}": path for i, path in enumerate(unique_paths)}
+    return MultiRepoResolution(
+        roots=roots,
+        primary_key="r0",
+        github_owner=github_owner,
+        github_repo=github_repo,
+    )

--- a/src/adt/tools/compare.py
+++ b/src/adt/tools/compare.py
@@ -1,0 +1,177 @@
+"""Compare two local repository roots (structure, key files, dependency hints)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from adt.tools import repo as repo_tools
+
+_KEY_FILES = (
+    "pyproject.toml",
+    "setup.cfg",
+    "setup.py",
+    "package.json",
+    "requirements.txt",
+    "requirements-dev.txt",
+    "Cargo.toml",
+    "go.mod",
+    "poetry.lock",
+    "Pipfile",
+)
+
+
+def _collect_paths(root: Path, *, max_entries: int) -> set[str]:
+    """Relative POSIX paths for files under root (bounded walk)."""
+    root = root.resolve()
+    spec = repo_tools._load_gitignore_spec(root)
+    out: set[str] = set()
+    count = 0
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [
+            d
+            for d in dirnames
+            if d not in repo_tools._ALWAYS_SKIP_DIR_NAMES
+            and not d.endswith(".egg-info")
+        ]
+        current = Path(dirpath)
+        try:
+            rel_dir = current.relative_to(root).as_posix()
+        except ValueError:
+            continue
+        if rel_dir != "." and repo_tools._is_ignored(
+            rel_dir,
+            spec=spec,
+            is_dir=True,
+        ):
+            dirnames[:] = []
+            continue
+        for d in list(dirnames):
+            child = current / d
+            cr = child.relative_to(root).as_posix()
+            if repo_tools._is_ignored(cr, spec=spec, is_dir=True):
+                dirnames.remove(d)
+
+        for name in filenames:
+            if count >= max_entries:
+                return out
+            fp = current / name
+            rel = fp.relative_to(root).as_posix()
+            if repo_tools._is_ignored(rel, spec=spec, is_dir=False):
+                continue
+            if fp.is_file():
+                out.add(rel)
+                count += 1
+    return out
+
+
+def compare_repos(
+    roots: dict[str, Path],
+    repo_a: str,
+    repo_b: str,
+    *,
+    max_tree_entries: int = 400,
+) -> str:
+    """Return a structured text summary comparing two registered repo keys.
+
+    Args:
+        roots: Map of stable repo keys to absolute roots (from the session).
+        repo_a: First key in ``roots``.
+        repo_b: Second key in ``roots``.
+        max_tree_entries: Cap on indexed file paths per side.
+
+    Returns:
+        Human-readable diff sections or an error line.
+    """
+    ra = repo_a.strip()
+    rb = repo_b.strip()
+    if ra not in roots or rb not in roots:
+        known = ", ".join(sorted(roots)) or "(none)"
+        return f"error: unknown repo_key (known: {known})"
+    if ra == rb:
+        return "error: repo_a and repo_b must differ"
+
+    pa = roots[ra].resolve()
+    pb = roots[rb].resolve()
+    if not pa.is_dir() or not pb.is_dir():
+        return "error: one or both roots are not directories"
+
+    set_a = _collect_paths(pa, max_entries=max_tree_entries)
+    set_b = _collect_paths(pb, max_entries=max_tree_entries)
+
+    only_a = sorted(set_a - set_b)
+    only_b = sorted(set_b - set_a)
+    common = sorted(set_a & set_b)
+
+    lines: list[str] = [
+        f"compare_repos: {ra} ({pa}) vs {rb} ({pb})",
+        f"indexed_files: {len(set_a)} vs {len(set_b)} (cap={max_tree_entries})",
+        "",
+        "[structure]",
+        f"only_in_{ra}: {len(only_a)}",
+        f"only_in_{rb}: {len(only_b)}",
+        f"in_both: {len(common)}",
+    ]
+    if only_a[:30]:
+        lines.append(f"sample_only_{ra}: {', '.join(only_a[:30])}")
+    if only_b[:30]:
+        lines.append(f"sample_only_{rb}: {', '.join(only_b[:30])}")
+
+    lines.extend(["", "[key_files]"])
+    for name in _KEY_FILES:
+        fa = pa / name
+        fb = pb / name
+        sa = fa.is_file()
+        sb = fb.is_file()
+        if not sa and not sb:
+            continue
+        if sa != sb:
+            lines.append(f"{name}: only in {ra}" if sa else f"{name}: only in {rb}")
+            continue
+        try:
+            ta = fa.read_text(encoding="utf-8", errors="replace")
+            tb = fb.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            lines.append(f"{name}: read_error {exc}")
+            continue
+        if ta == tb:
+            lines.append(f"{name}: identical ({len(ta)} chars)")
+        else:
+            lines.append(
+                f"{name}: differ (chars {len(ta)} vs {len(tb)}); "
+                "see read_file on each side for details",
+            )
+
+    lines.extend(["", "[dependency_hints]"])
+    for label, base in (ra, pa), (rb, pb):
+        req = base / "requirements.txt"
+        if req.is_file():
+            try:
+                n = len(
+                    [
+                        ln
+                        for ln in req.read_text(
+                            encoding="utf-8",
+                            errors="ignore",
+                        ).splitlines()
+                        if ln.strip() and not ln.lstrip().startswith("#")
+                    ],
+                )
+                lines.append(f"{label} requirements.txt: ~{n} non-comment lines")
+            except OSError:
+                lines.append(f"{label} requirements.txt: (unreadable)")
+        pp = base / "pyproject.toml"
+        if pp.is_file():
+            try:
+                text = pp.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                lines.append(f"{label} pyproject.toml: (unreadable)")
+            else:
+                has_proj = "[project]" in text
+                has_poetry = "[tool.poetry]" in text
+                lines.append(
+                    f"{label} pyproject.toml: "
+                    f"[project]={has_proj} [tool.poetry]={has_poetry}",
+                )
+
+    return "\n".join(lines)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def tool_registry(sample_repo_path: str) -> ToolRegistry:
     """A tool registry with repo tools bound to the sample fixture repository."""
     reg = ToolRegistry()
     root = Path(sample_repo_path)
-    register_repo_tools(reg, root)
+    register_repo_tools(reg, {"r0": root})
     register_research_tools(reg)
     register_project_tools(reg, root, token=None)
     return reg

--- a/tests/fake_llm.py
+++ b/tests/fake_llm.py
@@ -11,11 +11,17 @@ from adt.models.schemas import LLMMessage
 class FakeLLM:
     """Returns a fixed sequence of assistant messages (for integration tests)."""
 
-    def __init__(self, replies: list[LLMMessage]) -> None:
+    def __init__(
+        self,
+        replies: list[LLMMessage],
+        *,
+        router_json: dict[str, Any] | None = None,
+    ) -> None:
         self._replies = list(replies)
         self._idx = 0
         self.last_usage: dict[str, int] = {}
         self.model = "gpt-4o-mini"
+        self._router_json: dict[str, Any] = dict(router_json or {"agent": "repo_agent"})
 
     def chat(
         self,
@@ -30,3 +36,20 @@ class FakeLLM:
         r = self._replies[self._idx]
         self._idx += 1
         return r
+
+    def complete_json_object(
+        self,
+        *,
+        system: str,
+        user: str,
+        model: str | None = None,
+        max_completion_tokens: int = 120,
+    ) -> dict[str, Any]:
+        """Return fixed JSON for routing tests."""
+        del system, user, model, max_completion_tokens
+        self.last_usage = {
+            "prompt_tokens": 1,
+            "completion_tokens": 1,
+            "total_tokens": 2,
+        }
+        return dict(self._router_json)

--- a/tests/unit/test_adt_config.py
+++ b/tests/unit/test_adt_config.py
@@ -1,0 +1,72 @@
+"""~/.adt/config.toml load/save."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adt.config import (
+    AdtConfig,
+    apply_env_overrides,
+    ensure_adt_dir,
+    load_config_file,
+    save_config,
+    update_config_key,
+)
+
+
+def test_ensure_adt_dir(monkeypatch, tmp_path) -> None:
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    d = ensure_adt_dir()
+    assert d == fake_home / ".adt"
+    assert d.is_dir()
+
+
+def test_load_missing_returns_defaults(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    from adt import config as m
+
+    monkeypatch.setattr(m, "adt_config_path", lambda: tmp_path / "nope.toml")
+    cfg = load_config_file()
+    assert cfg.default_model == "gpt-4o-mini"
+    assert cfg.use_llm_routing is True
+
+
+def test_save_and_roundtrip(tmp_path, monkeypatch) -> None:
+    from adt import config as m
+
+    p = tmp_path / "c.toml"
+    monkeypatch.setattr(m, "adt_config_path", lambda: p)
+    save_config(AdtConfig(default_model="gpt-4o", agent_chain=["repo_agent"]))
+    cfg = load_config_file(p)
+    assert cfg.default_model == "gpt-4o"
+    assert cfg.agent_chain == ["repo_agent"]
+
+
+def test_update_config_key(tmp_path, monkeypatch) -> None:
+    from adt import config as m
+
+    p = tmp_path / "c.toml"
+    monkeypatch.setattr(m, "adt_config_path", lambda: p)
+    update_config_key(p, "log_level", "debug")
+    cfg = load_config_file(p)
+    assert cfg.log_level == "DEBUG"
+
+
+def test_load_corrupt_toml_returns_defaults(tmp_path, monkeypatch) -> None:
+    from adt import config as m
+
+    p = tmp_path / "bad.toml"
+    p.write_text("[[[not toml", encoding="utf-8")
+    monkeypatch.setattr(m, "adt_config_path", lambda: p)
+    cfg = load_config_file()
+    assert cfg.default_model == "gpt-4o-mini"
+
+
+def test_env_override_model(monkeypatch) -> None:
+    monkeypatch.setenv("ADT_DEFAULT_MODEL", "custom-model")
+    cfg = apply_env_overrides(AdtConfig())
+    assert cfg.default_model == "custom-model"

--- a/tests/unit/test_bootstrap_build_runner.py
+++ b/tests/unit/test_bootstrap_build_runner.py
@@ -1,0 +1,29 @@
+"""Smoke-test :func:`adt.bootstrap.build_runner` wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from adt.bootstrap import build_runner
+
+
+@patch("adt.core.llm.OpenAI")
+def test_build_runner_multi_root_registers(
+    mock_openai: MagicMock,
+    tmp_path: Path,
+) -> None:
+    mock_openai.return_value = MagicMock()
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    runner = build_runner(
+        {"r0": a, "r1": b},
+        api_key="sk-test",
+        use_llm_routing=False,
+    )
+    assert len(runner._repo_roots) == 2
+    assert "compare_repos" in {
+        t["function"]["name"] for t in runner._registry.to_openai_format("repo_agent")
+    }

--- a/tests/unit/test_bootstrap_repo_tools.py
+++ b/tests/unit/test_bootstrap_repo_tools.py
@@ -1,0 +1,47 @@
+"""Multi-root repo tool registration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adt.bootstrap import register_repo_tools
+from adt.mcp.executor import ExecutionController
+from adt.mcp.registry import ToolRegistry
+from adt.models.schemas import ToolCall
+
+
+def test_register_repo_tools_two_roots_read_and_compare(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    (a / "x.txt").write_text("alpha", encoding="utf-8")
+    (b / "y.txt").write_text("beta", encoding="utf-8")
+    reg = ToolRegistry()
+    register_repo_tools(reg, {"r0": a, "r1": b}, primary_repo_key="r0")
+    ex = ExecutionController(reg)
+    r0 = ex.execute(
+        ToolCall(
+            name="read_file",
+            arguments={"path": "x.txt", "repo_key": "r0"},
+            agent="repo_agent",
+        ),
+    )
+    assert r0.success and "alpha" in r0.output
+    bad = ex.execute(
+        ToolCall(
+            name="read_file",
+            arguments={"path": "x.txt", "repo_key": "r1"},
+            agent="repo_agent",
+        ),
+    )
+    assert not bad.success or "error" in bad.output.lower()
+    cmp = ex.execute(
+        ToolCall(
+            name="compare_repos",
+            arguments={"repo_a": "r0", "repo_b": "r1"},
+            agent="repo_agent",
+        ),
+    )
+    assert cmp.success
+    assert "compare_repos" in cmp.output

--- a/tests/unit/test_cli_app.py
+++ b/tests/unit/test_cli_app.py
@@ -27,6 +27,59 @@ def test_cli_info() -> None:
     assert "ask" in result.stdout.lower()
 
 
+def test_cli_config_show() -> None:
+    """``config show`` prints effective settings."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["config", "show"])
+    assert result.exit_code == 0
+    assert "default_model" in result.stdout
+
+
+def test_cli_config_path() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["config", "path"])
+    assert result.exit_code == 0
+    assert ".adt" in result.stdout and "config.toml" in result.stdout
+
+
+def test_cli_config_set_writes_file(tmp_path, monkeypatch) -> None:
+    from adt import config as cfgmod
+
+    p = tmp_path / "cfg.toml"
+    monkeypatch.setattr(cfgmod, "adt_config_path", lambda: p)
+    runner = CliRunner()
+    result = runner.invoke(app, ["config", "set", "log_level", "WARNING"])
+    assert result.exit_code == 0
+    assert p.is_file()
+    assert "WARNING" in p.read_text(encoding="utf-8")
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
+@patch("adt.cli.app.build_runner")
+def test_cli_ask_multi_repo(mock_build, tmp_path) -> None:
+    mock_runner = MagicMock()
+    mock_runner.run.return_value = AgentResponse(
+        answer="ok",
+        tools_used=[],
+        context_summary="",
+        routed_agent="repo_agent",
+    )
+    mock_build.return_value = mock_runner
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["ask", "compare trees", "--repo", str(a), "--repo", str(b)],
+    )
+    assert result.exit_code == 0
+    roots = mock_build.call_args[0][0]
+    assert isinstance(roots, dict)
+    assert len(roots) == 2
+
+
 def test_cli_ask_requires_api_key(tmp_path) -> None:
     """``ask`` without ``OPENAI_API_KEY`` must exit with an error."""
     runner = CliRunner()

--- a/tests/unit/test_compare_repos_tool.py
+++ b/tests/unit/test_compare_repos_tool.py
@@ -1,0 +1,41 @@
+"""compare_repos structured diff."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adt.tools.compare import compare_repos
+
+
+def test_compare_repos_structure(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    (a / "only_a.txt").write_text("x", encoding="utf-8")
+    (b / "only_b.txt").write_text("y", encoding="utf-8")
+    (a / "shared.txt").write_text("same", encoding="utf-8")
+    (b / "shared.txt").write_text("same", encoding="utf-8")
+    roots = {"r0": a, "r1": b}
+    out = compare_repos(roots, "r0", "r1")
+    assert "compare_repos" in out
+    assert "in_both: 1" in out
+    assert "sample_only_r0" in out and "sample_only_r1" in out
+
+
+def test_compare_repos_pyproject_diff(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    (a / "pyproject.toml").write_text("[project]\nname='a'\n", encoding="utf-8")
+    (b / "pyproject.toml").write_text("[project]\nname='b'\n", encoding="utf-8")
+    roots = {"r0": a, "r1": b}
+    out = compare_repos(roots, "r0", "r1")
+    assert "pyproject.toml: differ" in out
+
+
+def test_compare_repos_unknown_key(tmp_path: Path) -> None:
+    roots = {"r0": tmp_path}
+    out = compare_repos(roots, "r0", "missing")
+    assert "error" in out.lower()

--- a/tests/unit/test_context_multi.py
+++ b/tests/unit/test_context_multi.py
@@ -1,0 +1,21 @@
+"""Multi-repository context blocks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adt.mcp.context import ContextBuilder
+
+
+def test_build_from_repos_labels(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    (a / "README.md").write_text("# A", encoding="utf-8")
+    (b / "README.md").write_text("# B", encoding="utf-8")
+    ctx = ContextBuilder(use_repo_tree_cache=False)
+    out = ctx.build_from_repos({"r0": a, "r1": b}, query="readme", use_cache=False)
+    assert "[context:repo label=r0" in out
+    assert "[context:repo label=r1" in out
+    assert "# A" in out or "README" in out

--- a/tests/unit/test_hybrid_supervisor.py
+++ b/tests/unit/test_hybrid_supervisor.py
@@ -1,0 +1,59 @@
+"""LLM routing with rule fallback."""
+
+from __future__ import annotations
+
+from adt.core.hybrid_supervisor import HybridSupervisor, parse_router_json
+from adt.core.supervisor import Supervisor
+from adt.models.schemas import QueryRequest
+from tests.fake_llm import FakeLLM
+
+
+class _ExplodingRouter:
+    """Stub LLM that fails JSON routing."""
+
+    model = "gpt-4o-mini"
+
+    def complete_json_object(self, **kwargs: object) -> dict[str, str]:
+        del kwargs
+        msg = "simulated router failure"
+        raise RuntimeError(msg)
+
+
+def test_hybrid_uses_llm_when_enabled() -> None:
+    llm = FakeLLM([], router_json={"agent": "project_agent"})
+    sup = HybridSupervisor(llm=llm, use_llm_routing=True, routing_model="gpt-4o-mini")
+    req = QueryRequest(query="hello world")
+    out = sup.route(req)
+    assert out.agent_name == "project_agent"
+    assert out.request.options.get("route") == "llm_classifier"
+
+
+def test_hybrid_falls_back_when_llm_disabled() -> None:
+    llm = FakeLLM([], router_json={"agent": "project_agent"})
+    sup = HybridSupervisor(llm=llm, use_llm_routing=False)
+    req = QueryRequest(query="hello world")
+    out = sup.route(req)
+    assert out.agent_name == "repo_agent"
+    assert out.request.options.get("route") == "default"
+
+
+def test_hybrid_falls_back_when_llm_raises() -> None:
+    sup = HybridSupervisor(llm=_ExplodingRouter(), use_llm_routing=True)
+    req = QueryRequest(query="hello world")
+    out = sup.route(req)
+    assert out.agent_name == "repo_agent"
+    assert out.request.options.get("route") == "default"
+
+
+def test_parse_router_json() -> None:
+    raw = '{"agent":"research_agent"}'
+    assert parse_router_json(raw) == {"agent": "research_agent"}
+    assert parse_router_json("") is None
+
+
+def test_rules_match_supervisor_keyword() -> None:
+    """Keyword routing should match plain Supervisor."""
+    hybrid = HybridSupervisor(llm=None, use_llm_routing=True)
+    plain = Supervisor()
+    q = QueryRequest(query="list open issues")
+    assert hybrid.route(q).agent_name == plain.route(q).agent_name

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -46,6 +46,24 @@ def test_chat_parses_tool_calls() -> None:
     assert out.tool_calls[0].arguments == {"message": "z"}
 
 
+def test_complete_json_object() -> None:
+    client = MagicMock()
+    client.chat.completions.create.return_value = MagicMock(
+        choices=[_choice('{"agent":"repo_agent"}')],
+        usage=MagicMock(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+    llm = LLMClient(client=client)
+    data = llm.complete_json_object(
+        system="s",
+        user="u",
+        model="m",
+        max_completion_tokens=50,
+    )
+    assert data.get("agent") == "repo_agent"
+    call_kw = client.chat.completions.create.call_args[1]
+    assert call_kw.get("response_format") == {"type": "json_object"}
+
+
 def test_chat_retries_on_429(monkeypatch: pytest.MonkeyPatch) -> None:
     client = MagicMock()
     sleeps: list[float] = []

--- a/tests/unit/test_query_request.py
+++ b/tests/unit/test_query_request.py
@@ -13,6 +13,15 @@ def test_github_owner_and_repo_must_be_paired() -> None:
         QueryRequest(query="x", github_owner="org", github_repo=None)
 
 
+def test_effective_repo_paths_orders_and_dedupes() -> None:
+    q = QueryRequest(
+        query="x",
+        repo_path="/a",
+        additional_repo_paths=["/b", "/a"],
+    )
+    assert q.effective_repo_paths() == ["/a", "/b"]
+
+
 def test_github_pair_accepted() -> None:
     """Both GitHub fields may be set together."""
     q = QueryRequest(

--- a/tests/unit/test_repo_agent.py
+++ b/tests/unit/test_repo_agent.py
@@ -9,7 +9,12 @@ from adt.models.schemas import QueryRequest
 def test_repo_agent_tools_and_prompt() -> None:
     """Declared tools and prompt should match the MVP contract."""
     agent = RepoAgent()
-    assert agent.tools == ["read_repo_tree", "read_file", "search_code"]
+    assert agent.tools == [
+        "read_repo_tree",
+        "read_file",
+        "search_code",
+        "compare_repos",
+    ]
     assert "senior software engineer" in agent.system_prompt.lower()
 
 

--- a/tests/unit/test_repo_targets.py
+++ b/tests/unit/test_repo_targets.py
@@ -1,0 +1,53 @@
+"""Multi-value ``--repo`` resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adt.repo_spec import resolve_repo_targets
+
+
+def test_resolve_repo_targets_dedupes_same_path(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    a.mkdir()
+    r = resolve_repo_targets([str(a), str(a)])
+    assert list(r.roots.keys()) == ["r0"]
+    assert r.roots["r0"] == a.resolve()
+
+
+def test_resolve_repo_targets_two_distinct(tmp_path: Path) -> None:
+    one = tmp_path / "one"
+    two = tmp_path / "two"
+    one.mkdir()
+    two.mkdir()
+    r = resolve_repo_targets([str(one), str(two)])
+    assert set(r.roots.keys()) == {"r0", "r1"}
+    assert r.roots["r0"] == one.resolve()
+    assert r.roots["r1"] == two.resolve()
+    assert r.primary_key == "r0"
+
+
+def test_resolve_repo_targets_empty_uses_dot(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    r = resolve_repo_targets([])
+    assert r.roots["r0"] == tmp_path.resolve()
+
+
+def test_resolve_repo_targets_github_first_slug(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    r = resolve_repo_targets(["acme/demo"])
+    assert r.github_owner == "acme"
+    assert r.github_repo == "demo"
+    assert r.roots["r0"] == tmp_path.resolve()
+
+
+def test_resolve_repo_targets_mixed_slug_and_path(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    loc = tmp_path / "loc"
+    loc.mkdir()
+    r = resolve_repo_targets(["o/r", str(loc)])
+    assert r.github_owner == "o"
+    assert r.github_repo == "r"
+    assert len(r.roots) == 2
+    assert tmp_path.resolve() in r.roots.values()
+    assert loc.resolve() in r.roots.values()

--- a/tests/unit/test_runner_chain.py
+++ b/tests/unit/test_runner_chain.py
@@ -1,0 +1,48 @@
+"""Optional agent_chain sequential execution."""
+
+from __future__ import annotations
+
+from adt.agents.project_agent import ProjectAgent
+from adt.agents.repo_agent import RepoAgent
+from adt.agents.research_agent import ResearchAgent
+from adt.core.runner import Runner
+from adt.core.supervisor import Supervisor
+from adt.mcp.context import ContextBuilder
+from adt.mcp.executor import ExecutionController
+from adt.models.schemas import LLMMessage, QueryRequest
+from tests.fake_llm import FakeLLM
+
+
+def test_agent_chain_runs_sequentially(
+    tool_registry,
+    sample_repo_path: str,
+) -> None:
+    fake = FakeLLM(
+        [
+            LLMMessage(role="assistant", content="First pass."),
+            LLMMessage(role="assistant", content="Second pass."),
+        ],
+    )
+    supervisor = Supervisor()
+    context = ContextBuilder()
+    executor = ExecutionController(tool_registry)
+    agents = {
+        "repo_agent": RepoAgent(),
+        "project_agent": ProjectAgent(),
+        "research_agent": ResearchAgent(),
+    }
+    runner = Runner(
+        supervisor,
+        fake,
+        context,
+        executor,
+        tool_registry,
+        agents,
+        agent_chain=["repo_agent", "repo_agent"],
+    )
+    res = runner.run(
+        QueryRequest(query="what is in main.py", repo_path=sample_repo_path),
+    )
+    assert "First pass." in res.answer
+    assert "Second pass." in res.answer
+    assert res.routed_agent.startswith("chain:")

--- a/tests/unit/test_runner_multi_repo.py
+++ b/tests/unit/test_runner_multi_repo.py
@@ -1,0 +1,76 @@
+"""Runner loads multi-root context for repo_agent."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adt.agents.project_agent import ProjectAgent
+from adt.agents.repo_agent import RepoAgent
+from adt.agents.research_agent import ResearchAgent
+from adt.bootstrap import register_repo_tools, register_research_tools
+from adt.core.runner import Runner
+from adt.core.supervisor import Supervisor
+from adt.mcp.context import ContextBuilder
+from adt.mcp.executor import ExecutionController
+from adt.mcp.registry import ToolRegistry
+from adt.models.schemas import LLMMessage, QueryRequest
+from tests.fake_llm import FakeLLM
+
+
+class _SpyMultiContext(ContextBuilder):
+    """Counts :meth:`build_from_repos` invocations."""
+
+    def __init__(self) -> None:
+        super().__init__(use_repo_tree_cache=False)
+        self.repos_calls = 0
+
+    def build_from_repos(
+        self,
+        roots: dict[str, Path],
+        *,
+        query: str | None = None,
+        use_cache: bool = True,
+    ) -> str:
+        self.repos_calls += 1
+        return super().build_from_repos(
+            roots,
+            query=query,
+            use_cache=use_cache,
+        )
+
+
+def test_runner_uses_build_from_repos_for_two_roots(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    (a / "main.py").write_text("x=1\n", encoding="utf-8")
+    (b / "main.py").write_text("y=2\n", encoding="utf-8")
+    reg = ToolRegistry()
+    register_repo_tools(reg, {"r0": a, "r1": b})
+    register_research_tools(reg)
+    spy = _SpyMultiContext()
+    agents = {
+        "repo_agent": RepoAgent(),
+        "project_agent": ProjectAgent(),
+        "research_agent": ResearchAgent(),
+    }
+    runner = Runner(
+        Supervisor(),
+        FakeLLM([LLMMessage(role="assistant", content="done.")]),
+        spy,
+        ExecutionController(reg),
+        reg,
+        agents,
+        repo_roots={"r0": a, "r1": b},
+    )
+    res = runner.run(
+        QueryRequest(
+            query="explain both codebases",
+            repo_path=str(a),
+            additional_repo_paths=[str(b)],
+            force_agent="repo_agent",
+        ),
+    )
+    assert res.answer == "done."
+    assert spy.repos_calls == 1

--- a/tests/unit/test_runner_research_context.py
+++ b/tests/unit/test_runner_research_context.py
@@ -32,6 +32,7 @@ class SpyContext(ContextBuilder):
         max_chars_per_file: int = 4000,
         max_context_tokens: int | None = None,
         use_cache: bool = True,
+        source_label: str | None = None,
     ) -> str:
         """Increment repo counter and delegate to the base implementation."""
         self.repo_calls += 1
@@ -43,6 +44,7 @@ class SpyContext(ContextBuilder):
             max_chars_per_file=max_chars_per_file,
             max_context_tokens=max_context_tokens,
             use_cache=use_cache,
+            source_label=source_label,
         )
 
     def build_from_text(self, text: str, *, max_tokens: int | None = None) -> str:

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -6,4 +6,4 @@ import adt
 
 
 def test_package_version() -> None:
-    assert adt.__version__ == "0.6.0"
+    assert adt.__version__ == "0.7.0"


### PR DESCRIPTION
## Description

Delivers **Phase 6 — Advanced Features**: multiple local repositories per `ask`, structured repo comparison, LLM-first intent routing with safe fallback to keyword rules, persistent `~/.adt/config.toml`, and optional multi-agent chaining.

## Changes

- **Multi-repo:** repeatable `--repo` / `-r`; session keys `r0`, `r1`, …; `repo_key` on `read_repo_tree` / `read_file` / `search_code`; `QueryRequest.additional_repo_paths`; `ContextBuilder.build_from_repos` with labeled blocks.
- **Diff:** `compare_repos` tool (trees, overlap, key files like `pyproject.toml`, dependency hints); registered on `repo_agent`.
- **Routing:** `HybridSupervisor` + `LLMClient.complete_json_object`; fallback to existing `Supervisor` keywords; configurable via `use_llm_routing` / `routing_model` / `ADT_USE_LLM_ROUTING` / `ADT_ROUTING_MODEL`.
- **Config:** `~/.adt/config.toml` (`default_model`, `log_level`, `cache_ttl_seconds`, `token_budget`, `max_tool_iterations`, `agent_chain`, `custom_tools` reserved); `adt config show|path|set`; env overrides for `ADT_*`.
- **Chaining:** non-empty `agent_chain` runs agents in sequence when `--agent` is not set; merged answer with `routed_agent` prefix `chain:…`.
- **Docs & version:** README + `docs/agents.md`; package version **0.7.0**; dependencies `tomli` / `tomli-w`.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests pass (CI / local `pytest`)
- [ ] Manual testing done (describe scenario) — _ex.: `adt ask "…" --repo ./a --repo ./b` e `adt config show`_

## Checklist

- [x] Code follows project conventions
- [x] Docstrings on new public APIs where relevant
- [x] No hardcoded secrets or API keys
- [x] Lint and type checks pass (`make lint typecheck` or equivalent)