### PR TITLE
feat(mode): add supervised learning mode with step guidance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
-# Build, publish to PyPI, and create a GitHub Release when a version tag is pushed.
+# Create a GitHub Release when a version tag is pushed.
 #
-# Setup (maintainers):
-# 1. PyPI: add a "pending" trusted publisher for this repo workflow, or set the
-#    PYPI_API_TOKEN repository secret for pypa/gh-action-pypi-publish.
-# 2. GitHub: ensure Actions can create releases (default write for GITHUB_TOKEN).
+# PyPI publishing is disabled until a trusted publisher is configured.
+# To re-enable, uncomment the "Publish to PyPI" step and configure
+# OIDC trusted publishing on pypi.org or set the PYPI_API_TOKEN secret.
 
 name: Release
 
@@ -14,10 +13,9 @@ on:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -33,11 +31,10 @@ jobs:
       - name: Build sdist and wheel
         run: python -m build
 
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          # Empty secret → OIDC trusted publishing; or set PYPI_API_TOKEN.
-          password: ${{ secrets.PYPI_API_TOKEN }}
+      # - name: Publish to PyPI
+      #   uses: pypa/gh-action-pypi-publish@release/v1
+      #   with:
+      #     password: ${{ secrets.PYPI_API_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/src/adt/ask_session.py
+++ b/src/adt/ask_session.py
@@ -11,7 +11,7 @@ from adt.bootstrap import build_runner
 from adt.config import apply_env_overrides, load_config_file
 from adt.core.runner import Runner
 from adt.logging.json_log import setup_adt_file_logging
-from adt.models.schemas import AgentResponse, QueryRequest
+from adt.models.schemas import AgentResponse, QueryRequest, SupervisedResponse
 from adt.repo_spec import resolve_repo_targets
 from adt.tracing.context import TraceContext
 
@@ -29,6 +29,7 @@ class AskExecution:
     response: AgentResponse
     runner: Runner
     trace_context: TraceContext | None = None
