### PR TITLE
feat(skill): add supervised engineering skill definition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,10 @@ Issues = "https://github.com/brunoramosmartins/agentic-dev-tool/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/adt"]
+include = [
+  "src/adt/**/*.py",
+  "src/adt/**/*.md",
+]
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/src/adt/core/supervised_supervisor.py
+++ b/src/adt/core/supervised_supervisor.py
@@ -13,6 +13,14 @@ from adt.models.schemas import (
     SupervisedResponse,
     SupervisedStep,
 )
+from adt.skills.supervised_engineering import load_skill_content
+
+_SKILL_HEADER = (
+    "## Skill: Supervised Engineering\n"
+    "The heuristics below define how you decompose problems and give "
+    "feedback. Treat them as binding rules, not suggestions.\n\n"
+)
+_SKILL_SEPARATOR = "\n\n---\n\n"
 
 logger = logging.getLogger(__name__)
 
@@ -59,9 +67,21 @@ The user's difficulty level is: {level}
 """
 
 
-def build_supervised_system_prompt(level: str) -> str:
-    """Return the system prompt with the difficulty level interpolated."""
-    return _SUPERVISED_SYSTEM_PROMPT.format(level=level)
+def build_supervised_system_prompt(
+    level: str,
+    *,
+    skill_content: str | None = None,
+) -> str:
+    """Return the system prompt with skill heuristics and difficulty interpolated.
+
+    Args:
+        level: Difficulty level (``beginner`` / ``intermediate`` / ``advanced``).
+        skill_content: Optional override for the supervised engineering skill
+            body. When ``None``, the packaged ``SKILL.md`` is loaded at runtime.
+    """
+    skill = skill_content if skill_content is not None else load_skill_content()
+    base = _SUPERVISED_SYSTEM_PROMPT.format(level=level)
+    return _SKILL_HEADER + skill + _SKILL_SEPARATOR + base
 
 
 def parse_supervised_response(raw_answer: str) -> SupervisedResponse | None:
@@ -168,9 +188,21 @@ The user's difficulty level is: {level}
 """
 
 
