### PR TITLE
refactor: code quality polish — DRY, coverage 85%, logging consistency

### DIFF
--- a/src/adt/agents/__init__.py
+++ b/src/adt/agents/__init__.py
@@ -1,1 +1,8 @@
 """Specialized agents (repo, project, research)."""
+
+from adt.agents.base import BaseAgent
+from adt.agents.project_agent import ProjectAgent
+from adt.agents.repo_agent import RepoAgent
+from adt.agents.research_agent import ResearchAgent
+
+__all__ = ["BaseAgent", "ProjectAgent", "RepoAgent", "ResearchAgent"]

--- a/src/adt/core/hybrid_supervisor.py
+++ b/src/adt/core/hybrid_supervisor.py
@@ -7,6 +7,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from adt.core.supervisor import Supervisor
+from adt.logging.json_log import log_adt
 from adt.models.schemas import QueryRequest, RoutedRequest
 
 if TYPE_CHECKING:
@@ -76,11 +77,7 @@ def _llm_classify_agent(
             max_completion_tokens=80,
         )
     except Exception as exc:
-        logger.info(
-            "llm routing failed, using rules: %s",
-            exc,
-            extra={"adt": {"event": "llm_route_fallback", "error": str(exc)}},
-        )
+        log_adt(logger, logging.INFO, event="llm_route_fallback", error=str(exc))
         return None
 
     agent = raw.get("agent") if isinstance(raw, dict) else None

--- a/src/adt/core/llm.py
+++ b/src/adt/core/llm.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from openai import APIStatusError, OpenAI
 
+from adt.logging.json_log import log_adt
 from adt.models.schemas import LLMMessage, ToolCall
 
 logger = logging.getLogger(__name__)
@@ -126,10 +127,7 @@ class LLMClient:
                         "completion_tokens": usage.completion_tokens,
                         "total_tokens": usage.total_tokens,
                     }
