### PR TITLE
feat(review): add supervised code review and feedback loop

### DIFF
--- a/src/adt/ask_session.py
+++ b/src/adt/ask_session.py
@@ -10,6 +10,7 @@ from typing import Any
 from adt.bootstrap import build_runner
 from adt.config import apply_env_overrides, load_config_file
 from adt.core.runner import Runner
+from adt.core.session import SessionContext
 from adt.logging.json_log import setup_adt_file_logging
 from adt.models.schemas import AgentResponse, QueryRequest, SupervisedResponse
 from adt.repo_spec import resolve_repo_targets
@@ -143,6 +144,10 @@ def run_ask(
         from adt.core.supervised_supervisor import parse_supervised_response
 
         supervised_resp = parse_supervised_response(response.answer)
+        if supervised_resp is not None:
+            sess = SessionContext.load()
+            sess.update_from_supervised(supervised_resp)
+            sess.save()
 
     return AskExecution(
         response=response,

--- a/src/adt/cli/app.py
+++ b/src/adt/cli/app.py
@@ -17,6 +17,7 @@ from adt.config import (
     load_config_file,
     update_config_key,
 )
+from adt.review_session import ReviewConfigurationError, run_review
 
 app = typer.Typer(help="Agentic Dev Tool CLI", add_completion=False)
 config_app = typer.Typer(help="View or edit ~/.adt/config.toml", add_completion=False)
@@ -280,6 +281,88 @@ def ask_cmd(
         br = getattr(runner, "last_budget_report", None)
         if br:
             console.print(f"[dim]Token budget (estimated):[/dim] {br}")
+
+
+@app.command("review")
+def review_cmd(
+    file: Annotated[
+        str,
+        typer.Argument(help="Path to the source file to review."),
+    ],
+    context: Annotated[
+        str | None,
+        typer.Option(
+            "--context",
+            "-c",
+            help="Optional description of what the code should do.",
+        ),
+    ] = None,
+    level: Annotated[
+        str,
+        typer.Option(
+            "--level",
+            help="Difficulty level for the reviewer: beginner, intermediate, advanced.",
+        ),
+    ] = "intermediate",
+    model: Annotated[
+        str | None,
+        typer.Option(
+            "--model",
+            "-m",
+            help="OpenAI chat model (default: config default_model).",
+        ),
+    ] = None,
+    verbose: Annotated[
+        bool,
+        typer.Option("--verbose", "-v", help="Print debug logs."),
+    ] = False,
+) -> None:
+    """Review a source file in supervised mode and print structured feedback."""
+    valid_levels = {"beginner", "intermediate", "advanced"}
+    if level not in valid_levels:
+        console.print(
+            f"[red]Invalid --level {level!r}.[/red] "
+            f"Choose one of: {', '.join(sorted(valid_levels))}.",
+        )
+        raise typer.Exit(code=1)
+
+    try:
+        result = run_review(
+            file=file,
+            extra_context=context,
+            level=level,
+            model=model,
+            verbose=verbose,
+        )
+    except ReviewConfigurationError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    except Exception as exc:  # noqa: BLE001 — last-resort CLI guard
+        console.print(
+            "[red]Unexpected error while running the reviewer.[/red] "
+            f"({type(exc).__name__}: {exc})",
+        )
+        raise typer.Exit(code=1) from exc
+
+    if result.feedback is None:
+        console.print(
+            Panel(
+                result.raw_answer or "(empty response)",
+                title="Code Review (raw)",
+                border_style="red",
+                title_align="left",
+            ),
+        )
+        raise typer.Exit(code=1)
+
+    from adt.cli.review_renderer import ReviewRenderer
+
+    ReviewRenderer(console).render(result.feedback)
+    if result.session.problem_summary:
+        console.print(
+            f"[dim]Session:[/dim] step {result.session.current_step}/"
+            f"{result.session.total_steps} — {result.session.problem_summary}",
+        )
 
 
 @app.command("serve")

--- a/src/adt/cli/review_renderer.py
+++ b/src/adt/cli/review_renderer.py
@@ -1,0 +1,97 @@
+"""Rich-based terminal renderer for supervised code review feedback."""
+
+from __future__ import annotations
+
+from rich.console import Console, Group
+from rich.panel import Panel
+from rich.text import Text
+
+from adt.models.schemas import CodeIssue, ReviewFeedback
+
+_ASSESSMENT_LABEL = {
+    "needs_work": ("Needs Work", "red"),
+    "on_track": ("On Track", "yellow"),
+    "excellent": ("Excellent", "green"),
+}
+
+_SEVERITY_GLYPH = {
+    "error": ("x", "red"),
+    "warning": ("!", "yellow"),
+    "suggestion": ("i", "blue"),
+}
+
+
+class ReviewRenderer:
+    """Render a :class:`ReviewFeedback` as a structured terminal panel."""
+
+    def __init__(self, console: Console | None = None) -> None:
+        self._console = console or Console()
+
+    def render(self, feedback: ReviewFeedback) -> None:
+        """Print the review with assessment, issues, strengths, and next step."""
+        sections: list[Text] = [self._assessment_header(feedback.overall_assessment)]
+
+        if feedback.issues:
+            sections.append(self._issues_section(feedback.issues))
+        if feedback.strengths:
+            sections.append(self._bullet_section("Strengths", feedback.strengths))
+        if feedback.improvements:
+            sections.append(self._bullet_section("Improvements", feedback.improvements))
+        if feedback.next_step:
+            note = Text()
+            note.append("\n")
+            note.append("Next Step:\n", style="bold")
+            note.append("  ")
+            note.append(feedback.next_step)
+            sections.append(note)
+
+        border = _ASSESSMENT_LABEL.get(feedback.overall_assessment, ("", "cyan"))[1]
+        self._console.print(
+            Panel(
+                Group(*sections),
+                title="Code Review",
+                border_style=border,
+                title_align="left",
+            ),
+        )
+
+    # ---------- sections ----------
+
+    @staticmethod
+    def _assessment_header(assessment: str) -> Text:
+        label, color = _ASSESSMENT_LABEL.get(assessment, (assessment, "white"))
+        text = Text()
+        text.append("Assessment: ", style="bold")
+        text.append(label, style=f"bold {color}")
+        return text
+
+    @staticmethod
+    def _issues_section(issues: list[CodeIssue]) -> Text:
+        text = Text()
+        text.append("\n")
+        text.append("Issues:\n", style="bold")
+        for issue in issues:
+            glyph, color = _SEVERITY_GLYPH.get(issue.severity, ("-", "white"))
+            text.append("  ")
+            text.append(glyph, style=color)
+            text.append(" ")
+            if issue.line is not None:
+                text.append(f"Line {issue.line}: ", style="bold")
+            text.append(issue.description)
+            text.append("\n")
+            if issue.fix_hint:
+                text.append("      Hint: ", style="dim")
+                text.append(issue.fix_hint, style="dim")
+                text.append("\n")
+        return text
+
+    @staticmethod
+    def _bullet_section(title: str, items: list[str]) -> Text:
+        text = Text()
+        text.append("\n")
+        text.append(f"{title}:\n", style="bold")
+        for item in items:
+            text.append("  - ", style="cyan")
+            text.append(item)
+            text.append("\n")
+        return text

--- a/src/adt/core/session.py
+++ b/src/adt/core/session.py
@@ -1,0 +1,173 @@
+"""Lightweight supervised-mode session state persisted between CLI runs.
+
+The CLI process is short-lived, but users expect follow-up ``adt ask`` and
+``adt review`` commands to build on the previous step. We persist a minimal
+snapshot under ``~/.adt/session.json`` so the next invocation can reload it.
+Only the most recent session is kept.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from adt.config import ensure_adt_dir
+from adt.logging.json_log import log_adt
+from adt.models.schemas import SupervisedResponse
+
+logger = logging.getLogger(__name__)
+
+
+def session_file_path() -> Path:
+    """Return the path to ``~/.adt/session.json``."""
+    return ensure_adt_dir() / "session.json"
+
+
+@dataclass
+class SessionContext:
+    """Tracks state within a supervised learning session.
+
+    Attributes:
+        problem_summary: Concise problem statement from the first supervised
+            turn. Used to detect when the user switched to a new problem.
+        current_step: 1-based index of the step the user is currently on.
+        total_steps: Total number of planned steps.
+        previous_feedback: Short summaries of past review assessments in order.
+        iteration_count: Number of commands executed against this session.
+    """
+
+    problem_summary: str = ""
+    current_step: int = 0
+    total_steps: int = 0
+    previous_feedback: list[str] = field(default_factory=list)
+    iteration_count: int = 0
+
+    # ---------- predicates ----------
+
+    def is_empty(self) -> bool:
+        """Return True if no supervised session has been started yet."""
+        return not self.problem_summary and self.current_step == 0
+
+    def matches_problem(self, other_summary: str) -> bool:
+        """Return True when ``other_summary`` describes the same problem.
+
+        Uses a coarse containment check so small wording differences do not
+        reset the session unnecessarily.
+        """
+        if not self.problem_summary or not other_summary:
+            return False
+        a = self.problem_summary.strip().lower()
+        b = other_summary.strip().lower()
+        if not a or not b:
+            return False
+        return a == b or a in b or b in a
+
+    # ---------- mutations ----------
+
+    def update_from_supervised(self, response: SupervisedResponse) -> None:
+        """Refresh the session from a parsed :class:`SupervisedResponse`.
+
+        Resets feedback history if the problem summary changed so the new
+        session starts clean.
+        """
+        if not self.matches_problem(response.problem_summary):
+            self.previous_feedback = []
+        self.problem_summary = response.problem_summary
+        self.current_step = response.current_step.step_number
+        self.total_steps = response.total_steps
+        self.iteration_count += 1
+
+    def record_feedback(self, assessment: str) -> None:
+        """Append a short review outcome to the feedback history."""
+        summary = assessment.strip()
+        if not summary:
+            return
+        self.previous_feedback.append(summary)
+        # keep the history small
+        if len(self.previous_feedback) > 10:
+            self.previous_feedback = self.previous_feedback[-10:]
+        self.iteration_count += 1
+
+    def clear(self) -> None:
+        """Reset all state to the initial empty session."""
+        self.problem_summary = ""
+        self.current_step = 0
+        self.total_steps = 0
+        self.previous_feedback = []
+        self.iteration_count = 0
+
+    # ---------- rendering ----------
+
+    def as_step_context(self) -> str:
+        """Return a compact string describing the current step for review prompts."""
+        if self.is_empty():
+            return ""
+        lines = [
+            f"Problem: {self.problem_summary}",
+            f"Step {self.current_step} of {self.total_steps}",
+        ]
+        if self.previous_feedback:
+            recent = self.previous_feedback[-1]
+            lines.append(f"Previous feedback: {recent}")
+        return "\n".join(lines)
+
+    # ---------- persistence ----------
+
+    def save(self, path: Path | None = None) -> None:
+        """Write the session to disk as JSON (best-effort)."""
+        target = path or session_file_path()
+        try:
+            target.write_text(
+                json.dumps(asdict(self), indent=2),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            log_adt(
+                logger,
+                logging.WARNING,
+                event="session_save_failed",
+                error=str(exc),
+            )
+
+    @classmethod
+    def load(cls, path: Path | None = None) -> SessionContext:
+        """Load a session from disk, returning an empty one on any failure."""
+        target = path or session_file_path()
+        if not target.exists():
+            return cls()
+        try:
+            data = json.loads(target.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            log_adt(
+                logger,
+                logging.WARNING,
+                event="session_load_failed",
+                error=str(exc),
+            )
+            return cls()
+        if not isinstance(data, dict):
+            return cls()
+        return cls(
+            problem_summary=str(data.get("problem_summary", "")),
+            current_step=int(data.get("current_step", 0) or 0),
+            total_steps=int(data.get("total_steps", 0) or 0),
+            previous_feedback=[str(x) for x in (data.get("previous_feedback") or [])],
+            iteration_count=int(data.get("iteration_count", 0) or 0),
+        )
+
+    @classmethod
+    def reset(cls, path: Path | None = None) -> None:
+        """Delete any persisted session file (no-op if missing)."""
+        target = path or session_file_path()
+        if target.exists():
+            try:
+                target.unlink()
+            except OSError as exc:
+                log_adt(
+                    logger,
+                    logging.WARNING,
+                    event="session_reset_failed",
+                    error=str(exc),
+                )

--- a/src/adt/core/supervised_supervisor.py
+++ b/src/adt/core/supervised_supervisor.py
@@ -8,6 +8,8 @@ from typing import Any
 
 from adt.logging.json_log import log_adt
 from adt.models.schemas import (
+    CodeIssue,
+    ReviewFeedback,
     SupervisedResponse,
     SupervisedStep,
 )
@@ -108,6 +110,151 @@ def parse_supervised_response(raw_answer: str) -> SupervisedResponse | None:
             logger,
             logging.WARNING,
             event="supervised_validation_failure",
+            raw_length=len(raw_answer),
+        )
+        return None
+
+
+_REVIEW_SYSTEM_PROMPT = """You are a senior engineer performing a technical code \
+review for a software engineer who is learning.
+
+## Communication rules
+- Always reply in the same language the user used in their question or context.
+- Be technical, precise, and specific. Reference concrete lines and identifiers.
+- No filler, no generic praise, no motivational closings.
+
+## Review behavior
+- Read the submitted code carefully. Assume it is a work-in-progress solution.
+- Identify real issues only. Do NOT invent problems to fill space.
+- Classify each issue by severity:
+  - error: blocks correctness (bugs, crashes, wrong output)
+  - warning: risky or likely to break under edge cases
+  - suggestion: readability, naming, idiomatic improvements
+- Cite the 1-based line number when the issue is localized; omit it for
+  file-wide observations.
+- For each issue, provide a fix_hint that guides without revealing the full
+  solution (ask a question or point at the concept).
+- Strengths must be specific. "Good code" is not acceptable.
+- next_step must be actionable: what the user should do right now.
+- overall_assessment:
+  - needs_work: at least one error-severity issue
+  - on_track: no errors, but warnings or several suggestions remain
+  - excellent: no issues worth fixing; ready to advance
+
+## Anti-patterns
+- Do NOT rewrite the whole function for the user.
+- Do NOT provide the full corrected code.
+- Do NOT give generic advice ("add tests", "use types") without tying it to
+  a concrete line or pattern in the submission.
+
+## Output format
+You MUST respond with a single JSON object (no markdown, no extra text):
+{{
+  "issues": [
+    {{
+      "line": 12,
+      "severity": "warning",
+      "description": "Variable name `x` does not convey intent.",
+      "fix_hint": "What does this value represent in the problem domain?"
+    }}
+  ],
+  "improvements": ["non-blocking improvement tied to a specific location"],
+  "strengths": ["specific thing the submission got right"],
+  "next_step": "concrete action to take now",
+  "overall_assessment": "on_track"
+}}
+
+The user's difficulty level is: {level}
+"""
+
+
+def build_review_system_prompt(level: str) -> str:
+    """Return the code review system prompt with the difficulty level interpolated."""
+    return _REVIEW_SYSTEM_PROMPT.format(level=level)
+
+
+def build_review_user_prompt(
+    *,
+    file_path: str,
+    code: str,
+    extra_context: str | None = None,
+    step_context: str | None = None,
+) -> str:
+    """Assemble the reviewer user message from code and optional session context.
+
+    Args:
+        file_path: Display path of the file being reviewed.
+        code: Full file contents to review.
+        extra_context: Optional description of what the code should do.
+        step_context: Optional reminder of the current supervised step the
+            user is working on (from session state).
+    """
+    parts: list[str] = []
+    if step_context:
+        parts.append(f"Current supervised step:\n{step_context.strip()}")
+    if extra_context:
+        parts.append(f"User-provided context:\n{extra_context.strip()}")
+    parts.append(f"File: {file_path}")
+    parts.append("```\n" + code.rstrip() + "\n```")
+    parts.append(
+        "Review the code above and return the JSON object described in the "
+        "system prompt. Do not include any text outside the JSON."
+    )
+    return "\n\n".join(parts)
+
+
+def parse_review_feedback(raw_answer: str) -> ReviewFeedback | None:
+    """Parse a structured JSON review into :class:`ReviewFeedback`.
+
+    Returns ``None`` if parsing or validation fails; callers should fall back
+    to displaying the raw text.
+    """
+    text = raw_answer.strip()
+    if text.startswith("```"):
+        lines = text.splitlines()
+        lines = [line for line in lines if not line.strip().startswith("```")]
+        text = "\n".join(lines).strip()
+
+    try:
+        data: Any = json.loads(text)
+    except json.JSONDecodeError:
+        log_adt(
+            logger,
+            logging.WARNING,
+            event="review_parse_failure",
+            raw_length=len(raw_answer),
+        )
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    try:
+        raw_issues = data.get("issues") or []
+        issues: list[CodeIssue] = []
+        for item in raw_issues:
+            if not isinstance(item, dict):
+                continue
+            issues.append(
+                CodeIssue(
+                    line=item.get("line"),
+                    severity=item.get("severity", "suggestion"),
+                    description=item.get("description", ""),
+                    fix_hint=item.get("fix_hint", ""),
+                )
+            )
+        return ReviewFeedback(
+            issues=issues,
+            improvements=list(data.get("improvements") or []),
+            strengths=list(data.get("strengths") or []),
+            next_step=data.get("next_step", ""),
+            overall_assessment=data.get("overall_assessment", "on_track"),
+        )
+    except Exception:  # noqa: BLE001
+        log_adt(
+            logger,
+            logging.WARNING,
+            event="review_validation_failure",
             raw_length=len(raw_answer),
         )
         return None

--- a/src/adt/models/schemas.py
+++ b/src/adt/models/schemas.py
@@ -11,6 +11,8 @@ Role = Literal["system", "user", "assistant", "tool"]
 
 Mode = Literal["execution", "supervised"]
 Level = Literal["beginner", "intermediate", "advanced"]
+Severity = Literal["error", "warning", "suggestion"]
+Assessment = Literal["needs_work", "on_track", "excellent"]
 
 
 class QueryRequest(BaseModel):
@@ -219,4 +221,51 @@ class SupervisedResponse(BaseModel):
     progress_note: str = Field(
         default="",
         description="Brief, specific note on what comes next (not generic praise).",
+    )
+
+
+class CodeIssue(BaseModel):
+    """A specific issue found in the user's code during supervised review."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    line: int | None = Field(
+        default=None,
+        description="1-based line number where the issue is; None if file-wide.",
+    )
+    severity: Severity = Field(
+        ...,
+        description="error (blocks correctness), warning (risky), suggestion (polish).",
+    )
+    description: str = Field(..., description="What is wrong, in concrete terms.")
+    fix_hint: str = Field(
+        default="",
+        description="Nudge toward the fix without revealing the full solution.",
+    )
+
+
+class ReviewFeedback(BaseModel):
+    """Structured feedback from a supervised code review."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    issues: list[CodeIssue] = Field(
+        default_factory=list,
+        description="Specific issues found in the submitted code.",
+    )
+    improvements: list[str] = Field(
+        default_factory=list,
+        description="Non-blocking improvements the user could apply next.",
+    )
+    strengths: list[str] = Field(
+        default_factory=list,
+        description="What the user did well (specific, not generic praise).",
+    )
+    next_step: str = Field(
+        default="",
+        description="Concrete action the user should take after addressing feedback.",
+    )
+    overall_assessment: Assessment = Field(
+        ...,
+        description="High-level verdict: needs_work, on_track, or excellent.",
     )

--- a/src/adt/review_session.py
+++ b/src/adt/review_session.py
@@ -1,0 +1,172 @@
+"""Shared logic for running one ``review`` turn (CLI and tests).
+
+A review submits a code file to the supervised reviewer LLM and returns a
+parsed :class:`ReviewFeedback`. The previous supervised session (if any) is
+loaded so the reviewer can reference the current step the user is on.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from adt.config import apply_env_overrides, load_config_file
+from adt.core.llm import LLMClient
+from adt.core.runner import LLMBackend
+from adt.core.session import SessionContext
+from adt.core.supervised_supervisor import (
+    build_review_system_prompt,
+    build_review_user_prompt,
+    parse_review_feedback,
+)
+from adt.logging.json_log import log_adt, setup_adt_file_logging
+from adt.models.schemas import LLMMessage, ReviewFeedback
+
+logger = logging.getLogger(__name__)
+
+_MAX_FILE_BYTES = 200_000
+
+
+class ReviewConfigurationError(ValueError):
+    """Raised when the environment or arguments prevent a review run."""
+
+
+@dataclass(frozen=True)
+class ReviewExecution:
+    """Outcome of a review run: parsed feedback + raw answer + session snapshot."""
+
+    feedback: ReviewFeedback | None
+    raw_answer: str
+    session: SessionContext
+
+
+def run_review(
+    *,
+    file: str | Path,
+    extra_context: str | None = None,
+    level: str = "intermediate",
+    model: str | None = None,
+    verbose: bool = False,
+    log_level: str | None = None,
+    configure_logging: bool = True,
+    llm: LLMBackend | None = None,
+    session: SessionContext | None = None,
+) -> ReviewExecution:
+    """Read ``file``, send it to the reviewer LLM, return parsed feedback.
+
+    Args:
+        file: Path to the source file to review.
+        extra_context: Optional description of what the code should do.
+        level: Difficulty level for the reviewer prompt.
+        model: OpenAI chat model override; otherwise from config.
+        verbose: When True and ``configure_logging`` is True, raise log to DEBUG.
+        log_level: File log level name.
+        configure_logging: When True, set up the JSON file logger.
+        llm: Inject an LLM client (used by tests). When None, build a real
+            :class:`LLMClient` from environment + config.
+        session: Inject a session context. When None, load from disk.
+
+    Raises:
+        ReviewConfigurationError: When the file is missing, unreadable, too
+            large, or when the API key is required but absent.
+    """
+    path = Path(file).expanduser()
+    if not path.exists() or not path.is_file():
+        msg = f"File not found: {path}"
+        raise ReviewConfigurationError(msg)
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        raise ReviewConfigurationError(f"Cannot stat {path}: {exc}") from exc
+    if size > _MAX_FILE_BYTES:
+        msg = (
+            f"File {path.name} is {size} bytes; review limit is "
+            f"{_MAX_FILE_BYTES} bytes."
+        )
+        raise ReviewConfigurationError(msg)
+    try:
+        code = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ReviewConfigurationError(f"Cannot read {path}: {exc}") from exc
+
+    cfg = apply_env_overrides(load_config_file())
+    eff_model = model if model is not None else cfg.default_model
+    eff_log = (log_level or cfg.log_level).upper()
+
+    if configure_logging:
+        lvl = getattr(logging, eff_log, logging.INFO)
+        if verbose:
+            lvl = logging.DEBUG
+        setup_adt_file_logging(level=lvl)
+        logging.getLogger("adt").setLevel(lvl)
+
+    sess = session if session is not None else SessionContext.load()
+
+    if llm is None:
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            msg = (
+                "Missing OPENAI_API_KEY. Set it in the environment or in a "
+                "`.env` file."
+            )
+            raise ReviewConfigurationError(msg)
+        llm = LLMClient(model=eff_model, api_key=api_key)
+
+    system_prompt = build_review_system_prompt(level)
+    user_prompt = build_review_user_prompt(
+        file_path=str(path),
+        code=code,
+        extra_context=extra_context,
+        step_context=sess.as_step_context() or None,
+    )
+    messages: list[LLMMessage] = [
+        LLMMessage(role="system", content=system_prompt),
+        LLMMessage(role="user", content=user_prompt),
+    ]
+
+    log_adt(
+        logger,
+        logging.INFO,
+        event="review_started",
+        file=str(path),
+        size_bytes=size,
+        supervised_level=level,
+    )
+
+    try:
+        reply = llm.chat(messages, None)
+    except Exception as exc:  # noqa: BLE001
+        log_adt(
+            logger,
+            logging.ERROR,
+            event="review_llm_failure",
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
+        return ReviewExecution(
+            feedback=None,
+            raw_answer=(
+                f"Reviewer LLM request failed ({type(exc).__name__}: {exc}). "
+                "Check OPENAI_API_KEY, network, and quota."
+            ),
+            session=sess,
+        )
+
+    raw_answer = reply.content or ""
+    feedback = parse_review_feedback(raw_answer)
+    if feedback is not None:
+        sess.record_feedback(feedback.overall_assessment)
+        sess.save()
+
+    log_adt(
+        logger,
+        logging.INFO,
+        event="review_completed",
+        parsed=feedback is not None,
+        assessment=feedback.overall_assessment if feedback else None,
+        issue_count=len(feedback.issues) if feedback else 0,
+    )
+
+    return ReviewExecution(feedback=feedback, raw_answer=raw_answer, session=sess)

--- a/tests/integration/test_review_flow.py
+++ b/tests/integration/test_review_flow.py
@@ -1,0 +1,86 @@
+"""Integration test for the review flow through ``run_review`` with a fake LLM."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adt.core.session import SessionContext
+from adt.models.schemas import LLMMessage, SupervisedResponse, SupervisedStep
+from adt.review_session import run_review
+from tests.fake_llm import FakeLLM
+
+_REVIEW_JSON = """{
+    "issues": [
+        {"line": 2, "severity": "error",
+         "description": "Off-by-one in upper bound",
+         "fix_hint": "Should `high` be inclusive?"}
+    ],
+    "improvements": ["Add a docstring with examples"],
+    "strengths": ["Clear function signature"],
+    "next_step": "Fix the boundary check and rerun the test.",
+    "overall_assessment": "needs_work"
+}"""
+
+
+def test_run_review_parses_feedback_and_updates_session(tmp_path: Path) -> None:
+    target = tmp_path / "solution.py"
+    target.write_text("def search(xs):\n    return -1\n", encoding="utf-8")
+
+    sess_file = tmp_path / "session.json"
+    sess = SessionContext()
+    sess.update_from_supervised(
+        SupervisedResponse(
+            problem_summary="Implement binary search",
+            current_step=SupervisedStep(step_number=2, goal="add base case"),
+            total_steps=4,
+        ),
+    )
+    sess.save(sess_file)
+
+    fake = FakeLLM([LLMMessage(role="assistant", content=_REVIEW_JSON)])
+    loaded = SessionContext.load(sess_file)
+    result = run_review(
+        file=target,
+        extra_context="should return the index of `target` in xs",
+        level="beginner",
+        configure_logging=False,
+        llm=fake,
+        session=loaded,
+    )
+
+    assert result.feedback is not None
+    assert result.feedback.overall_assessment == "needs_work"
+    assert result.feedback.issues[0].line == 2
+    # Session was updated with the review outcome
+    assert "needs_work" in result.session.previous_feedback
+
+
+def test_run_review_returns_raw_when_llm_returns_garbage(tmp_path: Path) -> None:
+    target = tmp_path / "x.py"
+    target.write_text("a = 1\n", encoding="utf-8")
+    fake = FakeLLM([LLMMessage(role="assistant", content="not json at all")])
+    result = run_review(
+        file=target,
+        configure_logging=False,
+        llm=fake,
+        session=SessionContext(),
+    )
+    assert result.feedback is None
+    assert "not json" in result.raw_answer
+
+
+def test_run_review_missing_file_raises(tmp_path: Path) -> None:
+    from adt.review_session import ReviewConfigurationError
+
+    missing = tmp_path / "nope.py"
+    try:
+        run_review(
+            file=missing,
+            configure_logging=False,
+            llm=FakeLLM([]),
+            session=SessionContext(),
+        )
+    except ReviewConfigurationError as exc:
+        assert "not found" in str(exc).lower()
+    else:
+        raise AssertionError("expected ReviewConfigurationError")

--- a/tests/unit/test_cli_review.py
+++ b/tests/unit/test_cli_review.py
@@ -1,0 +1,103 @@
+"""Smoke tests for the ``adt review`` Typer command."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from adt.cli.app import app
+from adt.core.session import SessionContext
+from adt.models.schemas import CodeIssue, ReviewFeedback
+from adt.review_session import ReviewExecution
+
+
+def _ok_execution() -> ReviewExecution:
+    return ReviewExecution(
+        feedback=ReviewFeedback(
+            issues=[
+                CodeIssue(
+                    line=3,
+                    severity="warning",
+                    description="Variable `x` is not descriptive.",
+                    fix_hint="What does it represent?",
+                ),
+            ],
+            improvements=["Add a docstring."],
+            strengths=["Function signature is clear."],
+            next_step="Rename `x` and rerun the test.",
+            overall_assessment="on_track",
+        ),
+        raw_answer="{...}",
+        session=SessionContext(
+            problem_summary="Binary search",
+            current_step=2,
+            total_steps=4,
+        ),
+    )
+
+
+def test_review_rejects_invalid_level(tmp_path) -> None:
+    target = tmp_path / "x.py"
+    target.write_text("a = 1\n", encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(app, ["review", str(target), "--level", "expert"])
+    assert result.exit_code == 1
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
+@patch("adt.cli.app.run_review")
+def test_review_renders_feedback(mock_run, tmp_path) -> None:
+    mock_run.return_value = _ok_execution()
+    target = tmp_path / "solution.py"
+    target.write_text("def f(): return 1\n", encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(app, ["review", str(target)])
+    assert result.exit_code == 0
+    assert "On Track" in result.stdout
+    assert "Variable `x` is not descriptive" in result.stdout
+    assert "Rename `x`" in result.stdout
+    # Session footer
+    assert "step 2/4" in result.stdout
+    assert "Binary search" in result.stdout
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
+@patch("adt.cli.app.run_review")
+def test_review_unparsed_feedback_exits_nonzero(mock_run, tmp_path) -> None:
+    mock_run.return_value = ReviewExecution(
+        feedback=None,
+        raw_answer="not json",
+        session=SessionContext(),
+    )
+    target = tmp_path / "x.py"
+    target.write_text("a = 1\n", encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(app, ["review", str(target)])
+    assert result.exit_code == 1
+    assert "raw" in result.stdout.lower()
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
+@patch("adt.cli.app.run_review")
+def test_review_configuration_error(mock_run, tmp_path) -> None:
+    from adt.review_session import ReviewConfigurationError
+
+    mock_run.side_effect = ReviewConfigurationError("missing file")
+    target = tmp_path / "x.py"
+    target.write_text("a = 1\n", encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(app, ["review", str(target)])
+    assert result.exit_code == 1
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
+@patch("adt.cli.app.run_review")
+def test_review_unexpected_exception(mock_run, tmp_path) -> None:
+    mock_run.side_effect = RuntimeError("kaboom")
+    target = tmp_path / "x.py"
+    target.write_text("a = 1\n", encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(app, ["review", str(target)])
+    assert result.exit_code == 1

--- a/tests/unit/test_review_renderer.py
+++ b/tests/unit/test_review_renderer.py
@@ -1,0 +1,89 @@
+"""Unit tests for the ReviewRenderer."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from rich.console import Console
+
+from adt.cli.review_renderer import ReviewRenderer
+from adt.models.schemas import CodeIssue, ReviewFeedback
+
+
+def _make_console() -> Console:
+    return Console(file=StringIO(), force_terminal=True, width=120)
+
+
+def _sample_feedback() -> ReviewFeedback:
+    return ReviewFeedback(
+        issues=[
+            CodeIssue(
+                line=12,
+                severity="warning",
+                description="Variable `x` is not descriptive",
+                fix_hint="What does this value represent?",
+            ),
+            CodeIssue(
+                line=18,
+                severity="error",
+                description="Off-by-one in boundary check",
+                fix_hint="Should `high` be inclusive?",
+            ),
+        ],
+        improvements=["Add edge case handling for empty list"],
+        strengths=["Correct function signature and types"],
+        next_step="Fix the boundary check, then implement the recursive case.",
+        overall_assessment="needs_work",
+    )
+
+
+def test_renderer_shows_assessment_and_issues() -> None:
+    con = _make_console()
+    ReviewRenderer(con).render(_sample_feedback())
+    out = con.file.getvalue()  # type: ignore[union-attr]
+    assert "Assessment" in out
+    assert "Needs Work" in out
+    assert "Line 12" in out
+    assert "Variable `x` is not descriptive" in out
+    assert "What does this value represent?" in out
+    assert "Line 18" in out
+    assert "Off-by-one" in out
+
+
+def test_renderer_shows_strengths_improvements_next_step() -> None:
+    con = _make_console()
+    ReviewRenderer(con).render(_sample_feedback())
+    out = con.file.getvalue()  # type: ignore[union-attr]
+    assert "Strengths" in out
+    assert "Correct function signature and types" in out
+    assert "Improvements" in out
+    assert "Add edge case handling for empty list" in out
+    assert "Next Step" in out
+    assert "boundary check" in out
+
+
+def test_renderer_skips_empty_sections() -> None:
+    con = _make_console()
+    fb = ReviewFeedback(overall_assessment="excellent")
+    ReviewRenderer(con).render(fb)
+    out = con.file.getvalue()  # type: ignore[union-attr]
+    assert "Excellent" in out
+    assert "Issues" not in out
+    assert "Strengths" not in out
+    assert "Improvements" not in out
+    assert "Next Step" not in out
+
+
+def test_renderer_handles_issue_without_line() -> None:
+    con = _make_console()
+    fb = ReviewFeedback(
+        issues=[
+            CodeIssue(severity="suggestion", description="missing module docstring"),
+        ],
+        overall_assessment="on_track",
+    )
+    ReviewRenderer(con).render(fb)
+    out = con.file.getvalue()  # type: ignore[union-attr]
+    assert "missing module docstring" in out
+    assert "On Track" in out
+    assert "Line " not in out

--- a/tests/unit/test_review_schemas.py
+++ b/tests/unit/test_review_schemas.py
@@ -1,0 +1,53 @@
+"""Unit tests for the review feedback schemas."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from adt.models.schemas import CodeIssue, ReviewFeedback
+
+
+def test_code_issue_minimal() -> None:
+    issue = CodeIssue(severity="warning", description="bad name")
+    assert issue.line is None
+    assert issue.severity == "warning"
+    assert issue.fix_hint == ""
+
+
+def test_code_issue_invalid_severity_rejected() -> None:
+    with pytest.raises(ValidationError):
+        CodeIssue(severity="critical", description="x")  # type: ignore[arg-type]
+
+
+def test_review_feedback_minimal() -> None:
+    fb = ReviewFeedback(overall_assessment="on_track")
+    assert fb.issues == []
+    assert fb.improvements == []
+    assert fb.strengths == []
+    assert fb.next_step == ""
+
+
+def test_review_feedback_full() -> None:
+    fb = ReviewFeedback(
+        issues=[
+            CodeIssue(
+                line=12,
+                severity="error",
+                description="off-by-one",
+                fix_hint="check the upper bound",
+            )
+        ],
+        improvements=["add docstring"],
+        strengths=["clear naming"],
+        next_step="run the failing test",
+        overall_assessment="needs_work",
+    )
+    assert fb.overall_assessment == "needs_work"
+    assert fb.issues[0].line == 12
+    assert fb.issues[0].severity == "error"
+
+
+def test_review_feedback_invalid_assessment_rejected() -> None:
+    with pytest.raises(ValidationError):
+        ReviewFeedback(overall_assessment="amazing")  # type: ignore[arg-type]

--- a/tests/unit/test_review_supervisor.py
+++ b/tests/unit/test_review_supervisor.py
@@ -1,0 +1,100 @@
+"""Unit tests for the review prompt builders and JSON parser."""
+
+from __future__ import annotations
+
+from adt.core.supervised_supervisor import (
+    build_review_system_prompt,
+    build_review_user_prompt,
+    parse_review_feedback,
+)
+
+
+def test_review_prompt_includes_level() -> None:
+    prompt = build_review_system_prompt("advanced")
+    assert "advanced" in prompt
+    assert "JSON" in prompt
+    assert "overall_assessment" in prompt
+
+
+def test_user_prompt_includes_code_and_path() -> None:
+    msg = build_review_user_prompt(
+        file_path="solution.py",
+        code="def f():\n    return 1\n",
+    )
+    assert "solution.py" in msg
+    assert "def f():" in msg
+
+
+def test_user_prompt_includes_step_and_extra_context() -> None:
+    msg = build_review_user_prompt(
+        file_path="x.py",
+        code="pass\n",
+        extra_context="should sort the list",
+        step_context="Step 2 of 4",
+    )
+    assert "should sort the list" in msg
+    assert "Step 2 of 4" in msg
+
+
+def test_parse_valid_feedback() -> None:
+    raw = """{
+        "issues": [
+            {"line": 12, "severity": "warning",
+             "description": "bad name", "fix_hint": "rename"}
+        ],
+        "improvements": ["add docstring"],
+        "strengths": ["clear types"],
+        "next_step": "fix the warning",
+        "overall_assessment": "on_track"
+    }"""
+    fb = parse_review_feedback(raw)
+    assert fb is not None
+    assert fb.overall_assessment == "on_track"
+    assert len(fb.issues) == 1
+    assert fb.issues[0].line == 12
+    assert fb.improvements == ["add docstring"]
+
+
+def test_parse_feedback_with_markdown_fences() -> None:
+    raw = """```json
+{
+  "issues": [],
+  "improvements": [],
+  "strengths": [],
+  "next_step": "",
+  "overall_assessment": "excellent"
+}
+```"""
+    fb = parse_review_feedback(raw)
+    assert fb is not None
+    assert fb.overall_assessment == "excellent"
+
+
+def test_parse_invalid_json_returns_none() -> None:
+    assert parse_review_feedback("totally not json") is None
+
+
+def test_parse_non_dict_json_returns_none() -> None:
+    assert parse_review_feedback("[1, 2, 3]") is None
+
+
+def test_parse_skips_malformed_issue_entries() -> None:
+    raw = """{
+        "issues": ["not a dict", {"severity": "error",
+         "description": "real one"}],
+        "improvements": [],
+        "strengths": [],
+        "next_step": "",
+        "overall_assessment": "needs_work"
+    }"""
+    fb = parse_review_feedback(raw)
+    assert fb is not None
+    assert len(fb.issues) == 1
+    assert fb.issues[0].severity == "error"
+
+
+def test_parse_missing_assessment_defaults_to_on_track() -> None:
+    raw = '{"issues": [], "improvements": [], "strengths": [], "next_step": ""}'
+    fb = parse_review_feedback(raw)
+    assert fb is not None
+    assert fb.overall_assessment == "on_track"

--- a/tests/unit/test_session_context.py
+++ b/tests/unit/test_session_context.py
@@ -1,0 +1,121 @@
+"""Unit tests for the supervised SessionContext lifecycle and persistence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adt.core.session import SessionContext
+from adt.models.schemas import SupervisedResponse, SupervisedStep
+
+
+def _supervised(problem: str, step: int = 1, total: int = 4) -> SupervisedResponse:
+    return SupervisedResponse(
+        problem_summary=problem,
+        current_step=SupervisedStep(step_number=step, goal="g"),
+        total_steps=total,
+    )
+
+
+def test_empty_session_is_empty() -> None:
+    sess = SessionContext()
+    assert sess.is_empty()
+    assert sess.as_step_context() == ""
+
+
+def test_update_from_supervised_populates_state() -> None:
+    sess = SessionContext()
+    sess.update_from_supervised(_supervised("Binary search", step=2, total=5))
+    assert not sess.is_empty()
+    assert sess.problem_summary == "Binary search"
+    assert sess.current_step == 2
+    assert sess.total_steps == 5
+    assert sess.iteration_count == 1
+
+
+def test_update_with_different_problem_clears_feedback() -> None:
+    sess = SessionContext()
+    sess.update_from_supervised(_supervised("Binary search"))
+    sess.record_feedback("on_track")
+    assert sess.previous_feedback == ["on_track"]
+
+    sess.update_from_supervised(_supervised("Quicksort"))
+    assert sess.previous_feedback == []
+    assert sess.problem_summary == "Quicksort"
+
+
+def test_update_with_same_problem_keeps_feedback() -> None:
+    sess = SessionContext()
+    sess.update_from_supervised(_supervised("Binary search"))
+    sess.record_feedback("needs_work")
+    sess.update_from_supervised(_supervised("Binary search", step=2))
+    assert sess.previous_feedback == ["needs_work"]
+    assert sess.current_step == 2
+
+
+def test_record_feedback_caps_history() -> None:
+    sess = SessionContext()
+    sess.update_from_supervised(_supervised("X"))
+    for _ in range(15):
+        sess.record_feedback("on_track")
+    assert len(sess.previous_feedback) == 10
+
+
+def test_as_step_context_includes_recent_feedback() -> None:
+    sess = SessionContext()
+    sess.update_from_supervised(_supervised("Binary search", step=3, total=5))
+    sess.record_feedback("needs_work")
+    out = sess.as_step_context()
+    assert "Binary search" in out
+    assert "Step 3 of 5" in out
+    assert "needs_work" in out
+
+
+def test_clear_resets_state() -> None:
+    sess = SessionContext()
+    sess.update_from_supervised(_supervised("X"))
+    sess.clear()
+    assert sess.is_empty()
+    assert sess.previous_feedback == []
+
+
+def test_save_and_load_roundtrip(tmp_path: Path) -> None:
+    target = tmp_path / "session.json"
+    sess = SessionContext()
+    sess.update_from_supervised(_supervised("Binary search", step=2, total=4))
+    sess.record_feedback("excellent")
+    sess.save(target)
+
+    loaded = SessionContext.load(target)
+    assert loaded.problem_summary == "Binary search"
+    assert loaded.current_step == 2
+    assert loaded.total_steps == 4
+    assert loaded.previous_feedback == ["excellent"]
+
+
+def test_load_missing_file_returns_empty(tmp_path: Path) -> None:
+    sess = SessionContext.load(tmp_path / "nope.json")
+    assert sess.is_empty()
+
+
+def test_load_corrupted_file_returns_empty(tmp_path: Path) -> None:
+    target = tmp_path / "session.json"
+    target.write_text("{not valid json", encoding="utf-8")
+    sess = SessionContext.load(target)
+    assert sess.is_empty()
+
+
+def test_reset_deletes_file(tmp_path: Path) -> None:
+    target = tmp_path / "session.json"
+    target.write_text("{}", encoding="utf-8")
+    SessionContext.reset(target)
+    assert not target.exists()
+    # No error if missing
+    SessionContext.reset(target)
+
+
+def test_matches_problem_loose_containment() -> None:
+    sess = SessionContext()
+    sess.update_from_supervised(_supervised("Binary search"))
+    assert sess.matches_problem("Binary search")
+    assert sess.matches_problem("Binary search algorithm")
+    assert not sess.matches_problem("Quicksort")


### PR DESCRIPTION
## Description

Phase 9.2 — Interactive Feedback Loop. Completes the supervised learning
workflow by adding `adt review`: the user implements a step, submits the
file, and gets structured technical feedback tied to the current
supervised session. This closes the implement → review → refine loop
kicked off in Phase 9.1.

The reviewer never rewrites the full solution. It cites concrete lines,
classifies severity (error / warning / suggestion), gives a fix hint
that nudges without revealing the answer, and points to the next action.

## Related Issues

Closes #P9-08..P9-11 (Phase 9.2 scope)

## Changes

- `src/adt/models/schemas.py` — add `Severity`, `Assessment` literals and
  `CodeIssue` / `ReviewFeedback` models with `extra="forbid"`.
- `src/adt/core/supervised_supervisor.py` — add `build_review_system_prompt`,
  `build_review_user_prompt` (includes optional session step context and
  user-provided `--context`), and a tolerant `parse_review_feedback`
  that strips markdown fences and skips malformed issue entries.
- `src/adt/core/session.py` — new `SessionContext` dataclass with
  `problem_summary`, `current_step`, `total_steps`, `previous_feedback`
  (capped at 10), and `iteration_count`. JSON persistence at
  `~/.adt/session.json`; `load()` returns an empty session on missing
  or corrupted files. Switching problems resets feedback history;
  matching uses loose containment so small wording drift does not
  reset the session.
- `src/adt/review_session.py` — new `run_review()` orchestrator:
  validates the file (existence, readability, 200 KB cap), loads the
  session, builds the prompts, calls the LLM once (no tool loop),
  parses the feedback, records the assessment, saves the session,
  and emits `review_started` / `review_completed` / `review_llm_failure`
  JSON log events.
- `src/adt/cli/review_renderer.py` — new `ReviewRenderer` Rich panel.
  Color-coded assessment header (red / yellow / green), per-issue
  severity glyphs, line-prefixed descriptions, and a `Next Step`
  footer.
- `src/adt/cli/app.py` — add the `adt review` Typer command with
  `--context`, `--level`, `--model`, `--verbose` flags. Falls back to
  a raw panel + exit 1 when the LLM returns unparseable output.
- `src/adt/ask_session.py` — supervised `run_ask` now loads the
  existing session, calls `update_from_supervised()`, and persists it
  so the next `adt review` invocation has the current step context.

## Testing

- [x] Unit tests added
  - `tests/unit/test_review_schemas.py` (5): validators and defaults.
  - `tests/unit/test_review_supervisor.py` (9): prompt building, JSON
    parsing (valid, fenced, garbage, non-dict, malformed entries,
    missing assessment).
  - `tests/unit/test_session_context.py` (12): empty state, update,
    problem switch clears feedback, same-problem keeps it, feedback
    cap at 10, `as_step_context` rendering, save/load round-trip,
    missing file, corrupted file, reset, loose matching.
  - `tests/unit/test_review_renderer.py` (4): assessment header,
    issue formatting, section skipping, missing line number.
  - `tests/unit/test_cli_review.py` (5): invalid level, happy path
    with session footer, unparsed feedback, configuration error,
    unexpected exception.
- [x] Integration tests pass
  - `tests/integration/test_review_flow.py` (3): end-to-end through
    `run_review` with `FakeLLM`, session update from prior supervised
    turn, garbage LLM output, missing file.
- [x] Manual testing done
  - `adt ask "me ensine binary search em python" --mode supervised --level beginner`
    → supervised panel + session saved.
  - `adt review solution.py --context "should return the index"`
    → `Code Review` panel with line-level issues; footer shows
    `step 2/4 — Binary search`.
  - `adt review solution.py` a second time after edits → new
    assessment recorded; previous ones retained up to 10.
- Full suite: **264 tests passing**, `ruff check` and
  `ruff format --check` clean, `mypy` clean (49 source files).

## Checklist

- [x] Code follows project conventions
- [x] Docstrings added to new public functions
- [x] No hardcoded secrets or API keys
- [x] Lint and type checks pass (`make lint typecheck`)