-def build_review_system_prompt(level: str) -> str:
-    """Return the code review system prompt with the difficulty level interpolated."""
-    return _REVIEW_SYSTEM_PROMPT.format(level=level)
+def build_review_system_prompt(
+    level: str,
+    *,
+    skill_content: str | None = None,
+) -> str:
+    """Return the review system prompt with skill heuristics and level embedded.
+
+    Args:
+        level: Difficulty level (``beginner`` / ``intermediate`` / ``advanced``).
+        skill_content: Optional override for the supervised engineering skill
+            body. When ``None``, the packaged ``SKILL.md`` is loaded at runtime.
+    """
+    skill = skill_content if skill_content is not None else load_skill_content()
+    base = _REVIEW_SYSTEM_PROMPT.format(level=level)
+    return _SKILL_HEADER + skill + _SKILL_SEPARATOR + base
 
 
 def build_review_user_prompt(

--- a/src/adt/skills/__init__.py
+++ b/src/adt/skills/__init__.py
@@ -1,0 +1,7 @@
+"""Reusable, versionable skill definitions consumed by agents and supervisors.
+
+A *skill* is a self-contained directory with a ``SKILL.md`` document and an
+optional Python loader. Skills encode behavior heuristics that the core code
+references at runtime, so they can be edited independently of the agent
+implementations and shipped with the package as data files.
+"""

--- a/src/adt/skills/supervised_engineering/SKILL.md
+++ b/src/adt/skills/supervised_engineering/SKILL.md
@@ -1,0 +1,85 @@
+# Supervised Engineering Skill
+
+This skill drives the supervised learning mode of `adt`. It is loaded at
+runtime by `SupervisedSupervisor` and injected into both the step-guidance
+and code-review prompts. The goal is to keep teaching heuristics in one
+place so they can be edited, versioned, and reused without touching
+agent code.
+
+## When to Use
+
+- User explicitly requests `--mode supervised`.
+- User asks to "learn", "practice", "understand", or "study" a concept.
+- User asks for step-by-step guidance on an implementation they intend
+  to write themselves.
+- User submits code via `adt review` for technical feedback.
+
+## When NOT to Use
+
+- User wants a quick answer or a complete solution.
+- User is debugging production code under time pressure.
+- User explicitly asks for execution mode (`--mode execution`) or uses
+  `adt ask` without the supervised flag.
+- User requests a refactor of an existing, finished codebase.
+
+## Teaching Heuristics
+
+1. Always start by clarifying the problem scope in a single sentence.
+2. Decompose into 3–6 steps. Never more than 8.
+3. Each step must be implementable in 10–30 minutes by the target level.
+4. Define clear acceptance criteria per step (concrete, testable).
+5. Never reveal step N+1 in detail before step N is reviewed.
+6. Ask exactly one probing question per step to deepen understanding.
+7. Adapt granularity to the user level:
+   - beginner: smaller steps, more hints, explicit type guidance.
+   - intermediate: balanced hints, standard granularity.
+   - advanced: larger steps, design trade-offs, minimal hand-holding.
+
+## Decomposition Patterns
+
+Pick the pattern that best fits the problem and stick to it within a
+single supervised session:
+
+- **Function-first:** signature → core logic → edge cases → tests.
+- **Data-first:** define types → input parsing → processing → output.
+- **Test-first:** write failing test → make it pass → refactor → next test.
+- **Architecture-first:** components → interfaces → implementation → integration.
+
+When in doubt for an algorithmic problem, default to function-first.
+For data pipelines, default to data-first. For feature additions to an
+existing codebase, prefer test-first.
+
+## Feedback Guidelines
+
+Applied by `adt review` when evaluating user-submitted code:
+
+- Always cite specific line numbers when the issue is localized.
+- Explain *why* something is an issue, not just *what*.
+- Acknowledge what the user did well with **specific** observations
+  (e.g. "the type annotations on `search` match the problem statement"),
+  never generic praise.
+- Phrase suggestions as questions when possible to keep the user thinking
+  (e.g. "should `high` be inclusive here?").
+- Severity classification:
+  - `error`: blocks correctness (bugs, wrong output, crashes).
+  - `warning`: risky or likely to break under edge cases.
+  - `suggestion`: readability, naming, idiomatic improvements.
+- `overall_assessment`:
+  - `needs_work`: at least one error-severity issue.
+  - `on_track`: no errors; warnings or several suggestions remain.
+  - `excellent`: no issues worth fixing; ready to advance.
+
+## Anti-Patterns to Avoid
+
+- "Looks good!" without specifics. Generic praise is forbidden.
+- Rewriting the user's entire solution or providing a full code block
+  that replaces their work.
+- Skipping directly to an advanced pattern the user has not approached
+  yet (e.g. jumping to recursion when the user is on the iterative step).
+- Hints that are effectively the answer ("change `<` to `<=` on line 12").
+- Assuming knowledge the user has not demonstrated in the conversation
+  or in the submitted code.
+- Closing with filler ("let me know if you need anything", motivational
+  phrases). End when the information is delivered.
+- Switching languages mid-response. Always reply in the language the
+  user used.

--- a/src/adt/skills/supervised_engineering/__init__.py
+++ b/src/adt/skills/supervised_engineering/__init__.py
@@ -1,0 +1,15 @@
+"""Supervised engineering skill: teaching heuristics for the supervised mode.
+
+This package bundles :data:`SKILL.md` with a small loader. The Markdown file
+is the source of truth for how the supervised supervisor decomposes problems
+and how the reviewer formulates feedback. Importing this package only exposes
+the loader; the content is read lazily so test fixtures can override the path.
+"""
+
+from adt.skills.supervised_engineering.loader import (
+    SKILL_FILENAME,
+    SKILL_NAME,
+    load_skill_content,
+)
+
+__all__ = ["SKILL_FILENAME", "SKILL_NAME", "load_skill_content"]

--- a/src/adt/skills/supervised_engineering/loader.py
+++ b/src/adt/skills/supervised_engineering/loader.py
@@ -1,0 +1,104 @@
+"""Loader utility that reads ``SKILL.md`` from the installed package.
+
+The skill is shipped as a data file inside ``adt.skills.supervised_engineering``.
+It is resolved via :mod:`importlib.resources` so the loader works both in an
+editable install and from a built wheel. The content is cached after the first
+read so repeated supervisor initializations do not touch the filesystem.
+"""
+
+from __future__ import annotations
+
+import logging
+from importlib import resources
+from pathlib import Path
+
+from adt.logging.json_log import log_adt
+
+logger = logging.getLogger(__name__)
+
+SKILL_NAME = "supervised_engineering"
+SKILL_FILENAME = "SKILL.md"
+
+_FALLBACK_SKILL = (
+    "# Supervised Engineering Skill (fallback)\n\n"
+    "Skill file could not be loaded. Behavior falls back to the built-in "
+    "system prompt. Check the package installation.\n"
+)
+
+_cache: str | None = None
+
+
+def _read_packaged_skill() -> str:
+    """Read the bundled ``SKILL.md`` via :mod:`importlib.resources`.
+
+    Raises:
+        FileNotFoundError: When the resource is missing from the package.
+    """
+    package = "adt.skills.supervised_engineering"
+    try:
+        ref = resources.files(package).joinpath(SKILL_FILENAME)
+    except (ModuleNotFoundError, AttributeError) as exc:
+        raise FileNotFoundError(f"skill package not importable: {exc}") from exc
+    if not ref.is_file():
+        raise FileNotFoundError(f"{SKILL_FILENAME} missing from {package}")
+    return ref.read_text(encoding="utf-8")
+
+
+def load_skill_content(
+    *,
+    path: Path | None = None,
+    use_cache: bool = True,
+) -> str:
+    """Return the ``SKILL.md`` content for the supervised engineering skill.
+
+    Args:
+        path: Optional override pointing to a ``SKILL.md`` file on disk. When
+            set, the cache is bypassed so tests can inject alternative content.
+        use_cache: Cache the packaged content after the first successful read.
+            Ignored when ``path`` is supplied.
+
+    Returns:
+        The raw Markdown body of the skill document. On any read failure a
+        short fallback notice is returned so callers can still build a prompt.
+    """
+    global _cache
+
+    if path is not None:
+        try:
+            return path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            log_adt(
+                logger,
+                logging.WARNING,
+                event="skill_load_failed",
+                skill=SKILL_NAME,
+                source=str(path),
+                error=str(exc),
+            )
+            return _FALLBACK_SKILL
+
+    if use_cache and _cache is not None:
+        return _cache
+
+    try:
+        content = _read_packaged_skill()
+    except FileNotFoundError as exc:
+        log_adt(
+            logger,
+            logging.WARNING,
+            event="skill_load_failed",
+            skill=SKILL_NAME,
+            source="package",
+            error=str(exc),
+        )
+        return _FALLBACK_SKILL
+
+    if use_cache:
+        _cache = content
+    return content
+
+
+def reset_cache() -> None:
+    """Clear the in-memory cache (used by tests)."""
+    global _cache
+    _cache = None

--- a/tests/unit/test_skill_loader.py
+++ b/tests/unit/test_skill_loader.py
@@ -1,0 +1,62 @@
+"""Unit tests for the supervised engineering skill loader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from adt.skills.supervised_engineering import (
+    SKILL_FILENAME,
+    SKILL_NAME,
+    load_skill_content,
+)
+from adt.skills.supervised_engineering.loader import reset_cache
+
+
+def test_skill_constants() -> None:
+    assert SKILL_NAME == "supervised_engineering"
+    assert SKILL_FILENAME == "SKILL.md"
+
+
+def test_packaged_skill_loads_and_contains_sections() -> None:
+    reset_cache()
+    content = load_skill_content()
+    assert "# Supervised Engineering Skill" in content
+    assert "Teaching Heuristics" in content
+    assert "Decomposition Patterns" in content
+    assert "Feedback Guidelines" in content
+    assert "Anti-Patterns" in content
+    assert "When to Use" in content
+    assert "When NOT to Use" in content
+
+
+def test_packaged_skill_is_cached() -> None:
+    reset_cache()
+    first = load_skill_content()
+    second = load_skill_content()
+    assert first == second
+    # Same identity thanks to the module-level cache
+    assert first is second
+
+
+def test_path_override_bypasses_cache(tmp_path: Path) -> None:
+    reset_cache()
+    load_skill_content()  # populate cache
+    custom = tmp_path / "SKILL.md"
+    custom.write_text("# Custom skill body\n", encoding="utf-8")
+    out = load_skill_content(path=custom)
+    assert out == "# Custom skill body\n"
+    # Original cache still intact for the packaged path
+    assert "# Supervised Engineering Skill" in load_skill_content()
+
+
+def test_missing_path_returns_fallback(tmp_path: Path) -> None:
+    out = load_skill_content(path=tmp_path / "nope.md")
+    assert "fallback" in out.lower()
+
+
+def test_use_cache_false_rereads_package() -> None:
+    reset_cache()
+    a = load_skill_content(use_cache=False)
+    b = load_skill_content(use_cache=False)
+    assert a == b
+    assert "Teaching Heuristics" in a

--- a/tests/unit/test_supervised_skill_injection.py
+++ b/tests/unit/test_supervised_skill_injection.py
@@ -1,0 +1,67 @@
+"""Unit tests verifying the skill content is injected into the prompts."""
+
+from __future__ import annotations
+
+from adt.core.supervised_supervisor import (
+    build_review_system_prompt,
+    build_supervised_system_prompt,
+)
+from adt.skills.supervised_engineering import load_skill_content
+from adt.skills.supervised_engineering.loader import reset_cache
+
+
+def test_supervised_prompt_embeds_skill_heuristics() -> None:
+    reset_cache()
+    prompt = build_supervised_system_prompt("intermediate")
+    assert "Skill: Supervised Engineering" in prompt
+    assert "Teaching Heuristics" in prompt
+    assert "Decomposition Patterns" in prompt
+    # Level still interpolated after the skill block
+    assert "intermediate" in prompt
+    # JSON output spec still present
+    assert '"problem_summary"' in prompt
+
+
+def test_review_prompt_embeds_skill_heuristics() -> None:
+    reset_cache()
+    prompt = build_review_system_prompt("advanced")
+    assert "Skill: Supervised Engineering" in prompt
+    assert "Feedback Guidelines" in prompt
+    assert "Anti-Patterns" in prompt
+    assert "advanced" in prompt
+    assert '"overall_assessment"' in prompt
+
+
+def test_supervised_prompt_accepts_skill_override() -> None:
+    prompt = build_supervised_system_prompt(
+        "beginner",
+        skill_content="# Custom\n- rule one\n",
+    )
+    assert "Custom" in prompt
+    assert "rule one" in prompt
+    # Packaged content should NOT leak in when override is used
+    assert "Decomposition Patterns" not in prompt
+    # Base prompt still interpolated
+    assert "beginner" in prompt
+    assert '"problem_summary"' in prompt
+
+
+def test_review_prompt_accepts_skill_override() -> None:
+    prompt = build_review_system_prompt(
+        "beginner",
+        skill_content="# Override\n",
+    )
+    assert "Override" in prompt
+    assert "Decomposition Patterns" not in prompt
+    assert '"overall_assessment"' in prompt
+
+
+def test_skill_content_is_complete_and_reused() -> None:
+    reset_cache()
+    raw = load_skill_content()
+    prompt = build_supervised_system_prompt("intermediate")
+    # Every non-empty line of the skill must appear in the prompt
+    for line in raw.strip().splitlines():
+        stripped = line.strip()
+        if stripped:
+            assert stripped in prompt


### PR DESCRIPTION
## Description

Phase 9.3 — Skill Integration. Introduce a **skill** paradigm for the
supervised mode: a self-contained directory with a `SKILL.md` document
and a small loader. The supervised and review prompts now pull their
teaching heuristics from this file at runtime, so the behavior becomes
reusable, versionable, and independently extensible without editing
agent code.

There is no visible change for end users. `adt ask --mode supervised`
and `adt review` continue to work exactly as before; the prompts are
just assembled from data files instead of hard-coded strings.

## Related Issues

Closes #P9-12..P9-14 (Phase 9.3 scope)

## Changes

- `src/adt/skills/__init__.py` — new package for reusable skill
  definitions, with a short module docstring describing the paradigm.
- `src/adt/skills/supervised_engineering/__init__.py` — re-exports the
  loader API (`load_skill_content`, `SKILL_NAME`, `SKILL_FILENAME`).
- `src/adt/skills/supervised_engineering/SKILL.md` — authoritative skill
  document with sections: *When to Use*, *When NOT to Use*, *Teaching
  Heuristics*, *Decomposition Patterns* (function-first, data-first,
  test-first, architecture-first), *Feedback Guidelines*, and
  *Anti-Patterns to Avoid*. Covers severity classification and
  `overall_assessment` semantics used by the reviewer.
- `src/adt/skills/supervised_engineering/loader.py` — new loader built
  on `importlib.resources` so it works from both editable installs
  and built wheels. Features: in-memory cache, `path=` override for
  tests, `use_cache=False` escape hatch, and a short fallback string
  on any read failure (logged via `log_adt` as `skill_load_failed`).
- `src/adt/core/supervised_supervisor.py` — `build_supervised_system_prompt`
  and `build_review_system_prompt` now accept an optional
  `skill_content` kwarg and prepend a `## Skill: Supervised Engineering`
  block (separated by `---`) before the base prompt. Default behavior
  calls `load_skill_content()` automatically, so existing callers
  (`runner._run_supervised`, `review_session.run_review`) pick up the
  skill without any change.
- `pyproject.toml` — wheel target now explicitly includes
  `src/adt/**/*.py` and `src/adt/**/*.md` so `SKILL.md` is bundled
  alongside the Python sources.

## Testing

- [x] Unit tests added
  - `tests/unit/test_skill_loader.py` (6): module constants, packaged
    load contains all expected sections, cache identity, path override
    bypasses cache, missing path returns fallback, `use_cache=False`
    re-reads the package.
  - `tests/unit/test_supervised_skill_injection.py` (5): supervised
    prompt embeds heuristics + keeps `{level}` interpolation and JSON
    schema; review prompt embeds feedback guidelines + anti-patterns +
    assessment schema; overrides bypass the packaged content; every
    non-empty line of the loaded skill appears in the assembled
    prompt.
- [x] Integration tests pass (existing supervised and review flows
  now go through skill injection by default).
- [x] Manual wheel check
  - `python -m build --wheel` produces
    `agentic_dev_tool-1.1.0-py3-none-any.whl` containing
    `adt/skills/supervised_engineering/SKILL.md`, confirming the
    asset ships in the distribution.
- Full suite: **275 tests passing**, `ruff check` and
  `ruff format --check` clean, `mypy` clean (52 source files).

## Checklist

- [x] Code follows project conventions
- [x] Docstrings added to new public functions
- [x] No hardcoded secrets or API keys
- [x] Lint and type checks pass (`make lint typecheck`)