-                    logger.info(
-                        "",
-                        extra={"adt": {"event": "llm_usage", **self._last_usage}},
-                    )
+                    log_adt(logger, logging.INFO, event="llm_usage", **self._last_usage)
                 tool_calls = _tool_calls_from_openai(choice.tool_calls)
                 return LLMMessage(
                     role="assistant",

--- a/src/adt/mcp/__init__.py
+++ b/src/adt/mcp/__init__.py
@@ -1,1 +1,12 @@
 """MCP-style context, tool registry, and execution layer."""
+
+from adt.mcp.context import ContextBuilder
+from adt.mcp.executor import ExecutionController
+from adt.mcp.registry import ToolDefinition, ToolRegistry
+
+__all__ = [
+    "ContextBuilder",
+    "ExecutionController",
+    "ToolDefinition",
+    "ToolRegistry",
+]

--- a/src/adt/mcp/context.py
+++ b/src/adt/mcp/context.py
@@ -14,22 +14,8 @@ from adt.mcp.tokens import (
     trim_context,
     truncate_head_tail,
 )
+from adt.tools._paths import SKIP_DIR_NAMES as _SKIP_DIR_NAMES
 
-_SKIP_DIR_NAMES = {
-    ".git",
-    ".hg",
-    ".svn",
-    "__pycache__",
-    ".venv",
-    "venv",
-    "node_modules",
-    ".mypy_cache",
-    ".ruff_cache",
-    ".pytest_cache",
-    "dist",
-    "build",
-    ".eggs",
-}
 _TEXT_SUFFIXES = {
     ".py",
     ".md",

--- a/src/adt/mcp/executor.py
+++ b/src/adt/mcp/executor.py
@@ -11,6 +11,7 @@ from typing import Any
 import jsonschema
 from jsonschema import ValidationError
 
+from adt.logging.json_log import log_adt
 from adt.mcp.registry import ToolRegistry
 from adt.models.schemas import ToolCall, ToolResult
 
@@ -131,4 +132,4 @@ class ExecutionController:
         }
         if error is not None:
             payload["error"] = error
-        logger.info("", extra={"adt": payload})
+        log_adt(logger, logging.INFO, **payload)

--- a/src/adt/mcp/ranking.py
+++ b/src/adt/mcp/ranking.py
@@ -79,6 +79,11 @@ def _type_tier(path: Path) -> int:
     return _TYPE_TIERS.get(suf, 20)
 
 
+_KEYWORD_MATCH_BONUS = 12.0
+_MAX_TYPE_TIER_BONUS = 25.0
+_FILE_SIZE_BONUS = 15.0
+
+
 def score_candidate_file(path: Path, root: Path, keywords: frozenset[str]) -> float:
     """Score a text file for inclusion in ranked context (higher is better).
 
@@ -99,14 +104,14 @@ def score_candidate_file(path: Path, root: Path, keywords: frozenset[str]) -> fl
     score = 0.0
     for kw in keywords:
         if kw in name_l or kw in rel_s:
-            score += 12.0
+            score += _KEYWORD_MATCH_BONUS
     tier = _type_tier(path)
-    score += max(0.0, 25.0 - float(tier))
+    score += max(0.0, _MAX_TYPE_TIER_BONUS - float(tier))
     try:
         kb = path.stat().st_size / 1024.0
     except OSError:
         kb = 1024.0
-    score += 15.0 / (1.0 + kb)
+    score += _FILE_SIZE_BONUS / (1.0 + kb)
     return score
 
 

--- a/src/adt/tools/__init__.py
+++ b/src/adt/tools/__init__.py
@@ -1,1 +1,8 @@
 """Concrete tool implementations used by agents."""
+
+__all__ = [
+    "compare",
+    "project",
+    "repo",
+    "research",
+]

--- a/src/adt/tools/_paths.py
+++ b/src/adt/tools/_paths.py
@@ -1,0 +1,46 @@
+"""Shared path-safety utilities and constants for tool implementations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+SKIP_DIR_NAMES: frozenset[str] = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        "__pycache__",
+        ".venv",
+        "venv",
+        "node_modules",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".pytest_cache",
+        "dist",
+        "build",
+        ".eggs",
+    },
+)
+
+
+def safe_resolve_under(root: Path, relative: str) -> Path:
+    """Resolve ``relative`` under ``root``; reject path-traversal attempts.
+
+    Args:
+        root: Directory that acts as the sandbox boundary.
+        relative: User- or model-supplied relative path (POSIX-style ok).
+
+    Returns:
+        An absolute, resolved path guaranteed to be inside ``root``.
+
+    Raises:
+        ValueError: If the resolved path would escape ``root``.
+    """
+    base = root.resolve()
+    candidate = (base / relative).resolve()
+    try:
+        candidate.relative_to(base)
+    except ValueError as exc:
+        msg = "path escapes root directory"
+        raise ValueError(msg) from exc
+    return candidate

--- a/src/adt/tools/compare.py
+++ b/src/adt/tools/compare.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 
 from adt.tools import repo as repo_tools