+    supervised_response: SupervisedResponse | None = None
 
 
 def run_ask(
@@ -43,6 +44,8 @@ def run_ask(
     model: str | None = None,
     configure_logging: bool = True,
     trace: bool = False,
+    mode: str = "execution",
+    level: str = "intermediate",
 ) -> AskExecution:
     """Resolve repos, build a :class:`~adt.core.runner.Runner`, and run the query.
 
@@ -130,6 +133,20 @@ def run_ask(
         github_repo=resolved.github_repo,
         force_agent=force_agent,
         options=opts,
+        mode=mode,  # type: ignore[arg-type]
+        level=level,  # type: ignore[arg-type]
     )
     response = runner.run(request)
-    return AskExecution(response=response, runner=runner, trace_context=trace_ctx)
+
+    supervised_resp: SupervisedResponse | None = None
+    if mode == "supervised":
+        from adt.core.supervised_supervisor import parse_supervised_response
+
+        supervised_resp = parse_supervised_response(response.answer)
+
+    return AskExecution(
+        response=response,
+        runner=runner,
+        trace_context=trace_ctx,
+        supervised_response=supervised_resp,
+    )

--- a/src/adt/cli/app.py
+++ b/src/adt/cli/app.py
@@ -190,8 +190,39 @@ def ask_cmd(
             help="Show request trace: routing, context, LLM calls, cost estimate.",
         ),
     ] = False,
+    mode: Annotated[
+        str,
+        typer.Option(
+            "--mode",
+            help=(
+                "Operational mode: 'execution' (default) solves tasks; "
+                "'supervised' guides step-by-step for learning."
+            ),
+        ),
+    ] = "execution",
+    level: Annotated[
+        str,
+        typer.Option(
+            "--level",
+            help="Difficulty for supervised mode: beginner, intermediate, advanced.",
+        ),
+    ] = "intermediate",
 ) -> None:
     """Ask a question: supervisor picks an agent unless ``--agent`` is set."""
+    valid_modes = {"execution", "supervised"}
+    if mode not in valid_modes:
+        console.print(
+            f"[red]Invalid --mode {mode!r}.[/red] "
+            f"Choose one of: {', '.join(sorted(valid_modes))}.",
+        )
+        raise typer.Exit(code=1)
+    valid_levels = {"beginner", "intermediate", "advanced"}
+    if level not in valid_levels:
+        console.print(
+            f"[red]Invalid --level {level!r}.[/red] "
+            f"Choose one of: {', '.join(sorted(valid_levels))}.",
+        )
+        raise typer.Exit(code=1)
     if agent is not None and agent not in _VALID_AGENTS:
         console.print(
             "[red]Invalid --agent.[/red] "
@@ -211,6 +242,8 @@ def ask_cmd(
             model=model,
             configure_logging=True,
             trace=trace,
+            mode=mode,
+            level=level,
         )
     except AskConfigurationError as exc:
         console.print(f"[red]{exc}[/red]")
@@ -226,7 +259,13 @@ def ask_cmd(
     runner = exe.runner
     routed = response.routed_agent or agent or "supervisor"
     console.print(f"[dim]Agent:[/dim] [bold]{routed}[/bold]")
-    _format_ask_panel(response.routed_agent or agent or "", response.answer)
+
+    if exe.supervised_response is not None:
+        from adt.cli.supervised_renderer import SupervisedRenderer
+
+        SupervisedRenderer(console).render(exe.supervised_response)
+    else:
+        _format_ask_panel(response.routed_agent or agent or "", response.answer)
     tools_line = ", ".join(response.tools_used) if response.tools_used else "none"
     console.print(f"[dim]Tools used:[/dim] {tools_line}")
     if exe.trace_context is not None:

--- a/src/adt/cli/supervised_renderer.py
+++ b/src/adt/cli/supervised_renderer.py
@@ -1,0 +1,67 @@
+"""Rich-based terminal renderer for supervised mode responses."""
+
+from __future__ import annotations
+
+from rich.console import Console, Group
+from rich.panel import Panel
+from rich.text import Text
+
+from adt.models.schemas import SupervisedResponse
+
+
+class SupervisedRenderer:
+    """Render a :class:`SupervisedResponse` as a teaching panel."""
+
+    def __init__(self, console: Console | None = None) -> None:
+        self._console = console or Console()
+
+    def render(self, response: SupervisedResponse) -> None:
+        """Print the current step with goal, requirements, hints, questions."""
+        step = response.current_step
+
+        header = Text()
+        header.append("Problem: ", style="bold")
+        header.append(response.problem_summary)
+        header.append("\n\n")
+        header.append(
+            f"Step {step.step_number} of {response.total_steps}: ",
+            style="bold cyan",
+        )
+        header.append(step.goal)
+
+        sections: list[Text] = [header]
+
+        if step.requirements:
+            sections.append(self._section("Requirements", step.requirements))
+        if step.hints:
+            sections.append(self._section("Hints", step.hints))
+        if step.questions:
+            sections.append(self._section("Questions for you", step.questions))
+
+        if response.progress_note:
+            note = Text()
+            note.append("\n")
+            note.append("Next: ", style="bold dim")
+            note.append(response.progress_note, style="dim")
+            sections.append(note)
+
+        self._console.print(
+            Panel(
+                Group(*sections),
+                title="Supervised Mode",
+                border_style="cyan",
+                title_align="left",
+            ),
+        )
+
+    @staticmethod
+    def _section(title: str, items: list[str]) -> Text:
+        text = Text()
+        text.append("\n")
+        text.append(f"{title}:", style="bold")
+        text.append("\n")
+        for item in items:
+            text.append("  - ", style="cyan")
+            text.append(item)
+            text.append("\n")
+        return text

--- a/src/adt/core/mode_router.py
+++ b/src/adt/core/mode_router.py
@@ -1,0 +1,19 @@
+"""Routes requests by operational mode (execution vs supervised)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from adt.models.schemas import QueryRequest
+
+if TYPE_CHECKING:
+    pass
+
+
+class ModeRouter:
+    """Determine which supervisor path to use based on ``request.mode``."""
+
+    @staticmethod
+    def is_supervised(request: QueryRequest) -> bool:
+        """Return True when the request should follow the supervised path."""
+        return request.mode == "supervised"

--- a/src/adt/core/runner.py
+++ b/src/adt/core/runner.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
 from adt.agents.base import BaseAgent
+from adt.core.mode_router import ModeRouter
+from adt.core.supervised_supervisor import build_supervised_system_prompt
 from adt.logging.json_log import log_adt
 from adt.mcp.budget import allocate_budget
 from adt.mcp.context import ContextBuilder
@@ -83,6 +85,10 @@ class Runner:
     def run(self, request: QueryRequest) -> AgentResponse:
         """Route the query, build context, run the LLM/tool loop, return an answer."""
         use_cache = not bool(request.options.get("no_cache", False))
+
+        if ModeRouter.is_supervised(request):
+            return self._run_supervised(request, use_cache=use_cache)
+
         if self._agent_chain and request.force_agent is None:
             return self._run_agent_chain(request, use_cache=use_cache)
 
@@ -102,6 +108,98 @@ class Runner:
         else:
             routed = self._supervisor.route(request)
         return self._execute_routed(routed, use_cache=use_cache)
+
+    def _run_supervised(
+        self,
+        request: QueryRequest,
+        *,
+        use_cache: bool,
+    ) -> AgentResponse:
+        """Run supervised mode: single LLM call with teaching prompt, no tools."""
+        t0 = time.perf_counter()
+        sys_prompt = build_supervised_system_prompt(request.level)
+
+        # Build minimal context if a repo is available
+        paths = request.effective_repo_paths()
+        if paths:
+            raw_context = self._context.build_from_repo(
+                paths[0], query=request.query, use_cache=use_cache
+            )
+        else:
+            raw_context = ""
+
+        user_content = f"{raw_context}\n\nUser question:\n{request.query.strip()}\n"
+        messages: list[LLMMessage] = [
+            LLMMessage(role="system", content=sys_prompt),
+            LLMMessage(role="user", content=user_content),
+        ]
+
+        if self._trace is not None:
+            self._trace.emit(
+                "runner",
+                "supervised_start",
+                level=request.level,
+            )
+
+        log_adt(
+            logger,
+            logging.INFO,
+            event="supervised_mode",
+            supervised_level=request.level,
+            query_preview=request.query[:500],
+        )
+
+        try:
+            reply = self._llm.chat(messages, None)
+        except Exception as exc:  # noqa: BLE001
+            log_adt(
+                logger,
+                logging.ERROR,
+                event="llm_failure",
+                error=str(exc),
+                error_type=type(exc).__name__,
+                agent="supervised",
+            )
+            return AgentResponse(
+                answer=(
+                    f"LLM request failed ({type(exc).__name__}: {exc}). "
+                    "Check OPENAI_API_KEY, network, and quota."
+                ),
+                tools_used=[],
+                context_summary="",
+                routed_agent="supervised",
+            )
+
+        usage = self.last_token_usage
+        if self._trace is not None:
+            self._trace.emit("runner", "llm_call", iteration=0, **usage)
+            self._trace.add_token_usage(
+                prompt_tokens=usage.get("prompt_tokens", 0),
+                completion_tokens=usage.get("completion_tokens", 0),
+            )
+
+        elapsed_ms = round((time.perf_counter() - t0) * 1000, 2)
+        log_adt(
+            logger,
+            logging.INFO,
+            event="supervised_completed",
+            duration_ms=elapsed_ms,
+            **usage,
+        )
+        if self._trace is not None:
+            self._trace.emit(
+                "runner",
+                "request_completed",
+                agent="supervised",
+                total_elapsed_ms=elapsed_ms,
+            )
+
+        return AgentResponse(
+            answer=reply.content.strip(),
+            tools_used=[],
+            context_summary="",
+            routed_agent="supervised",
+        )
 
     def _run_agent_chain(
         self,

--- a/src/adt/core/supervised_supervisor.py
+++ b/src/adt/core/supervised_supervisor.py
@@ -1,0 +1,113 @@
+"""Supervised-mode supervisor: guides users step-by-step instead of solving."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from adt.logging.json_log import log_adt
+from adt.models.schemas import (
+    SupervisedResponse,
+    SupervisedStep,
+)
+
+logger = logging.getLogger(__name__)
+
+_SUPERVISED_SYSTEM_PROMPT = """You are a technical mentor guiding a software engineer \
+through problem decomposition and incremental implementation.
+
+## Communication rules
+- Always reply in the same language the user used in their question.
+- Be technical, precise, and direct. No filler.
+
+## Core behavior
+- Decompose the problem into small, implementable steps (3-7 steps typical).
+- Present ONLY the current step. Do not reveal future steps in detail.
+- Do NOT provide the full solution. Guide the user to implement it themselves.
+- Each step must have a clear goal, concrete requirements, optional hints, and
+  reflective questions.
+- Adapt depth based on the configured difficulty level:
+  - beginner: more hints, smaller steps, explicit type annotations guidance
+  - intermediate: balanced hints, standard step granularity
+  - advanced: minimal hints, larger steps, focus on design trade-offs
+
+## Anti-patterns to avoid
+- Do NOT say "looks good!" or give generic praise.
+- Do NOT skip steps or jump to the final answer.
+- Do NOT assume the user knows implementation details without evidence.
+- Do NOT provide code blocks with the full solution.
+
+## Output format
+You MUST respond with a single JSON object (no markdown, no extra text):
+{{
+  "problem_summary": "concise restatement of the problem",
+  "current_step": {{
+    "step_number": 1,
+    "goal": "what to achieve",
+    "requirements": ["concrete deliverable 1", "concrete deliverable 2"],
+    "hints": ["nudge without revealing solution"],
+    "questions": ["reflective question to deepen understanding"]
+  }},
+  "total_steps": 4,
+  "progress_note": "brief note on what follows this step"
+}}
+
+The user's difficulty level is: {level}
+"""
+
+
+def build_supervised_system_prompt(level: str) -> str:
+    """Return the system prompt with the difficulty level interpolated."""
+    return _SUPERVISED_SYSTEM_PROMPT.format(level=level)
+
+
+def parse_supervised_response(raw_answer: str) -> SupervisedResponse | None:
+    """Try to parse structured JSON from the LLM answer into SupervisedResponse.
+
+    Returns None if parsing fails (caller falls back to raw text display).
+    """
+    text = raw_answer.strip()
+    # Strip markdown fences if present
+    if text.startswith("```"):
+        lines = text.splitlines()
+        lines = [line for line in lines if not line.strip().startswith("```")]
+        text = "\n".join(lines).strip()
+
+    try:
+        data: dict[str, Any] = json.loads(text)
+    except json.JSONDecodeError:
+        log_adt(
+            logger,
+            logging.WARNING,
+            event="supervised_parse_failure",
+            raw_length=len(raw_answer),
+        )
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    try:
+        step_data = data.get("current_step", {})
+        step = SupervisedStep(
+            step_number=step_data.get("step_number", 1),
+            goal=step_data.get("goal", ""),
+            requirements=step_data.get("requirements", []),
+            hints=step_data.get("hints", []),
+            questions=step_data.get("questions", []),
+        )
+        return SupervisedResponse(
+            problem_summary=data.get("problem_summary", ""),
+            current_step=step,
+            total_steps=data.get("total_steps", 1),
+            progress_note=data.get("progress_note", ""),
+        )
+    except Exception:  # noqa: BLE001
+        log_adt(
+            logger,
+            logging.WARNING,
+            event="supervised_validation_failure",
+            raw_length=len(raw_answer),
+        )
+        return None

--- a/src/adt/models/schemas.py
+++ b/src/adt/models/schemas.py
@@ -9,12 +9,24 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 Role = Literal["system", "user", "assistant", "tool"]
 
 
+Mode = Literal["execution", "supervised"]
+Level = Literal["beginner", "intermediate", "advanced"]
+
+
 class QueryRequest(BaseModel):
     """User query and optional repository context for a single agent run."""
 
     model_config = ConfigDict(extra="forbid")
 
     query: str = Field(..., description="Natural language question or instruction.")
+    mode: Mode = Field(
+        default="execution",
+        description="Operational mode: execution (default) or supervised (guided).",
+    )
+    level: Level = Field(
+        default="intermediate",
+        description="Difficulty level for supervised mode guidance.",
+    )
     repo_path: str | None = Field(
         default=None,
         description=(
@@ -168,4 +180,43 @@ class RoutedRequest(BaseModel):
     request: QueryRequest = Field(
         ...,
         description="Original or enriched request (options may hold routing metadata).",
+    )
+
+
+class SupervisedStep(BaseModel):
+    """A single guided step in the supervised learning flow."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    step_number: int = Field(..., description="1-based index of this step.")
+    goal: str = Field(..., description="What the user should achieve in this step.")
+    requirements: list[str] = Field(
+        default_factory=list,
+        description="Concrete deliverables or acceptance criteria.",
+    )
+    hints: list[str] = Field(
+        default_factory=list,
+        description="Optional nudges without revealing the solution.",
+    )
+    questions: list[str] = Field(
+        default_factory=list,
+        description="Reflective questions to deepen understanding.",
+    )
+
+
+class SupervisedResponse(BaseModel):
+    """Structured response from supervised mode with the current guided step."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    problem_summary: str = Field(
+        ..., description="Concise restatement of the problem to solve."
+    )
+    current_step: SupervisedStep = Field(
+        ..., description="The step the user should work on now."
+    )
+    total_steps: int = Field(..., description="Total number of planned steps.", ge=1)
+    progress_note: str = Field(
+        default="",
+        description="Brief, specific note on what comes next (not generic praise).",
     )

--- a/tests/integration/test_supervised_flow.py
+++ b/tests/integration/test_supervised_flow.py
@@ -1,0 +1,121 @@
+"""Integration test for supervised mode end-to-end through Runner."""
+
+from __future__ import annotations
+
+from adt.agents.project_agent import ProjectAgent
+from adt.agents.repo_agent import RepoAgent
+from adt.agents.research_agent import ResearchAgent
+from adt.core.runner import Runner
+from adt.core.supervised_supervisor import parse_supervised_response
+from adt.core.supervisor import Supervisor
+from adt.mcp.context import ContextBuilder
+from adt.mcp.executor import ExecutionController
+from adt.models.schemas import LLMMessage, QueryRequest
+from adt.tracing.context import TraceContext
+from tests.fake_llm import FakeLLM
+
+_SAMPLE_JSON = """{
+    "problem_summary": "Implement binary search",
+    "current_step": {
+        "step_number": 1,
+        "goal": "Define the function signature",
+        "requirements": ["accept sorted list", "return index or -1"],
+        "hints": ["think about parameter types"],
+        "questions": ["why does the list need to be sorted?"]
+    },
+    "total_steps": 4,
+    "progress_note": "next: implement the base case"
+}"""
+
+
+def test_supervised_mode_bypasses_tool_loop(
+    tool_registry,
+    sample_repo_path: str,
+) -> None:
+    """Supervised mode calls LLM once, no tool execution, returns structured JSON."""
+    replies = [LLMMessage(role="assistant", content=_SAMPLE_JSON)]
+    fake = FakeLLM(replies)
+    supervisor = Supervisor()
+    context = ContextBuilder()
+    executor = ExecutionController(tool_registry)
+    agents = {
+        "repo_agent": RepoAgent(),
+        "project_agent": ProjectAgent(),
+        "research_agent": ResearchAgent(),
+    }
+    runner = Runner(supervisor, fake, context, executor, tool_registry, agents)
+
+    req = QueryRequest(
+        query="Teach me binary search",
+        repo_path=sample_repo_path,
+        mode="supervised",
+        level="beginner",
+    )
+    res = runner.run(req)
+
+    assert res.routed_agent == "supervised"
+    assert res.tools_used == []
+
+    parsed = parse_supervised_response(res.answer)
+    assert parsed is not None
+    assert parsed.problem_summary == "Implement binary search"
+    assert parsed.current_step.step_number == 1
+    assert parsed.total_steps == 4
+
+
+def test_supervised_mode_with_tracing(
+    tool_registry,
+    sample_repo_path: str,
+) -> None:
+    """Supervised mode emits trace events (supervised_start, llm_call, completed)."""
+    trace = TraceContext()
+    replies = [LLMMessage(role="assistant", content=_SAMPLE_JSON)]
+    fake = FakeLLM(replies)
+    supervisor = Supervisor(trace=trace)
+    context = ContextBuilder(trace=trace)
+    executor = ExecutionController(tool_registry)
+    agents = {
+        "repo_agent": RepoAgent(),
+        "project_agent": ProjectAgent(),
+        "research_agent": ResearchAgent(),
+    }
+    runner = Runner(
+        supervisor, fake, context, executor, tool_registry, agents, trace=trace
+    )
+
+    req = QueryRequest(
+        query="Teach me binary search",
+        repo_path=sample_repo_path,
+        mode="supervised",
+    )
+    runner.run(req)
+
+    event_types = [e.event_type for e in trace.events]
+    assert "supervised_start" in event_types
+    assert "llm_call" in event_types
+    assert "request_completed" in event_types
+    # No tool events since supervised mode does not call tools
+    assert "tool_call" not in event_types
+
+
+def test_execution_mode_still_works(
+    tool_registry,
+    sample_repo_path: str,
+) -> None:
+    """Execution mode (default) still uses the agent routing + tool loop."""
+    replies = [LLMMessage(role="assistant", content="direct answer")]
+    fake = FakeLLM(replies)
+    supervisor = Supervisor()
+    context = ContextBuilder()
+    executor = ExecutionController(tool_registry)
+    agents = {
+        "repo_agent": RepoAgent(),
+        "project_agent": ProjectAgent(),
+        "research_agent": ResearchAgent(),
+    }
+    runner = Runner(supervisor, fake, context, executor, tool_registry, agents)
+
+    req = QueryRequest(query="explain this", repo_path=sample_repo_path)
+    res = runner.run(req)
+    assert res.routed_agent == "repo_agent"
+    assert res.answer == "direct answer"

--- a/tests/unit/test_mode_router.py
+++ b/tests/unit/test_mode_router.py
@@ -1,0 +1,21 @@
+"""Unit tests for ModeRouter."""
+
+from __future__ import annotations
+
+from adt.core.mode_router import ModeRouter
+from adt.models.schemas import QueryRequest
+
+
+def test_execution_mode_is_not_supervised() -> None:
+    req = QueryRequest(query="x", mode="execution")
+    assert ModeRouter.is_supervised(req) is False
+
+
+def test_supervised_mode_detected() -> None:
+    req = QueryRequest(query="x", mode="supervised")
+    assert ModeRouter.is_supervised(req) is True
+
+
+def test_default_mode_is_execution() -> None:
+    req = QueryRequest(query="x")
+    assert ModeRouter.is_supervised(req) is False

--- a/tests/unit/test_supervised_renderer.py
+++ b/tests/unit/test_supervised_renderer.py
@@ -1,0 +1,65 @@
+"""Unit tests for SupervisedRenderer."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from rich.console import Console
+
+from adt.cli.supervised_renderer import SupervisedRenderer
+from adt.models.schemas import SupervisedResponse, SupervisedStep
+
+
+def _make_console() -> Console:
+    return Console(file=StringIO(), force_terminal=True, width=120)
+
+
+def _sample_response() -> SupervisedResponse:
+    return SupervisedResponse(
+        problem_summary="Implement binary search",
+        current_step=SupervisedStep(
+            step_number=1,
+            goal="Define the function signature",
+            requirements=["Accept sorted list", "Return index or -1"],
+            hints=["Consider type annotations"],
+            questions=["Why must the list be sorted?"],
+        ),
+        total_steps=4,
+        progress_note="Next: handle the base case",
+    )
+
+
+def test_renderer_shows_problem_and_step() -> None:
+    con = _make_console()
+    SupervisedRenderer(con).render(_sample_response())
+    out = con.file.getvalue()  # type: ignore[union-attr]
+    assert "Implement binary search" in out
+    assert "Step 1 of 4" in out
+    assert "Define the function signature" in out
+
+
+def test_renderer_shows_all_sections() -> None:
+    con = _make_console()
+    SupervisedRenderer(con).render(_sample_response())
+    out = con.file.getvalue()  # type: ignore[union-attr]
+    assert "Requirements" in out
+    assert "Accept sorted list" in out
+    assert "Hints" in out
+    assert "Consider type annotations" in out
+    assert "Questions for you" in out
+    assert "Why must the list be sorted?" in out
+    assert "Next" in out
+
+
+def test_renderer_skips_empty_sections() -> None:
+    con = _make_console()
+    resp = SupervisedResponse(
+        problem_summary="X",
+        current_step=SupervisedStep(step_number=1, goal="Y"),
+        total_steps=1,
+    )
+    SupervisedRenderer(con).render(resp)
+    out = con.file.getvalue()  # type: ignore[union-attr]
+    assert "Requirements" not in out
+    assert "Hints" not in out
+    assert "Questions" not in out

--- a/tests/unit/test_supervised_schemas.py
+++ b/tests/unit/test_supervised_schemas.py
@@ -1,0 +1,68 @@
+"""Unit tests for supervised mode schemas."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from adt.models.schemas import QueryRequest, SupervisedResponse, SupervisedStep
+
+
+def test_query_request_defaults_to_execution_mode() -> None:
+    req = QueryRequest(query="hello")
+    assert req.mode == "execution"
+    assert req.level == "intermediate"
+
+
+def test_query_request_supervised_mode() -> None:
+    req = QueryRequest(query="teach me", mode="supervised", level="beginner")
+    assert req.mode == "supervised"
+    assert req.level == "beginner"
+
+
+def test_query_request_invalid_mode_rejected() -> None:
+    with pytest.raises(ValidationError):
+        QueryRequest(query="x", mode="autopilot")  # type: ignore[arg-type]
+
+
+def test_query_request_invalid_level_rejected() -> None:
+    with pytest.raises(ValidationError):
+        QueryRequest(query="x", level="expert")  # type: ignore[arg-type]
+
+
+def test_supervised_step_minimal() -> None:
+    step = SupervisedStep(step_number=1, goal="define signature")
+    assert step.step_number == 1
+    assert step.goal == "define signature"
+    assert step.requirements == []
+    assert step.hints == []
+    assert step.questions == []
+
+
+def test_supervised_response_full() -> None:
+    step = SupervisedStep(
+        step_number=2,
+        goal="implement base case",
+        requirements=["handle empty list"],
+        hints=["think about the termination condition"],
+        questions=["what if the list has one element?"],
+    )
+    resp = SupervisedResponse(
+        problem_summary="Binary search",
+        current_step=step,
+        total_steps=4,
+        progress_note="next we add the loop",
+    )
+    assert resp.total_steps == 4
+    assert resp.current_step.step_number == 2
+    assert resp.current_step.hints == ["think about the termination condition"]
+
+
+def test_supervised_response_requires_total_steps_at_least_one() -> None:
+    step = SupervisedStep(step_number=1, goal="x")
+    with pytest.raises(ValidationError):
+        SupervisedResponse(
+            problem_summary="x",
+            current_step=step,
+            total_steps=0,
+        )

--- a/tests/unit/test_supervised_supervisor.py
+++ b/tests/unit/test_supervised_supervisor.py
@@ -1,0 +1,80 @@
+"""Unit tests for SupervisedSupervisor parsing and prompt building."""
+
+from __future__ import annotations
+
+from adt.core.supervised_supervisor import (
+    build_supervised_system_prompt,
+    parse_supervised_response,
+)
+
+
+def test_build_prompt_includes_level() -> None:
+    prompt = build_supervised_system_prompt("beginner")
+    assert "beginner" in prompt
+    assert "JSON" in prompt
+    assert "problem_summary" in prompt
+
+
+def test_parse_valid_json() -> None:
+    raw = """{
+        "problem_summary": "Implement binary search",
+        "current_step": {
+            "step_number": 1,
+            "goal": "Define the function signature",
+            "requirements": ["accept sorted list", "return index or -1"],
+            "hints": ["think about parameter types"],
+            "questions": ["why sorted?"]
+        },
+        "total_steps": 4,
+        "progress_note": "next: base case"
+    }"""
+    result = parse_supervised_response(raw)
+    assert result is not None
+    assert result.problem_summary == "Implement binary search"
+    assert result.current_step.step_number == 1
+    assert result.current_step.requirements == [
+        "accept sorted list",
+        "return index or -1",
+    ]
+    assert result.total_steps == 4
+
+
+def test_parse_json_with_markdown_fences() -> None:
+    raw = """```json
+{
+  "problem_summary": "X",
+  "current_step": {
+    "step_number": 1,
+    "goal": "Y",
+    "requirements": [],
+    "hints": [],
+    "questions": []
+  },
+  "total_steps": 2,
+  "progress_note": ""
+}
+```"""
+    result = parse_supervised_response(raw)
+    assert result is not None
+    assert result.problem_summary == "X"
+    assert result.total_steps == 2
+
+
+def test_parse_invalid_json_returns_none() -> None:
+    assert parse_supervised_response("not json at all") is None
+
+
+def test_parse_non_dict_json_returns_none() -> None:
+    assert parse_supervised_response("[1, 2, 3]") is None
+
+
+def test_parse_missing_fields_uses_defaults() -> None:
+    raw = (
+        '{"problem_summary": "X", '
+        '"current_step": {"step_number": 1, "goal": "Y"}, '
+        '"total_steps": 1}'
+    )
+    result = parse_supervised_response(raw)
+    assert result is not None
+    assert result.current_step.requirements == []
+    assert result.progress_note == ""


### PR DESCRIPTION
## Description

Phase 9.1 — Supervised Mode MVP. Adds a new `supervised` mode to
`adt ask` that guides the user through a problem step-by-step
instead of producing a direct answer. The LLM is instructed to act
as a technical mentor, decompose the problem into 3–7 steps, and
return a single structured JSON object describing the *current*
step only (goal, requirements, hints, reflective questions).

The mode is selected via `--mode supervised` and depth is tuned via
`--level {beginner,intermediate,advanced}`. Execution mode remains
the default and is unchanged.

## Related Issues

Closes #P9-01..P9-07 (Phase 9.1 scope)

## Changes

- `src/adt/models/schemas.py` — add `Mode` / `Level` literals,
  `mode` and `level` fields on `QueryRequest`, and new
  `SupervisedStep` / `SupervisedResponse` models.
- `src/adt/core/mode_router.py` — new helper that decides whether a
  request should take the supervised path.
- `src/adt/core/supervised_supervisor.py` — teaching system prompt
  with level interpolation and a tolerant JSON parser
  (`parse_supervised_response`) that strips markdown fences and
  falls back to `None` on failure.
- `src/adt/core/runner.py` — new `_run_supervised()` path: single
  LLM call, no tool loop, emits `supervised_start`, `llm_call`, and
  `request_completed` trace events.
- `src/adt/cli/supervised_renderer.py` — Rich panel renderer for
  the guided step (goal, requirements, hints, questions, next note).
- `src/adt/cli/app.py` — add `--mode` and `--level` flags with
  validation; dispatch to `SupervisedRenderer` when a parsed
  supervised response is available.
- `src/adt/ask_session.py` — thread `mode` / `level` through
  `run_ask()` and expose `supervised_response` on `AskExecution`.
- `.github/workflows/release.yml` — disable the PyPI publish step
  (kept as a commented block for future reactivation). Tag-driven
  GitHub Releases still work.

## Testing

- [x] Unit tests added/updated
  - `tests/unit/test_supervised_schemas.py` (7)
  - `tests/unit/test_supervised_supervisor.py` (6)
  - `tests/unit/test_mode_router.py` (3)
  - `tests/unit/test_supervised_renderer.py` (3)
- [x] Integration tests pass
  - `tests/integration/test_supervised_flow.py` (3): supervised
    mode bypasses the tool loop, emits the expected trace events,
    and execution mode remains unaffected.
- [x] Manual testing done
  - `adt ask "me ensine binary search em python" --mode supervised --level beginner`
    returns a single guided step rendered in the Supervised Mode
    panel.
  - `adt ask "explique este repo" --repo .` still routes to
    `repo_agent` unchanged.
- Full suite: **226 tests passing**, `ruff check` clean,
  `ruff format --check` clean, `mypy` clean (46 source files).

## Checklist

- [x] Code follows project conventions
- [x] Docstrings added to new public functions
- [x] No hardcoded secrets or API keys
- [x] Lint and type checks pass (`make lint typecheck`)