### PR TITLE
chore: prepare v1.0.0 production release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,21 @@ jobs:
           name: coverage-xml
           path: coverage.xml
           if-no-files-found: ignore
+
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+
+      - name: Build wheel and smoke-install
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+          python -m pip install "dist/"*.whl
+          adt version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+# Build, publish to PyPI, and create a GitHub Release when a version tag is pushed.
+#
+# Setup (maintainers):
+# 1. PyPI: add a "pending" trusted publisher for this repo workflow, or set the
+#    PYPI_API_TOKEN repository secret for pypa/gh-action-pypi-publish.
+# 2. GitHub: ensure Actions can create releases (default write for GITHUB_TOKEN).
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build
+        run: python -m pip install --upgrade pip build
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Empty secret → OIDC trusted publishing; or set PYPI_API_TOKEN.
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [1.0.0] — 2026-04-03
+
+### Added
+
+- **PyPI distribution** as `agentic-dev-tool` with stable metadata and `hatchling` builds.
+- **GitHub Actions** `release.yml`: on `v*` tags, build wheels/sdists, publish to PyPI (trusted publishing or token), create a GitHub Release with generated notes.
+- **Optional HTTP API** (`pip install 'agentic-dev-tool[api]'`): FastAPI app with `GET /healthz`, `POST /ask`, OpenAPI at `/docs`; **`adt serve`** CLI to run **uvicorn**.
+- **Shared ask pipeline** in `adt.ask_session.run_ask` for CLI and API.
+- **Documentation:** `docs/architecture.md`, `docs/mcp.md`, expanded `docs/contributing.md` and `docs/agents.md` (prompt notes), `docs/portfolio.md` (external portfolio checklist).
+
+### Changed
+
+- **Development Status** classifier set to **Production/Stable**; version **1.0.0**.
+- README oriented toward **install from PyPI**, badges, command reference, architecture links, and demo placeholder.
+
+### Notes
+
+- Publishing to PyPI requires a [trusted publisher](https://docs.pypi.org/trusted-publishers/) or `PYPI_API_TOKEN` secret; see `docs/contributing.md`.
+
+[1.0.0]: https://github.com/brunoramosmartins/agentic-dev-tool/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -1,18 +1,40 @@
 # Agentic Dev Tool (adt)
 
 [![CI](https://github.com/brunoramosmartins/agentic-dev-tool/actions/workflows/ci.yml/badge.svg)](https://github.com/brunoramosmartins/agentic-dev-tool/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/agentic-dev-tool.svg)](https://pypi.org/project/agentic-dev-tool/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-A context-oriented AI assistant CLI built with a simplified Model Context Protocol (MCP). The project is designed for extensibility, real-world engineering use, and professional demonstration.
+Context-oriented **CLI** (and optional **HTTP API**) for working with repositories, GitHub project data, and research sources—using OpenAI tool calling and an **MCP-style** in-process tool layer (registry, JSON Schema, bounded context packing with **tiktoken**).
 
-## Status
+## Demo
 
-**Phase 6 — Advanced features:** Repeat **`--repo`** for **multi-repo** sessions (`r0`, `r1`, …); repo tools take optional **`repo_key`**; **`compare_repos`** diffs two roots. **LLM-based routing** (JSON classify, then keyword fallback) via config; **`~/.adt/config.toml`** holds defaults (`adt config show|set|path`). Optional **`agent_chain`** runs several agents in one `ask`. **Phase 5** still applies (tiktoken budgets, tree cache, JSON logs). See [docs/agents.md](docs/agents.md).
+Record a terminal session (e.g. [asciinema](https://asciinema.org/)) and link it here or in your portfolio. Suggested flow: `adt ask "…" --repo .`, then multi-repo `--repo a --repo b`, then `adt config show`. See [docs/portfolio.md](docs/portfolio.md).
+
+## Status (v1.0.0)
+
+**Production release** on PyPI as **`agentic-dev-tool`**. Features: multi-repo **`--repo`**, **`compare_repos`**, hybrid **LLM + keyword routing**, **`~/.adt/config.toml`**, optional **`agent_chain`**, JSON logs, tree cache, and optional **`adt serve`** (FastAPI). Documentation: [docs/architecture.md](docs/architecture.md), [docs/mcp.md](docs/mcp.md), [docs/agents.md](docs/agents.md), [CHANGELOG.md](CHANGELOG.md).
 
 ## Installation
 
 Requires **Python 3.10+**.
+
+### From PyPI (users)
+
+```bash
+pip install agentic-dev-tool
+adt version
+```
+
+Optional HTTP API:
+
+```bash
+pip install "agentic-dev-tool[api]"
+adt serve --port 8765
+# OpenAPI: http://127.0.0.1:8765/docs
+```
+
+### From source (contributors)
 
 ```bash
 python -m venv .venv
@@ -106,16 +128,44 @@ adt ask "List issues" --repo myorg/repo --agent project_agent
 - `--no-cache` — skip reading/writing the repo tree cache for this run.
 - `--model`, `-m` — OpenAI model (default from **`~/.adt/config.toml`** or `gpt-4o-mini`).
 
-Other commands:
+### HTTP API (optional)
+
+With `[api]` installed, **`adt serve`** binds to **127.0.0.1:8765** by default:
+
+- **`GET /healthz`** — liveness JSON (`status`, `version`).
+- **`POST /ask`** — JSON body: `query`, optional `repo` (list), `github_token`, `agent`, `no_cache`, `model`. Same orchestration as **`adt ask`**; requires **`OPENAI_API_KEY`** in the server environment.
+
+### Command summary
+
+| Command | Purpose |
+|--------|---------|
+| `adt ask …` | Main agent loop (routing, tools, answer). |
+| `adt serve` | Start FastAPI + uvicorn (`[api]` extra). |
+| `adt config show` / `path` / `set` | Manage `~/.adt/config.toml`. |
+| `adt version` | Package version. |
+| `adt info` | Short feature blurb. |
 
 ```bash
 adt --help
 adt ask --help
+adt serve --help
 adt config show
 adt config set default_model gpt-4o-mini
 adt version
 adt info
 ```
+
+## Architecture (overview)
+
+```text
+CLI / HTTP
+    → ask_session.run_ask
+    → build_runner (tools + HybridSupervisor + LLMClient + ContextBuilder)
+    → Runner (budget, context, chat + tool loop)
+    → AgentResponse
+```
+
+Details: [docs/architecture.md](docs/architecture.md). MCP-style tools: [docs/mcp.md](docs/mcp.md).
 
 ### Example session (shape of output)
 
@@ -128,6 +178,7 @@ make lint      # ruff check
 make format    # ruff format
 make test      # pytest with coverage (excludes live LLM tests by default)
 make typecheck # mypy src/
+python -m build   # sdist + wheel into dist/ (requires `pip install build`)
 ```
 
 Default pytest runs exclude tests marked `@pytest.mark.live`. For live OpenAI (and real GitHub when tests call the network):

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -73,3 +73,21 @@ When the runner builds repository context for `repo_agent` (and related paths), 
 **GitHub authentication:** Handlers receive a token from the CLI (`--token`) or environment **`GITHUB_TOKEN`**. Without a token, expect about **60 requests/hour** per IP; **403** responses include rate-limit hints when GitHub provides headers.
 
 **Context:** If a GitHub slug was passed on the CLI, the user message includes the default `owner/repo`. If only a local path was used, the runner adds repo tree context plus the markdown root path. Remote slug sessions skip the full tree (only short session hints) to avoid dumping unrelated `cwd` files.
+
+## Prompt engineering notes
+
+System prompts are **static strings** on each agent class (`repo_agent`, `project_agent`, `research_agent`). They are written to:
+
+- **Steer tool order** — e.g. repo agent starts with `read_repo_tree` unless paths are explicit; caps file reads per turn.
+- **Reduce hallucination** — instruct not to invent files or run shell commands; cite paths from tool output.
+- **Separate concerns** — project agent emphasizes GitHub API + markdown root; research agent emphasizes arXiv and safe HTTP fetch only.
+
+The **user message** assembled by `Runner` prepends the **packed context** (repo blocks, metadata) and ends with `User question:\n…`. No separate “chain-of-thought” channel: the model sees one user blob per turn.
+
+**Routing prompt** (`HybridSupervisor`) is minimal JSON-only: map the user text to one of three agent ids. It is kept short to limit latency and cost; failures fall back to **keyword routing** so behavior stays predictable in tests and offline scenarios.
+
+Tuning tips:
+
+- Adjust **keyword lists** in `supervisor.py` when users consistently mis-route.
+- Adjust **router system string** in `hybrid_supervisor.py` if the LLM over-selects one agent.
+- For **stricter repo behavior**, tighten the repo agent system prompt (e.g. max files, required `repo_key` wording for multi-repo).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,42 @@
 # Architecture
 
-Detailed architecture decisions will be documented in Phase 1+ (see project roadmap).
+This document summarizes how **agentic-dev-tool** (`adt`) is structured and why key choices were made. It complements the user-facing [README](../README.md) and the MCP-focused [mcp.md](mcp.md).
+
+## High-level flow
+
+1. **Input** — User question plus optional repo roots (`--repo`, repeatable), GitHub slug, or forced agent.
+2. **Configuration** — Defaults from `~/.adt/config.toml` and `ADT_*` environment variables; CLI flags override where applicable.
+3. **Routing** — `HybridSupervisor` tries a small **JSON LLM classification** (`LLMClient.complete_json_object`); on failure or when disabled, **keyword rules** (`Supervisor`) select `repo_agent`, `project_agent`, or `research_agent`.
+4. **Context** — `ContextBuilder` assembles bounded text: ranked files, tree listings, **tiktoken** budgets, optional **disk cache** for trees (`~/.adt/cache`). Multi-repo sessions use **labeled blocks** (`r0`, `r1`, …).
+5. **Execution** — `Runner` runs an OpenAI chat loop with **tools** from `ToolRegistry`; `ExecutionController` validates arguments (JSON Schema) and dispatches handlers.
+6. **Output** — `AgentResponse` (answer, tools used, routed agent, context summary). The CLI prints a Rich panel; the optional **FastAPI** layer returns JSON.
+
+Shared orchestration for CLI and HTTP lives in **`adt.ask_session.run_ask`**.
+
+## Major components
+
+| Module / area | Role |
+|---------------|------|
+| `adt.cli.app` | Typer entrypoint: `ask`, `config`, `serve`, `version`, `info`. |
+| `adt.ask_session` | Single-turn `run_ask` used by CLI and API. |
+| `adt.bootstrap` | Registers tools, builds `Runner`, wires `HybridSupervisor` + `LLMClient`. |
+| `adt.core.runner` | Budget allocation, context assembly per agent, tool loop, optional **agent_chain**. |
+| `adt.core.supervisor` | Deterministic keyword routing. |
+| `adt.core.hybrid_supervisor` | LLM routing with fallback to `Supervisor`. |
+| `adt.mcp.*` | Registry, executor, context builder, token budget, ranking, tree cache. |
+| `adt.tools.*` | Repo, project (GitHub + markdown), research (arXiv + HTTP fetch), `compare_repos`. |
+| `adt.api.server` | FastAPI: `/healthz`, `/ask` (optional extra `[api]`). |
+
+## Design decisions
+
+- **MCP-style, not a full MCP server** — Tools are described as JSON Schema and invoked in-process, which keeps deployment simple and avoids a long-running MCP host for the default CLI use case.
+- **Single OpenAI client** — One `LLMClient` for both chat and routing; routing uses `response_format: json_object` for a tiny payload.
+- **Multi-repo via explicit keys** — Session ids (`r0`, `r1`) avoid ambiguous path resolution and make `compare_repos` well-defined.
+- **Config file + env** — `toml` for persistent preferences; `ADT_*` for CI and shells without editing files.
+- **Optional API** — FastAPI and uvicorn are **not** core dependencies so `pip install agentic-dev-tool` stays lean for CLI-only users.
+
+## Extension points
+
+- **New tools** — Register `ToolDefinition` in `bootstrap.py` (or future plugin loading via `custom_tools` in config, reserved).
+- **New agents** — Subclass `BaseAgent`, add to `Runner` agent map and routing (LLM + keyword lists).
+- **Stricter API auth** — The stock server binds to `127.0.0.1` by default; add API keys or OAuth in front for public exposure.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,15 +1,56 @@
 # Contributing
 
-1. Use Python 3.10+ and a virtual environment.
+## Local setup
+
+1. Use **Python 3.10+** and a virtual environment.
 2. Install dev dependencies: `pip install -e ".[dev]"` (or `make install` where `make` is available).
-3. Run `ruff check .`, `ruff format .`, `mypy src/`, and `pytest` before opening a PR.
+3. Run **`ruff check .`**, **`ruff format .`**, **`mypy src/`**, and **`pytest`** before opening a PR.
 4. Enable pre-commit: `pre-commit install`.
 
-Pull requests should follow the template in `.github/PULL_REQUEST_TEMPLATE.md`.
+Pull requests should follow the template in [`.github/PULL_REQUEST_TEMPLATE.md`](../.github/PULL_REQUEST_TEMPLATE.md).
+
+## Optional API development
+
+The HTTP API is optional. Install extras:
+
+```bash
+pip install -e ".[dev]"
+# dev already includes fastapi + uvicorn; or: pip install -e ".[api]"
+adt serve --port 8765
+```
+
+Open `http://127.0.0.1:8765/docs` for OpenAPI.
+
+## Packaging and PyPI
+
+- **Build locally:** `python -m pip install build && python -m build` (artifacts in `dist/`).
+- **Smoke-install wheel:** `pip install dist/*.whl` then `adt version`.
+- **TestPyPI (manual):** `python -m twine upload --repository testpypi dist/*` (configure `~/.pypirc` or use `twine` with API token).
+- **Production release:** Push tag `v1.0.0` (etc.); [`.github/workflows/release.yml`](../.github/workflows/release.yml) builds and publishes.
+
+### PyPI authentication in CI
+
+Either:
+
+1. **Trusted publishing (recommended):** In PyPI project settings, add a trusted publisher for this GitHub repository and workflow `release.yml`. The workflow uses `permissions: id-token: write` and `pypa/gh-action-pypi-publish`.
+
+2. **API token:** Add repository secret **`PYPI_API_TOKEN`** and extend the publish step with:
+
+   ```yaml
+   with:
+     password: ${{ secrets.PYPI_API_TOKEN }}
+   ```
+
+   (See [PyPI publish action](https://github.com/pypa/gh-action-pypi-publish) docs for the exact inputs your org uses.)
 
 ## GitHub labels, milestones, and issues
 
-Optional automation for maintainers (requires `gh auth login`). All live under `scripts/`; if you already ran an older copy from the repo root, re-running is safe and skips existing GitHub entities.
+Optional automation for maintainers (requires `gh auth login`). Scripts live under `scripts/`; re-running is safe and skips existing GitHub entities.
 
 - `scripts/setup_all.sh` — runs `setup_labels.sh`, `setup_milestones.sh`, and `setup_issues.sh` in order.
 - `ADT_DELETE_DEFAULT_LABELS=1 ./scripts/setup_labels.sh` — opt-in removal of GitHub’s stock labels before creating the project label set.
+
+## Style
+
+- Prefer focused changes; match existing naming and typing (`mypy --strict`).
+- New public functions/classes should have concise **docstrings** (what + non-obvious side effects).

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,3 +1,27 @@
-# MCP layer
+# MCP layer specification
 
-Specification for context building, tool registry, and execution will be expanded in Phase 1+.
+This project uses a **simplified Model Context Protocol (MCP)**-style layer: tools are **declarative** (name, JSON Schema parameters, handler) and **executed in-process** against a `ToolRegistry`. It is **not** a network MCP server by default.
+
+## Concepts
+
+- **ToolRegistry** — Maps unique tool names to `ToolDefinition` (description, `parameters` schema, `allowed_agents`, Python `handler`).
+- **ExecutionController** — Validates tool call arguments with **jsonschema**, binds only parameters the handler accepts, runs the handler, returns `ToolResult` (text output, success flag).
+- **OpenAI tool format** — `registry.to_openai_format(agent_name)` filters tools by `allowed_agents` and emits `{"type":"function","function":{...}}` blocks for the chat API.
+- **ToolCall / ToolResult** — Pydantic models for assistant-proposed calls and normalized outcomes.
+
+## Context packing (not MCP wire format)
+
+Repository context is **plain text** embedded in the user message, not MCP resources:
+
+- Delimited blocks: `[context:repo label=r0 path=…]`, `[tree]`, `[file:rel/path]`, closing tags for budget trimming.
+- **Ranking** — Keyword overlap on paths, extension priority, smaller files preferred before packing.
+- **Budgeting** — `tiktoken` counts; `allocate_budget` splits a logical window (system / context / tools schema / completion).
+- **Cache** — Optional JSON cache files under `~/.adt/cache/` keyed by repo path and `git` HEAD, TTL configurable.
+
+## Logging
+
+Structured **JSON lines** append to `~/.adt/logs/adt.jsonl` (when file logging is configured): events such as `agent_selected`, `tool_called`, `request_completed`, `llm_failure`.
+
+## Relation to “full” MCP
+
+A full MCP deployment could expose the same tool set over stdio/WebSocket; this codebase optimizes for **CLI + optional HTTP** and **direct OpenAI tool calling** instead.

--- a/docs/portfolio.md
+++ b/docs/portfolio.md
@@ -1,0 +1,10 @@
+# Portfolio checklist (Phase 7)
+
+Items below are **outside the repository** or require manual recording; use this list when polishing a public portfolio.
+
+- [ ] Record a **terminal demo** (e.g. [asciinema](https://asciinema.org/)): `adt ask`, multi-repo `--repo`, `adt config show`, optional `adt serve` + `curl` to `/ask`.
+- [ ] Add the project to your **personal site** or portfolio page with one paragraph + links to PyPI, GitHub, and docs.
+- [ ] Publish a short **blog post** or LinkedIn article: problem, architecture (see [architecture.md](architecture.md)), and lessons learned.
+- [ ] Close or archive **GitHub issues** and mark milestone **Phase 7 — Production Release** complete.
+
+Optional: embed the asciinema cast in README once uploaded (link or player snippet).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,25 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentic-dev-tool"
-version = "0.7.0"
-description = "Context-oriented AI assistant CLI with a simplified MCP-style tool layer."
+version = "1.0.0"
+description = "Context-oriented AI CLI and optional HTTP API: agents, MCP-style tools, multi-repo, OpenAI."
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.10"
 authors = [{ name = "Bruno Ramos Martins" }]
-keywords = ["cli", "ai", "agents", "mcp", "llm"]
+maintainers = [{ name = "Bruno Ramos Martins" }]
+keywords = [
+  "cli",
+  "ai",
+  "agents",
+  "mcp",
+  "llm",
+  "openai",
+  "fastapi",
+  "typer",
+]
 classifiers = [
-  "Development Status :: 2 - Pre-Alpha",
+  "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
@@ -20,6 +30,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Topic :: Software Development :: Libraries :: Python Modules",
   "Typing :: Typed",
 ]
 dependencies = [
@@ -36,12 +47,19 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+api = [
+  "fastapi>=0.109",
+  "uvicorn[standard]>=0.27",
+]
 dev = [
   "pytest>=7.4",
   "pytest-cov>=4.1",
   "ruff>=0.6",
   "mypy>=1.8",
   "pre-commit>=3.6",
+  "build>=1.0",
+  "fastapi>=0.109",
+  "uvicorn[standard]>=0.27",
 ]
 test = [
   "pytest>=7.4",
@@ -54,13 +72,21 @@ adt = "adt.cli.app:app"
 [project.urls]
 Homepage = "https://github.com/brunoramosmartins/agentic-dev-tool"
 Repository = "https://github.com/brunoramosmartins/agentic-dev-tool"
+Documentation = "https://github.com/brunoramosmartins/agentic-dev-tool/tree/main/docs"
+Changelog = "https://github.com/brunoramosmartins/agentic-dev-tool/blob/main/CHANGELOG.md"
 Issues = "https://github.com/brunoramosmartins/agentic-dev-tool/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/adt"]
 
 [tool.hatch.build.targets.sdist]
-include = ["src/adt", "README.md", "LICENSE"]
+include = [
+  "src/adt",
+  "README.md",
+  "LICENSE",
+  "CHANGELOG.md",
+  "docs",
+]
 
 [tool.ruff]
 target-version = "py310"
@@ -96,6 +122,18 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "tomli_w"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "fastapi"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "fastapi.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "uvicorn"
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/adt/__init__.py
+++ b/src/adt/__init__.py
@@ -1,3 +1,3 @@
 """Agentic Dev Tool — context-oriented AI assistant CLI."""
 
-__version__ = "0.7.0"
+__version__ = "1.0.0"

--- a/src/adt/api/__init__.py
+++ b/src/adt/api/__init__.py
@@ -1,0 +1,1 @@
+"""Optional HTTP API (install with ``pip install 'agentic-dev-tool[api]'``)."""

--- a/src/adt/api/server.py
+++ b/src/adt/api/server.py
@@ -1,0 +1,109 @@
+"""FastAPI application exposing ``/healthz`` and ``/ask``."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from adt import __version__
+from adt.ask_session import AskConfigurationError, run_ask
+from adt.logging.json_log import setup_adt_file_logging
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    """Configure JSON file logging once at process start."""
+    setup_adt_file_logging(level=logging.INFO)
+    logging.getLogger("adt").setLevel(logging.INFO)
+    yield
+
+
+app = FastAPI(
+    title="Agentic Dev Tool API",
+    description="HTTP wrapper around the same ``ask`` pipeline as the CLI.",
+    version=__version__,
+    lifespan=_lifespan,
+)
+
+
+class AskRequest(BaseModel):
+    """JSON body for ``POST /ask``."""
+
+    query: str = Field(..., min_length=1, description="Natural language question.")
+    repo: list[str] | None = Field(
+        default=None,
+        description="Repository paths or owner/repo slugs (same as CLI ``--repo``).",
+    )
+    github_token: str | None = Field(
+        default=None,
+        description="Optional GitHub PAT for this request only.",
+    )
+    agent: str | None = Field(
+        default=None,
+        description="Force ``repo_agent``, ``project_agent``, or ``research_agent``.",
+    )
+    no_cache: bool = Field(default=False, description="Disable repo tree disk cache.")
+    model: str | None = Field(default=None, description="OpenAI model override.")
+
+
+class AskResponse(BaseModel):
+    """Structured agent result."""
+
+    answer: str
+    routed_agent: str
+    tools_used: list[str]
+    context_summary: str
+    token_usage: dict[str, int] = Field(default_factory=dict)
+
+
+@app.get("/healthz", tags=["meta"])
+def healthz() -> dict[str, str]:
+    """Liveness probe; does not call external APIs."""
+    return {"status": "ok", "version": __version__}
+
+
+@app.post("/ask", response_model=AskResponse, tags=["ask"])
+def post_ask(body: AskRequest) -> AskResponse:
+    """Run one agent turn (same orchestration as ``adt ask``)."""
+    try:
+        exe = run_ask(
+            query=body.query,
+            repo=body.repo,
+            github_token=body.github_token,
+            force_agent=body.agent,
+            verbose=False,
+            log_level=None,
+            no_cache=body.no_cache,
+            model=body.model,
+            configure_logging=False,
+        )
+    except AskConfigurationError as exc:
+        detail: Any = str(exc)
+        code = 503 if "OPENAI_API_KEY" in detail else 400
+        raise HTTPException(status_code=code, detail=detail) from exc
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("ask failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    r = exe.response
+    usage = getattr(exe.runner, "last_token_usage", None)
+    tok = usage if isinstance(usage, dict) else {}
+    return AskResponse(
+        answer=r.answer,
+        routed_agent=r.routed_agent,
+        tools_used=list(r.tools_used),
+        context_summary=r.context_summary,
+        token_usage={k: int(v) for k, v in tok.items() if isinstance(v, int)},
+    )
+
+
+def create_app() -> FastAPI:
+    """Return the FastAPI application (useful for ASGI servers and tests)."""
+    return app

--- a/src/adt/ask_session.py
+++ b/src/adt/ask_session.py
@@ -1,0 +1,129 @@
+"""Shared logic for running one ``ask`` turn (CLI, HTTP API, tests)."""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from adt.bootstrap import build_runner
+from adt.config import apply_env_overrides, load_config_file
+from adt.core.runner import Runner
+from adt.logging.json_log import setup_adt_file_logging
+from adt.models.schemas import AgentResponse, QueryRequest
+from adt.repo_spec import resolve_repo_targets
+
+_VALID_AGENTS = frozenset({"repo_agent", "research_agent", "project_agent"})
+
+
+class AskConfigurationError(ValueError):
+    """Raised when the environment or arguments prevent a run (e.g. missing API key)."""
+
+
+@dataclass(frozen=True)
+class AskExecution:
+    """Outcome of a single agent run plus the runner for metrics."""
+
+    response: AgentResponse
+    runner: Runner
+
+
+def run_ask(
+    *,
+    query: str,
+    repo: list[str] | None = None,
+    github_token: str | None = None,
+    force_agent: str | None = None,
+    verbose: bool = False,
+    log_level: str | None = None,
+    no_cache: bool = False,
+    model: str | None = None,
+    configure_logging: bool = True,
+) -> AskExecution:
+    """Resolve repos, build a :class:`~adt.core.runner.Runner`, and run the query.
+
+    Args:
+        query: User natural-language question.
+        repo: ``--repo`` values (dirs or ``owner/repo`` slugs); default ``["."]``.
+        github_token: Optional PAT; falls back to ``GITHUB_TOKEN`` in the environment.
+        force_agent: When set, skip supervisor routing and ``agent_chain``.
+        verbose: When True and ``configure_logging`` is True, set log level to DEBUG.
+        log_level: File log level name if ``configure_logging`` is True.
+        no_cache: Disable repository tree disk cache for this request.
+        model: OpenAI model override; otherwise config / default.
+        configure_logging: When True, call ``setup_adt_file_logging`` (JSON file logs).
+
+    Returns:
+        :class:`AskExecution` with the response and runner (token usage, budget).
+
+    Raises:
+        AskConfigurationError: Missing API key, invalid ``force_agent``, or bad repos.
+    """
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        msg = "Missing OPENAI_API_KEY. Set it in the environment or in a `.env` file."
+        raise AskConfigurationError(msg)
+
+    if force_agent is not None and force_agent not in _VALID_AGENTS:
+        known = ", ".join(sorted(_VALID_AGENTS))
+        msg = f"Invalid agent {force_agent!r}. Choose one of: {known}."
+        raise AskConfigurationError(msg)
+
+    cfg = apply_env_overrides(load_config_file())
+    eff_model = model if model is not None else cfg.default_model
+    eff_log = (log_level or cfg.log_level).upper()
+
+    repo_list = list(repo) if repo else ["."]
+    try:
+        resolved = resolve_repo_targets(repo_list)
+    except ValueError as exc:
+        raise AskConfigurationError(str(exc)) from exc
+
+    primary_path = resolved.roots[resolved.primary_key]
+    extra_paths = [
+        str(p) for k, p in resolved.roots.items() if k != resolved.primary_key
+    ]
+
+    if configure_logging:
+        lvl = getattr(logging, eff_log, logging.INFO)
+        if verbose:
+            lvl = logging.DEBUG
+        setup_adt_file_logging(level=lvl)
+        logging.getLogger("adt").setLevel(lvl)
+
+    tok = github_token.strip() if github_token else None
+    if not tok:
+        env_gh = os.environ.get("GITHUB_TOKEN")
+        tok = env_gh.strip() if env_gh else None
+
+    chain = cfg.agent_chain if cfg.agent_chain else None
+    runner = build_runner(
+        resolved.roots,
+        markdown_root=primary_path,
+        primary_repo_key=resolved.primary_key,
+        model=eff_model,
+        api_key=api_key,
+        github_token=tok,
+        use_context_cache=not no_cache,
+        context_cache_ttl=cfg.cache_ttl_seconds,
+        token_budget_total=cfg.token_budget,
+        use_llm_routing=cfg.use_llm_routing,
+        routing_model=cfg.routing_model,
+        agent_chain=chain,
+        max_tool_iterations=cfg.max_tool_iterations,
+    )
+    opts: dict[str, Any] = {}
+    if no_cache:
+        opts["no_cache"] = True
+    request = QueryRequest(
+        query=query,
+        repo_path=str(primary_path),
+        additional_repo_paths=extra_paths,
+        github_owner=resolved.github_owner,
+        github_repo=resolved.github_repo,
+        force_agent=force_agent,
+        options=opts,
+    )
+    response = runner.run(request)
+    return AskExecution(response=response, runner=runner)

--- a/src/adt/cli/app.py
+++ b/src/adt/cli/app.py
@@ -2,26 +2,21 @@
 
 from __future__ import annotations
 
-import logging
-import os
 from importlib import metadata
-from typing import Annotated, Any
+from typing import Annotated
 
 import typer
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
 
-from adt.bootstrap import build_runner
+from adt.ask_session import AskConfigurationError, run_ask
 from adt.config import (
     adt_config_path,
     apply_env_overrides,
     load_config_file,
     update_config_key,
 )
-from adt.logging.json_log import setup_adt_file_logging
-from adt.models.schemas import QueryRequest
-from adt.repo_spec import resolve_repo_targets
 
 app = typer.Typer(help="Agentic Dev Tool CLI", add_completion=False)
 config_app = typer.Typer(help="View or edit ~/.adt/config.toml", add_completion=False)
@@ -36,7 +31,7 @@ def _version_string() -> str:
     try:
         return metadata.version("agentic-dev-tool")
     except metadata.PackageNotFoundError:
-        return "0.7.0-dev"
+        return "1.0.0-dev"
 
 
 def _format_ask_panel(agent_name: str, answer: str) -> None:
@@ -84,9 +79,8 @@ def version_cmd() -> None:
 def info_cmd() -> None:
     """Print short project status and feature summary."""
     typer.echo(
-        "adt — Phase 6. ask: multi-repo --repo, compare_repos, LLM routing with "
-        "rule fallback, ~/.adt/config.toml (adt config show|set|path), optional "
-        "agent_chain. See docs/agents.md.",
+        "adt — v1.0.0 production: PyPI package, optional HTTP API (`adt serve`), "
+        "multi-repo ask, config.toml, LLM routing. Docs: README, docs/architecture.md.",
     )
 
 
@@ -135,9 +129,7 @@ def ask_cmd(
         typer.Option(
             "--repo",
             "-r",
-            help=(
-                "Local directory or owner/repo slug; repeat for multiple checkouts."
-            ),
+            help=("Local directory or owner/repo slug; repeat for multiple checkouts."),
         ),
     ] = None,
     token: Annotated[
@@ -186,14 +178,6 @@ def ask_cmd(
     ] = None,
 ) -> None:
     """Ask a question: supervisor picks an agent unless ``--agent`` is set."""
-    api_key = os.environ.get("OPENAI_API_KEY")
-    if not api_key:
-        console.print(
-            "[red]Missing OPENAI_API_KEY.[/red] "
-            "Set it in the environment or in a `.env` file.",
-        )
-        raise typer.Exit(code=1)
-
     if agent is not None and agent not in _VALID_AGENTS:
         console.print(
             "[red]Invalid --agent.[/red] "
@@ -201,62 +185,21 @@ def ask_cmd(
         )
         raise typer.Exit(code=1)
 
-    cfg = apply_env_overrides(load_config_file())
-    eff_model = model if model is not None else cfg.default_model
-    eff_log = (log_level or cfg.log_level).upper()
-
-    repo_list = list(repo) if repo else ["."]
     try:
-        resolved = resolve_repo_targets(repo_list)
-    except ValueError as exc:
-        raise typer.BadParameter(str(exc)) from exc
-
-    primary_path = resolved.roots[resolved.primary_key]
-    extra_paths = [
-        str(p) for k, p in resolved.roots.items() if k != resolved.primary_key
-    ]
-
-    lvl = getattr(logging, eff_log, logging.INFO)
-    if verbose:
-        lvl = logging.DEBUG
-    setup_adt_file_logging(level=lvl)
-    logging.getLogger("adt").setLevel(lvl)
-
-    github_token = token.strip() if token else None
-    if not github_token:
-        env_gh = os.environ.get("GITHUB_TOKEN")
-        github_token = env_gh.strip() if env_gh else None
-
-    chain = cfg.agent_chain if cfg.agent_chain else None
-    runner = build_runner(
-        resolved.roots,
-        markdown_root=primary_path,
-        primary_repo_key=resolved.primary_key,
-        model=eff_model,
-        api_key=api_key,
-        github_token=github_token,
-        use_context_cache=not no_cache,
-        context_cache_ttl=cfg.cache_ttl_seconds,
-        token_budget_total=cfg.token_budget,
-        use_llm_routing=cfg.use_llm_routing,
-        routing_model=cfg.routing_model,
-        agent_chain=chain,
-        max_tool_iterations=cfg.max_tool_iterations,
-    )
-    opts: dict[str, Any] = {}
-    if no_cache:
-        opts["no_cache"] = True
-    request = QueryRequest(
-        query=query,
-        repo_path=str(primary_path),
-        additional_repo_paths=extra_paths,
-        github_owner=resolved.github_owner,
-        github_repo=resolved.github_repo,
-        force_agent=agent,
-        options=opts,
-    )
-    try:
-        response = runner.run(request)
+        exe = run_ask(
+            query=query,
+            repo=repo,
+            github_token=token,
+            force_agent=agent,
+            verbose=verbose,
+            log_level=log_level,
+            no_cache=no_cache,
+            model=model,
+            configure_logging=True,
+        )
+    except AskConfigurationError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
     except Exception as exc:  # noqa: BLE001 — last-resort CLI guard
         console.print(
             "[red]Unexpected error while running the agent.[/red] "
@@ -264,6 +207,8 @@ def ask_cmd(
         )
         raise typer.Exit(code=1) from exc
 
+    response = exe.response
+    runner = exe.runner
     routed = response.routed_agent or agent or "supervisor"
     console.print(f"[dim]Agent:[/dim] [bold]{routed}[/bold]")
     _format_ask_panel(response.routed_agent or agent or "", response.answer)
@@ -276,6 +221,32 @@ def ask_cmd(
         br = getattr(runner, "last_budget_report", None)
         if br:
             console.print(f"[dim]Token budget (estimated):[/dim] {br}")
+
+
+@app.command("serve")
+def serve_cmd(
+    host: Annotated[
+        str,
+        typer.Option("--host", help="Bind address (default 127.0.0.1)."),
+    ] = "127.0.0.1",
+    port: Annotated[
+        int,
+        typer.Option("--port", help="TCP port (default 8765)."),
+    ] = 8765,
+) -> None:
+    """Run the optional HTTP API (install ``agentic-dev-tool[api]`` first)."""
+    try:
+        import uvicorn
+    except ImportError:
+        console.print(
+            "[red]Missing API dependencies.[/red] "
+            "Install with: pip install 'agentic-dev-tool[api]'",
+        )
+        raise typer.Exit(code=1) from None
+    from adt.api.server import app as api_app
+
+    console.print(f"[dim]Open http://{host}:{port}/docs[/dim]")
+    uvicorn.run(api_app, host=host, port=port, log_level="info")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_api_server.py
+++ b/tests/unit/test_api_server.py
@@ -1,0 +1,56 @@
+"""FastAPI server smoke tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from adt.api.server import app
+from adt.ask_session import AskConfigurationError, AskExecution
+from adt.models.schemas import AgentResponse
+
+
+def test_healthz() -> None:
+    client = TestClient(app)
+    res = client.get("/healthz")
+    assert res.status_code == 200
+    data = res.json()
+    assert data["status"] == "ok"
+    assert "version" in data
+
+
+@patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}, clear=False)
+@patch("adt.api.server.run_ask")
+def test_post_ask_success(mock_run: MagicMock) -> None:
+    runner = MagicMock()
+    runner.last_token_usage = {"total_tokens": 42}
+    mock_run.return_value = AskExecution(
+        response=AgentResponse(
+            answer="Hello.",
+            tools_used=["read_repo_tree"],
+            context_summary="ctx",
+            routed_agent="repo_agent",
+        ),
+        runner=runner,
+    )
+    client = TestClient(app)
+    res = client.post(
+        "/ask",
+        json={"query": "What is this?", "repo": ["."], "no_cache": True},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["answer"] == "Hello."
+    assert body["routed_agent"] == "repo_agent"
+    assert "read_repo_tree" in body["tools_used"]
+
+
+@patch("adt.api.server.run_ask")
+def test_post_ask_missing_key(mock_run: MagicMock) -> None:
+    mock_run.side_effect = AskConfigurationError(
+        "Missing OPENAI_API_KEY. Set it in the environment.",
+    )
+    client = TestClient(app)
+    res = client.post("/ask", json={"query": "Hi"})
+    assert res.status_code == 503

--- a/tests/unit/test_ask_session.py
+++ b/tests/unit/test_ask_session.py
@@ -1,0 +1,47 @@
+"""Tests for ``adt.ask_session``."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from adt.ask_session import AskConfigurationError, AskExecution, run_ask
+from adt.models.schemas import AgentResponse
+
+
+def test_run_ask_missing_api_key() -> None:
+    with (
+        patch.dict(os.environ, {"OPENAI_API_KEY": ""}, clear=False),
+        pytest.raises(AskConfigurationError, match="OPENAI_API_KEY"),
+    ):
+        run_ask(query="hi", configure_logging=False)
+
+
+def test_run_ask_invalid_agent() -> None:
+    with (
+        patch.dict(os.environ, {"OPENAI_API_KEY": "sk-x"}, clear=False),
+        pytest.raises(AskConfigurationError, match="Invalid agent"),
+    ):
+        run_ask(query="hi", force_agent="nope", configure_logging=False)
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
+@patch("adt.ask_session.build_runner")
+def test_run_ask_success(mock_br: MagicMock, tmp_path) -> None:
+    repo = tmp_path / "r"
+    repo.mkdir()
+    mock_runner = MagicMock()
+    mock_runner.run.return_value = AgentResponse(
+        answer="ok",
+        tools_used=[],
+        context_summary="",
+        routed_agent="repo_agent",
+    )
+    mock_br.return_value = mock_runner
+    exe = run_ask(query="q", repo=[str(repo)], configure_logging=False)
+    assert isinstance(exe, AskExecution)
+    assert exe.response.answer == "ok"
+    mock_br.assert_called_once()
+    mock_runner.run.assert_called_once()

--- a/tests/unit/test_cli_app.py
+++ b/tests/unit/test_cli_app.py
@@ -55,7 +55,7 @@ def test_cli_config_set_writes_file(tmp_path, monkeypatch) -> None:
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
-@patch("adt.cli.app.build_runner")
+@patch("adt.ask_session.build_runner")
 def test_cli_ask_multi_repo(mock_build, tmp_path) -> None:
     mock_runner = MagicMock()
     mock_runner.run.return_value = AgentResponse(
@@ -91,7 +91,7 @@ def test_cli_ask_requires_api_key(tmp_path) -> None:
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
-@patch("adt.cli.app.build_runner")
+@patch("adt.ask_session.build_runner")
 def test_cli_ask_runs_runner(mock_build, tmp_path) -> None:
     """``ask`` should call ``build_runner_for_repo`` and print the model answer."""
     mock_runner = MagicMock()
@@ -118,7 +118,7 @@ def test_cli_ask_runs_runner(mock_build, tmp_path) -> None:
 
 
 @patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
-@patch("adt.cli.app.build_runner")
+@patch("adt.ask_session.build_runner")
 def test_cli_ask_accepts_force_agent(mock_build, tmp_path) -> None:
     """``--agent`` should be forwarded on :class:`~adt.models.schemas.QueryRequest`."""
     mock_runner = MagicMock()
@@ -149,7 +149,7 @@ def test_cli_ask_accepts_force_agent(mock_build, tmp_path) -> None:
     assert req.force_agent == "research_agent"
 
 
-@patch("adt.cli.app.build_runner")
+@patch("adt.ask_session.build_runner")
 def test_cli_ask_rejects_invalid_agent(mock_build, tmp_path) -> None:
     """Unknown ``--agent`` values must exit before the runner is built."""
     runner = CliRunner()

--- a/tests/unit/test_smoke.py
+++ b/tests/unit/test_smoke.py
@@ -6,4 +6,4 @@ import adt
 
 
 def test_package_version() -> None:
-    assert adt.__version__ == "0.7.0"
+    assert adt.__version__ == "1.0.0"


### PR DESCRIPTION
## Description

Prepares the **v1.0.0** production release: PyPI packaging, optional HTTP API (`adt serve`), shared `run_ask` pipeline, documentation refresh, and release automation per `.github/workflows/release.yml`.

*(Substitua `#XX` pelos issues reais da Phase 7, se existirem.)*

## Changes

- `pyproject.toml` at **1.0.0**; optional `[api]` extra; build metadata for Hatchling
- `.github/workflows/release.yml` — tag `v*`: build, PyPI publish, GitHub Release with generated notes
- `adt ask_session`, `adt api/server`, CLI `serve`; README, CHANGELOG, docs under `docs/`

## Testing

- [x] Unit tests added/updated
- [x] Integration tests pass
- [x] Manual testing done (describe scenario)
  - `pip install -e ".[dev]"`; `make lint`, `make test`, `make typecheck`
  - `adt ask "…" --repo .` and optional `adt serve` + `/healthz`, `/ask`

## Checklist

- [x] Code follows project conventions
- [x] Docstrings added to new public functions
- [x] No hardcoded secrets or API keys
- [x] Lint and type checks pass (`make lint typecheck`)