+from adt.tools._paths import SKIP_DIR_NAMES
 
 _KEY_FILES = (
     "pyproject.toml",
@@ -31,7 +32,7 @@ def _collect_paths(root: Path, *, max_entries: int) -> set[str]:
         dirnames[:] = [
             d
             for d in dirnames
-            if d not in repo_tools._ALWAYS_SKIP_DIR_NAMES
+            if d not in SKIP_DIR_NAMES
             and not d.endswith(".egg-info")
         ]
         current = Path(dirpath)

--- a/src/adt/tools/project.py
+++ b/src/adt/tools/project.py
@@ -7,22 +7,12 @@ from pathlib import Path
 
 import httpx
 
+from adt.tools._paths import safe_resolve_under as _safe_resolve_under
+
 _GITHUB_API = "https://api.github.com"
 _DEFAULT_TIMEOUT = 30.0
 _MAX_ISSUES_CAP = 100
 _MAX_MILESTONES_CAP = 50
-
-
-def _safe_resolve_under(root: Path, relative: str) -> Path:
-    """Resolve ``relative`` under ``root``; raise ``ValueError`` on escape attempts."""
-    root = root.resolve()
-    candidate = (root / relative).resolve()
-    try:
-        candidate.relative_to(root)
-    except ValueError as exc:
-        msg = "Path escapes markdown root."
-        raise ValueError(msg) from exc
-    return candidate
 
 
 def _strip_optional_yaml_front_matter(text: str) -> str:

--- a/src/adt/tools/repo.py
+++ b/src/adt/tools/repo.py
@@ -8,23 +8,8 @@ from pathlib import Path
 
 import pathspec
 
-_ALWAYS_SKIP_DIR_NAMES = frozenset(
-    {
-        ".git",
-        ".hg",
-        ".svn",
-        "__pycache__",
-        ".venv",
-        "venv",
-        "node_modules",
-        ".mypy_cache",
-        ".ruff_cache",
-        ".pytest_cache",
-        "dist",
-        "build",
-        ".eggs",
-    },
-)
+from adt.tools._paths import SKIP_DIR_NAMES as _ALWAYS_SKIP_DIR_NAMES
+from adt.tools._paths import safe_resolve_under as _safe_resolve_under
 
 
 def _load_gitignore_spec(repo_root: Path) -> pathspec.PathSpec | None:
@@ -47,29 +32,6 @@ def _load_gitignore_spec(repo_root: Path) -> pathspec.PathSpec | None:
     if not lines:
         return None
     return pathspec.PathSpec.from_lines("gitwildmatch", lines)
-
-
-def _safe_resolve_under(repo_root: Path, relative_path: str) -> Path:
-    """Resolve ``relative_path`` under ``repo_root``; reject path traversal.
-
-    Args:
-        repo_root: Repository root (should be resolved by the caller).
-        relative_path: User- or model-supplied relative path (POSIX-style ok).
-
-    Returns:
-        An absolute, resolved path inside ``repo_root``.
-
-    Raises:
-        ValueError: If the resolved path would escape ``repo_root``.
-    """
-    base = repo_root.resolve()
-    candidate = (base / relative_path).resolve()
-    try:
-        candidate.relative_to(base)
-    except ValueError as exc:
-        msg = "path escapes repository root"
-        raise ValueError(msg) from exc
-    return candidate
 
 
 def _posix_relative_to(repo_root: Path, path: Path) -> str:

--- a/src/adt/tools/research.py
+++ b/src/adt/tools/research.py
@@ -11,6 +11,8 @@ from urllib.parse import urlparse
 
 import httpx
 
+from adt import __version__
+
 _ARXIV_API = "http://export.arxiv.org/api/query"
 _ATOM_NS = "{http://www.w3.org/2005/Atom}"
 _MAX_FETCH_BYTES = 2 * 1024 * 1024
@@ -150,7 +152,7 @@ def search_papers(query: str, max_results: int = 10) -> str:
             follow_redirects=True,
             headers={
                 "User-Agent": (
-                    "agentic-dev-tool/0.4 "
+                    f"agentic-dev-tool/{__version__} "
                     "(+https://github.com/brunoramosmartins/agentic-dev-tool)"
                 ),
             },
@@ -236,7 +238,7 @@ def fetch_article(url: str, max_chars: int = 80000) -> str:
                 follow_redirects=True,
                 headers={
                     "User-Agent": (
-                        "agentic-dev-tool/0.4 "
+                        f"agentic-dev-tool/{__version__} "
                         "(+https://github.com/brunoramosmartins/agentic-dev-tool)"
                     ),
                 },

--- a/tests/unit/test_adt_config.py
+++ b/tests/unit/test_adt_config.py
@@ -70,3 +70,202 @@ def test_env_override_model(monkeypatch) -> None:
     monkeypatch.setenv("ADT_DEFAULT_MODEL", "custom-model")
     cfg = apply_env_overrides(AdtConfig())
     assert cfg.default_model == "custom-model"
+
+
+# ── from_toml_table edge cases ──────────────────────────────────────
+
+def test_from_toml_table_invalid_cache_ttl() -> None:
+    cfg = AdtConfig.from_toml_table({"cache_ttl_seconds": "not-a-number"})
+    assert cfg.cache_ttl_seconds == 300.0
+
+
+def test_from_toml_table_invalid_max_tool_iterations() -> None:
+    cfg = AdtConfig.from_toml_table({"max_tool_iterations": "abc"})
+    assert cfg.max_tool_iterations == 5
+
+
+def test_from_toml_table_token_budget_empty_string() -> None:
+    cfg = AdtConfig.from_toml_table({"token_budget": ""})
+    assert cfg.token_budget is None
+
+
+def test_from_toml_table_token_budget_none() -> None:
+    cfg = AdtConfig.from_toml_table({"token_budget": None})
+    assert cfg.token_budget is None
+
+
+def test_from_toml_table_token_budget_invalid() -> None:
+    cfg = AdtConfig.from_toml_table({"token_budget": "xyz"})
+    assert cfg.token_budget is None
+
+
+def test_from_toml_table_token_budget_valid() -> None:
+    cfg = AdtConfig.from_toml_table({"token_budget": 4096})
+    assert cfg.token_budget == 4096
+
+
+def test_from_toml_table_use_llm_routing_string_true() -> None:
+    cfg = AdtConfig.from_toml_table({"use_llm_routing": "yes"})
+    assert cfg.use_llm_routing is True
+
+
+def test_from_toml_table_use_llm_routing_string_false() -> None:
+    cfg = AdtConfig.from_toml_table({"use_llm_routing": "false"})
+    assert cfg.use_llm_routing is False
+
+
+def test_from_toml_table_use_llm_routing_bool() -> None:
+    cfg = AdtConfig.from_toml_table({"use_llm_routing": False})
+    assert cfg.use_llm_routing is False
+
+
+def test_from_toml_table_agent_chain_none() -> None:
+    cfg = AdtConfig.from_toml_table({"agent_chain": None})
+    assert cfg.agent_chain == []
+
+
+def test_from_toml_table_agent_chain_single_string() -> None:
+    cfg = AdtConfig.from_toml_table({"agent_chain": "repo_agent"})
+    assert cfg.agent_chain == ["repo_agent"]
+
+
+def test_from_toml_table_agent_chain_list() -> None:
+    cfg = AdtConfig.from_toml_table({"agent_chain": ["repo_agent", "research_agent"]})
+    assert cfg.agent_chain == ["repo_agent", "research_agent"]
+
+
+def test_from_toml_table_custom_tools_none() -> None:
+    cfg = AdtConfig.from_toml_table({"custom_tools": None})
+    assert cfg.custom_tools == []
+
+
+def test_from_toml_table_custom_tools_single() -> None:
+    cfg = AdtConfig.from_toml_table({"custom_tools": "my_tool"})
+    assert cfg.custom_tools == ["my_tool"]
+
+
+# ── apply_env_overrides edge cases ──────────────────────────────────
+
+def test_env_override_cache_ttl(monkeypatch) -> None:
+    monkeypatch.setenv("ADT_CACHE_TTL", "600")
+    cfg = apply_env_overrides(AdtConfig())
+    assert cfg.cache_ttl_seconds == 600.0
+
+
+def test_env_override_use_llm_routing_off(monkeypatch) -> None:
+    monkeypatch.setenv("ADT_USE_LLM_ROUTING", "false")
+    cfg = apply_env_overrides(AdtConfig())
+    assert cfg.use_llm_routing is False
+
+
+def test_env_override_use_llm_routing_on(monkeypatch) -> None:
+    monkeypatch.setenv("ADT_USE_LLM_ROUTING", "true")
+    cfg = apply_env_overrides(AdtConfig(use_llm_routing=False))
+    assert cfg.use_llm_routing is True
+
+
+def test_env_override_max_tool_iterations(monkeypatch) -> None:
+    monkeypatch.setenv("ADT_MAX_TOOL_ITERATIONS", "10")
+    cfg = apply_env_overrides(AdtConfig())
+    assert cfg.max_tool_iterations == 10
+
+
+def test_env_override_token_budget(monkeypatch) -> None:
+    monkeypatch.setenv("ADT_TOKEN_BUDGET", "8000")
+    cfg = apply_env_overrides(AdtConfig())
+    assert cfg.token_budget == 8000
+
+
+# ── update_config_key edge cases ────────────────────────────────────
+
+def test_update_config_key_cache_ttl(tmp_path, monkeypatch) -> None:
+    from adt import config as m
+
+    p = tmp_path / "c.toml"
+    monkeypatch.setattr(m, "adt_config_path", lambda: p)
+    cfg = update_config_key(p, "cache_ttl_seconds", "120.5")
+    assert cfg.cache_ttl_seconds == 120.5
+
+
+def test_update_config_key_use_llm_routing(tmp_path, monkeypatch) -> None:
+    from adt import config as m
+
+    p = tmp_path / "c.toml"
+    monkeypatch.setattr(m, "adt_config_path", lambda: p)
+    cfg = update_config_key(p, "use_llm_routing", "false")
+    assert cfg.use_llm_routing is False
+
+
+def test_update_config_key_routing_model(tmp_path, monkeypatch) -> None:
+    from adt import config as m
+
+    p = tmp_path / "c.toml"
+    monkeypatch.setattr(m, "adt_config_path", lambda: p)
+    cfg = update_config_key(p, "routing_model", "gpt-4o")
+    assert cfg.routing_model == "gpt-4o"
+
+
+def test_update_config_key_max_tool_iterations(tmp_path, monkeypatch) -> None:
+    from adt import config as m
+
+    p = tmp_path / "c.toml"
+    monkeypatch.setattr(m, "adt_config_path", lambda: p)
+    cfg = update_config_key(p, "max_tool_iterations", "8")
+    assert cfg.max_tool_iterations == 8
+
+
+def test_update_config_key_token_budget(tmp_path, monkeypatch) -> None:
+    from adt import config as m
+
+    p = tmp_path / "c.toml"
+    monkeypatch.setattr(m, "adt_config_path", lambda: p)
+    cfg = update_config_key(p, "token_budget", "4096")
+    assert cfg.token_budget == 4096
+
+
+def test_update_config_key_token_budget_none(tmp_path, monkeypatch) -> None:
+    from adt import config as m
+
+    p = tmp_path / "c.toml"
+    monkeypatch.setattr(m, "adt_config_path", lambda: p)
+    cfg = update_config_key(p, "token_budget", "none")
+    assert cfg.token_budget is None
+
+
+def test_update_config_key_agent_chain(tmp_path, monkeypatch) -> None:
+    from adt import config as m
+
+    p = tmp_path / "c.toml"
+    monkeypatch.setattr(m, "adt_config_path", lambda: p)
+    cfg = update_config_key(p, "agent_chain", "repo_agent, research_agent")
+    assert cfg.agent_chain == ["repo_agent", "research_agent"]
+
+
+def test_update_config_key_custom_tools(tmp_path, monkeypatch) -> None:
+    from adt import config as m
+
+    p = tmp_path / "c.toml"
+    monkeypatch.setattr(m, "adt_config_path", lambda: p)
+    cfg = update_config_key(p, "custom_tools", "tool_a, tool_b")
+    assert cfg.custom_tools == ["tool_a", "tool_b"]
+
+
+def test_update_config_key_unknown_raises(tmp_path, monkeypatch) -> None:
+    import pytest
+
+    from adt import config as m
+
+    p = tmp_path / "c.toml"
+    monkeypatch.setattr(m, "adt_config_path", lambda: p)
+    with pytest.raises(ValueError, match="Unknown config key"):
+        update_config_key(p, "no_such_key", "val")
+
+
+def test_load_non_dict_section_returns_defaults(tmp_path, monkeypatch) -> None:
+    from adt import config as m
+
+    p = tmp_path / "c.toml"
+    p.write_text('adt = "not a table"\n', encoding="utf-8")
+    monkeypatch.setattr(m, "adt_config_path", lambda: p)
+    cfg = load_config_file()
+    assert cfg.default_model == "gpt-4o-mini"

--- a/tests/unit/test_cli_app.py
+++ b/tests/unit/test_cli_app.py
@@ -162,3 +162,125 @@ def test_cli_ask_rejects_invalid_agent(mock_build, tmp_path) -> None:
         )
     assert result.exit_code == 1
     mock_build.assert_not_called()
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
+@patch("adt.ask_session.build_runner")
+def test_cli_ask_verbose_shows_token_usage(mock_build, tmp_path) -> None:
+    mock_runner = MagicMock()
+    mock_runner.run.return_value = AgentResponse(
+        answer="verbose test",
+        tools_used=["read_repo_tree"],
+        context_summary="ctx summary",
+        routed_agent="repo_agent",
+    )
+    mock_runner.last_token_usage = {"total_tokens": 42}
+    mock_runner.last_budget_report = {"budget": 1000}
+    mock_build.return_value = mock_runner
+    repo = tmp_path / "r"
+    repo.mkdir()
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["ask", "test verbose", "--repo", str(repo), "--verbose"],
+    )
+    assert result.exit_code == 0
+    assert "42" in result.stdout or "token" in result.stdout.lower()
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
+@patch("adt.ask_session.build_runner")
+def test_cli_ask_chain_agent_formatting(mock_build, tmp_path) -> None:
+    mock_runner = MagicMock()
+    mock_runner.run.return_value = AgentResponse(
+        answer="chain result",
+        tools_used=[],
+        context_summary="",
+        routed_agent="chain:repo_agent+research_agent",
+    )
+    mock_build.return_value = mock_runner
+    repo = tmp_path / "r"
+    repo.mkdir()
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["ask", "chain test", "--repo", str(repo)],
+    )
+    assert result.exit_code == 0
+    assert "chain" in result.stdout.lower()
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
+@patch("adt.ask_session.build_runner")
+def test_cli_ask_research_agent_panel(mock_build, tmp_path) -> None:
+    mock_runner = MagicMock()
+    mock_runner.run.return_value = AgentResponse(
+        answer="research answer",
+        tools_used=["search_papers"],
+        context_summary="",
+        routed_agent="research_agent",
+    )
+    mock_build.return_value = mock_runner
+    repo = tmp_path / "r"
+    repo.mkdir()
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["ask", "papers on RAG", "--repo", str(repo)],
+    )
+    assert result.exit_code == 0
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
+@patch("adt.ask_session.build_runner")
+def test_cli_ask_project_agent_panel(mock_build, tmp_path) -> None:
+    mock_runner = MagicMock()
+    mock_runner.run.return_value = AgentResponse(
+        answer="project answer",
+        tools_used=["read_issues"],
+        context_summary="",
+        routed_agent="project_agent",
+    )
+    mock_build.return_value = mock_runner
+    repo = tmp_path / "r"
+    repo.mkdir()
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["ask", "open issues", "--repo", str(repo)],
+    )
+    assert result.exit_code == 0
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
+@patch("adt.cli.app.run_ask")
+def test_cli_ask_configuration_error(mock_run_ask, tmp_path) -> None:
+    from adt.ask_session import AskConfigurationError
+
+    mock_run_ask.side_effect = AskConfigurationError("bad config")
+    repo = tmp_path / "r"
+    repo.mkdir()
+    runner = CliRunner()
+    result = runner.invoke(app, ["ask", "test", "--repo", str(repo)])
+    assert result.exit_code == 1
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
+@patch("adt.cli.app.run_ask")
+def test_cli_ask_unexpected_exception(mock_run_ask, tmp_path) -> None:
+    mock_run_ask.side_effect = RuntimeError("kaboom")
+    repo = tmp_path / "r"
+    repo.mkdir()
+    runner = CliRunner()
+    result = runner.invoke(app, ["ask", "test", "--repo", str(repo)])
+    assert result.exit_code == 1
+
+
+def test_cli_config_set_unknown_key(tmp_path, monkeypatch) -> None:
+    from adt import config as cfgmod
+
+    p = tmp_path / "cfg.toml"
+    monkeypatch.setattr(cfgmod, "adt_config_path", lambda: p)
+    runner = CliRunner()
+    result = runner.invoke(app, ["config", "set", "unknown_key", "val"])
+    assert result.exit_code == 1

--- a/tests/unit/test_compare_repos_tool.py
+++ b/tests/unit/test_compare_repos_tool.py
@@ -39,3 +39,43 @@ def test_compare_repos_unknown_key(tmp_path: Path) -> None:
     roots = {"r0": tmp_path}
     out = compare_repos(roots, "r0", "missing")
     assert "error" in out.lower()
+
+
+def test_compare_repos_identical_keys(tmp_path: Path) -> None:
+    roots = {"r0": tmp_path}
+    out = compare_repos(roots, "r0", "r0")
+    assert "error" in out.lower() or "identical" in out.lower()
+
+
+def test_compare_repos_non_directory(tmp_path: Path) -> None:
+    f = tmp_path / "file.txt"
+    f.write_text("x", encoding="utf-8")
+    roots = {"r0": f, "r1": tmp_path}
+    out = compare_repos(roots, "r0", "r1")
+    assert "error" in out.lower() or "not a directory" in out.lower()
+
+
+def test_compare_repos_requirements_diff(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    (a / "requirements.txt").write_text("flask==2.0\nrequests\n", encoding="utf-8")
+    (b / "requirements.txt").write_text("django==4.0\n", encoding="utf-8")
+    roots = {"r0": a, "r1": b}
+    out = compare_repos(roots, "r0", "r1")
+    assert "requirements" in out.lower() or "dep" in out.lower()
+
+
+def test_compare_repos_with_gitignore(tmp_path: Path) -> None:
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    (a / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    (a / "app.py").write_text("x = 1\n", encoding="utf-8")
+    (a / "debug.log").write_text("log data\n", encoding="utf-8")
+    (b / "app.py").write_text("x = 2\n", encoding="utf-8")
+    roots = {"r0": a, "r1": b}
+    out = compare_repos(roots, "r0", "r1")
+    assert "debug.log" not in out

--- a/tests/unit/test_tokens.py
+++ b/tests/unit/test_tokens.py
@@ -1,0 +1,67 @@
+"""Edge-case tests for mcp/tokens.py covering uncovered branches."""
+
+from __future__ import annotations
+
+from adt.mcp.tokens import (
+    count_tokens,
+    get_encoder_for_model,
+    trim_context,
+    truncate_head_tail,
+)
+
+
+def test_get_encoder_fallback_unknown_model() -> None:
+    enc = get_encoder_for_model("totally-fake-model-xyz")
+    assert enc.name == "cl100k_base"
+
+
+def test_get_encoder_known_model() -> None:
+    enc = get_encoder_for_model("gpt-4o-mini")
+    assert enc is not None
+
+
+def test_trim_context_zero_tokens() -> None:
+    enc = get_encoder_for_model("gpt-4o-mini")
+    assert trim_context("hello world", 0, enc) == ""
+
+
+def test_trim_context_negative_tokens() -> None:
+    enc = get_encoder_for_model("gpt-4o-mini")
+    assert trim_context("hello world", -5, enc) == ""
+
+
+def test_trim_context_actually_trims() -> None:
+    enc = get_encoder_for_model("gpt-4o-mini")
+    long_text = "word " * 500
+    result = trim_context(long_text, 10, enc)
+    assert "[trimmed]" in result
+    assert count_tokens(result, enc) < count_tokens(long_text, enc)
+
+
+def test_trim_context_short_text_unchanged() -> None:
+    enc = get_encoder_for_model("gpt-4o-mini")
+    result = trim_context("hi", 100, enc)
+    assert result == "hi"
+
+
+def test_truncate_head_tail_zero_tokens() -> None:
+    enc = get_encoder_for_model("gpt-4o-mini")
+    assert truncate_head_tail("hello world", 0, enc) == ""
+
+
+def test_truncate_head_tail_actually_truncates() -> None:
+    enc = get_encoder_for_model("gpt-4o-mini")
+    long_text = "word " * 500
+    result = truncate_head_tail(long_text, 10, enc)
+    assert "..." in result
+
+
+def test_truncate_head_tail_short_text_unchanged() -> None:
+    enc = get_encoder_for_model("gpt-4o-mini")
+    result = truncate_head_tail("hi", 100, enc)
+    assert result == "hi"
+
+
+def test_count_tokens_empty() -> None:
+    enc = get_encoder_for_model("gpt-4o-mini")
+    assert count_tokens("", enc) == 0

--- a/tests/unit/test_tools_repo.py
+++ b/tests/unit/test_tools_repo.py
@@ -36,3 +36,59 @@ def test_safe_resolve_rejects_traversal(sample_repo_path: str) -> None:
     root = Path(sample_repo_path)
     out = repo_tools.read_file(root, "../../etc/passwd", max_lines=5)
     assert "error" in out.lower()
+
+
+def test_read_repo_tree_missing_dir(tmp_path: Path) -> None:
+    out = repo_tools.read_repo_tree(tmp_path, path="no_such_dir", max_depth=3)
+    assert "error" in out.lower() or "not" in out.lower()
+
+
+def test_read_file_not_a_file(tmp_path: Path) -> None:
+    sub = tmp_path / "subdir"
+    sub.mkdir()
+    out = repo_tools.read_file(tmp_path, "subdir", max_lines=10)
+    assert "error" in out.lower() or "not a file" in out.lower()
+
+
+def test_read_file_missing(tmp_path: Path) -> None:
+    out = repo_tools.read_file(tmp_path, "ghost.py", max_lines=10)
+    assert "error" in out.lower() or "not" in out.lower()
+
+
+def test_search_code_invalid_regex(sample_repo_path: str) -> None:
+    root = Path(sample_repo_path)
+    out = repo_tools.search_code(root, ".", r"[invalid", max_results=5)
+    assert "error" in out.lower()
+
+
+def test_search_code_missing_dir(tmp_path: Path) -> None:
+    out = repo_tools.search_code(tmp_path, "no_dir", r"foo", max_results=5)
+    assert "error" in out.lower() or "not" in out.lower()
+
+
+def test_read_repo_tree_traversal_rejected(tmp_path: Path) -> None:
+    out = repo_tools.read_repo_tree(tmp_path, path="../../etc", max_depth=2)
+    assert "error" in out.lower()
+
+
+def test_search_code_traversal_rejected(tmp_path: Path) -> None:
+    out = repo_tools.search_code(tmp_path, "../../etc", r"x", max_results=5)
+    assert "error" in out.lower()
+
+
+def test_read_repo_tree_with_gitignore(tmp_path: Path) -> None:
+    (tmp_path / ".gitignore").write_text("ignored_dir/\n", encoding="utf-8")
+    (tmp_path / "kept.py").write_text("x = 1\n", encoding="utf-8")
+    ig = tmp_path / "ignored_dir"
+    ig.mkdir()
+    (ig / "hidden.py").write_text("y = 2\n", encoding="utf-8")
+    out = repo_tools.read_repo_tree(tmp_path, path=".", max_depth=3)
+    assert "kept.py" in out
+    assert "hidden.py" not in out
+
+
+def test_search_code_binary_skip(tmp_path: Path) -> None:
+    (tmp_path / "data.bin").write_bytes(b"\x00\x01\x02\x03binary")
+    (tmp_path / "text.py").write_text("# match_me\n", encoding="utf-8")
+    out = repo_tools.search_code(tmp_path, ".", r"match_me", max_results=10)
+    assert "text.py" in out


### PR DESCRIPTION
## Description

Portfolio polish pass over the codebase: eliminates duplication, fixes inconsistencies,
improves test coverage, and standardizes internal patterns. No new features or behavior changes.

## Changes

- **DRY:** Extract `_safe_resolve_under()` and `SKIP_DIR_NAMES` into shared `tools/_paths.py`
- **Bug fix:** User-Agent header now uses `__version__` instead of hardcoded `"0.4"`
- **Readability:** Named magic numbers in `mcp/ranking.py` (`_KEYWORD_MATCH_BONUS`, etc.)
- **Logging:** Migrated 3 modules from raw `extra={"adt": ...}` to `log_adt()` helper
- **Exports:** Added `__all__` to `agents/`, `mcp/`, `tools/` subpackage `__init__.py`
- **Tests:** +59 new unit tests covering config edge cases, CLI error paths, tool error handling, and token utilities
- **Coverage:** 79.6% → 85.3% (branch-aware)
- **Docs:** Added `CLAUDE.md` with setup instructions and architecture summary

## Testing

- [x] 181 unit tests passing (was 122)
- [x] Coverage 85.3% (was 79.6%)
- [x] `ruff check` — All checks passed
- [x] `mypy --strict` — no issues found (38 files)
- [x] No behavior changes, all existing tests unmodified

## Checklist

- [x] Code follows project conventions
- [x] No hardcoded secrets or API keys
- [x] Lint and type checks pass (`make lint typecheck`)
