### PR TITLE
feat(analytics): track supervised learning sessions + add adt guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**Portfolio-grade CLI** (and optional **HTTP API**) that routes natural-language questions to **specialized agents**—repository analysis, GitHub project context, and technical research—backed by **OpenAI tool calling** and an **MCP-style** in-process layer: tool **registry**, **JSON Schema** validation, **tiktoken** budgets, ranked context, and disk cache.
+**Portfolio-grade CLI** (and optional **HTTP API**) that routes natural-language questions to **specialized agents**—repository analysis, GitHub project context, and technical research—backed by **OpenAI tool calling** and an **MCP-style** in-process layer: tool **registry**, **JSON Schema** validation, **tiktoken** budgets, ranked context, and disk cache. Ships with a **supervised learning mode** (step-by-step teaching with difficulty levels), **code review**, **request tracing** with cost estimates, and **learning analytics**.
 
 ## Demo
 
@@ -27,6 +27,8 @@
 - [Usage](#usage)
 - [HTTP API (optional)](#http-api-optional)
 - [Commands](#commands)
+- [File layout and state](#file-layout-and-state)
+- [Skills](#skills)
 - [Development](#development)
 - [Releasing (maintainers: PyPI + GitHub)](#releasing-maintainers-pypi--github)
 - [Portfolio checklist](#portfolio-checklist)
@@ -46,30 +48,37 @@ This repo demonstrates **agentic architecture** without a toy script: a real **T
 | Area | What you get |
 |------|----------------|
 | **Agents** | `repo_agent`, `project_agent`, `research_agent` with tool loops |
-| **Routing** | `HybridSupervisor`: cheap LLM JSON intent + rule fallback |
+| **Routing** | `HybridSupervisor`: cheap LLM JSON intent + keyword-rule fallback |
 | **Repos** | Multi `--repo`, `compare_repos`, tree cache, ranked files |
 | **GitHub** | Issues/milestones via API; optional PAT for rate limits |
 | **Research** | arXiv + HTTP fetch tools |
-| **Config** | `~/.adt/config.toml` + `adt config` |
+| **Supervised mode** | Step-by-step teaching guided by the `supervised_engineering` skill |
+| **Difficulty levels** | `beginner`, `intermediate`, `advanced` reshape hints, granularity, and tone |
+| **Code review** | `adt review <file>` → structured feedback (issues, strengths, next step, verdict) |
+| **Learning analytics** | Rotating `~/.adt/logs/learning.jsonl` + `adt stats` panel with trends, verdicts, common issues, tokens |
+| **Tracing** | `--trace` shows routing → context build → LLM/tool calls with token + USD estimates |
+| **Config** | `~/.adt/config.toml` + `adt config show/set/path` + `ADT_*` env overrides |
+| **Guide** | `adt guide` prints a static cheat sheet (no API key needed) |
 | **API** | `adt serve` — FastAPI `/healthz`, `/ask` ([`[api]`](https://pypi.org/project/agentic-dev-tool/) extra) |
 
 ---
 
 ## Architecture
 
-High-level data flow from terminal or HTTP into one shared pipeline (`adt.ask_session.run_ask`), then the runner, tools, and model.
+High-level data flow from terminal or HTTP into one shared pipeline (`adt.ask_session.run_ask`), then the runner, tools, and model. Shaded subsystems (Supervised, Tracing, Analytics) are Phase 8/9 additions that wrap the base agent loop.
 
 ```mermaid
 flowchart TB
   subgraph entry["Entry"]
-    CLI["Typer CLI<br/>adt ask · config · serve"]
+    CLI["Typer CLI<br/>ask · review · stats · guide · config · serve"]
     HTTP["FastAPI optional<br/>POST /ask · GET /healthz"]
   end
 
   subgraph orch["Orchestration"]
-    ASK["ask_session.run_ask"]
+    ASK["ask_session.run_ask<br/>review_session.run_review"]
     BOOT["bootstrap.build_runner"]
     HYB["HybridSupervisor<br/>LLM JSON + keyword rules"]
+    SUP["SupervisedSupervisor<br/>step + review prompts"]
     RUN["Runner<br/>chat + tool loop · budgets"]
   end
 
@@ -85,11 +94,29 @@ flowchart TB
     RE["research_agent"]
   end
 
+  subgraph supervised["Supervised (Phase 9)"]
+    SKILL["skills/<br/>supervised_engineering"]
+    LVL["level_config<br/>beginner/intermediate/advanced"]
+    SESS["SessionContext<br/>~/.adt/session.json"]
+  end
+
+  subgraph obs["Tracing + Analytics (Phase 8/9)"]
+    TRC["TraceContext + events<br/>renderer · cost estimator"]
+    ANL["analytics/<br/>LearningEvent · stats · reader"]
+    LOG["~/.adt/logs/<br/>adt.jsonl · learning.jsonl"]
+  end
+
   LLM["LLMClient<br/>OpenAI"]
 
   CLI --> ASK
   HTTP --> ASK
   ASK --> BOOT
+  ASK --> SUP
+  ASK --> TRC
+  ASK --> ANL
+  SUP --> SKILL
+  SUP --> LVL
+  SUP --> SESS
   BOOT --> HYB
   BOOT --> RUN
   BOOT --> REG
@@ -102,9 +129,12 @@ flowchart TB
   RUN --> EXE
   EXE --> REG
   CTX --> RUN
+  TRC --> RUN
+  ANL --> LOG
+  TRC -.render.-> CLI
 ```
 
-**Narrative:** the user’s query and repo hints become a `QueryRequest`; the supervisor picks an agent; `ContextBuilder` packs bounded context; the `Runner` chats with the model, executes **tool calls** through the registry/executor, and returns an `AgentResponse` (answer, tools used, routing metadata). The CLI renders **Rich** panels; the API returns JSON.
+**Narrative:** the user’s query and repo hints become a `QueryRequest`; the hybrid supervisor picks an agent; `ContextBuilder` packs bounded context; the `Runner` chats with the model, executes **tool calls** through the registry/executor, and returns an `AgentResponse` (answer, tools used, routing metadata). In **supervised mode**, `SupervisedSupervisor` overrides the prompt using the packaged `supervised_engineering` skill plus level directives and persists a lightweight `SessionContext` between runs. The **review** flow reuses the same skill to produce structured feedback (`ReviewFeedback`). **Tracing** captures per-iteration events (routing, context build, LLM/tool calls) plus token + USD estimates. **Analytics** writes supervised and review outcomes to a rotating JSONL log that `adt stats` aggregates. The CLI renders **Rich** panels; the API returns JSON.
 
 Deeper design notes: [`docs/architecture.md`](docs/architecture.md) · tool contracts: [`docs/mcp.md`](docs/mcp.md) · agents/prompts: [`docs/agents.md`](docs/agents.md).
 
@@ -233,6 +263,13 @@ cp .env.example .env
 
 `adt config show` / `adt config set` manage **`~/.adt/config.toml`**. CLI flags and `ADT_*` override file defaults where documented in code.
 
+**Related CLI flags (Phase 8/9 additions):**
+
+- `--mode {execution,supervised}` and `--level {beginner,intermediate,advanced}` on `adt ask` switch the pipeline to the supervised supervisor.
+- `--trace` on `adt ask` prints a Rich trace panel (routing, context, LLM calls, cost).
+- `adt review <file>` accepts `--level` and `--context` to tune reviewer tone and scope.
+- `adt stats --last N` limits aggregation to the most recent N supervised sessions.
+
 ---
 
 ## Usage
@@ -274,11 +311,79 @@ adt ask "Explain src layout" --repo . --agent repo_agent
 adt ask "List issues" --repo myorg/repo --agent project_agent
 ```
 
+### Supervised mode (learning)
+
+Instead of solving the task, `adt` acts as a tutor — it plans 3–6 steps, reveals
+them one at a time, and asks checkpoint questions. The `supervised_engineering`
+skill (packaged under `src/adt/skills/`) drives the teaching heuristics and the
+review rubric.
+
+```bash
+adt ask "Implement binary search in Python" \
+  --mode supervised --level beginner --repo .
+```
+
+Difficulty levels reshape the response:
+
+| Level | Effect |
+|-------|--------|
+| `beginner` | Smaller steps, more hints, explicit type guidance, encouraging tone. |
+| `intermediate` | Balanced granularity and hinting (default). |
+| `advanced` | Larger steps, trade-off discussion, minimal hand-holding, critical tone. |
+
+Session state (current step, previous feedback) is persisted at
+`~/.adt/session.json` so the next `ask`/`review` picks up where you left off.
+
+### Code review
+
+Submit a file and get structured feedback (issues with line numbers, strengths,
+next step, overall verdict) from the reviewer LLM. Feedback is rendered as a
+colored Rich panel and the verdict feeds back into the session + analytics log.
+
+```bash
+adt review src/mymod/solution.py --context "binary search exercise"
+adt review src/mymod/solution.py --level advanced
+```
+
+### Tracing (`--trace`)
+
+Adds a trace panel under the answer showing routing decision, context build
+stats, per-iteration LLM/tool calls, cumulative tokens, and a USD cost
+estimate via `adt.tracing.cost`.
+
+```bash
+adt ask "Explain this repo" --repo . --trace
+```
+
+### Learning analytics (`adt stats`)
+
+Supervised runs and reviews append `LearningEvent`s to a rotating
+`~/.adt/logs/learning.jsonl`. `adt stats` renders a panel with session count,
+review verdicts, common issue categories, improvement trend, and token totals.
+
+```bash
+adt stats           # full history
+adt stats --last 10 # only the last 10 supervised sessions
+```
+
+### Quick reference (`adt guide`)
+
+`adt guide` prints a static cheat sheet (commands, modes, levels, agents,
+skills, environment) without making any API calls — ideal when you just
+installed the tool or want to jog your memory.
+
+```bash
+adt guide
+```
+
 ### Common flags
 
 - `--repo`, `-r` — Repeatable: existing directory or `owner/repo` slug.
 - `--token` — GitHub PAT for this run (overrides `GITHUB_TOKEN`).
 - `--agent`, `-a` — `repo_agent`, `research_agent`, or `project_agent`.
+- `--mode` — `execution` (default) or `supervised`.
+- `--level` — `beginner`, `intermediate`, `advanced` (supervised only).
+- `--trace` — Print a trace panel with routing, LLM calls, token use, and cost.
 - `--verbose`, `-v` — Debug logging, token usage, budget hint, context snippet.
 - `--log-level` — `DEBUG` … `ERROR` for JSON file logs under `~/.adt/logs/`.
 - `--no-cache` — Skip repo tree cache.
@@ -305,15 +410,66 @@ adt serve --host 127.0.0.1 --port 8765
 
 | Command | Purpose |
 |---------|---------|
-| `adt ask …` | Main agent loop. |
+| `adt ask …` | Main agent loop (supports `--mode supervised`, `--level`, `--trace`). |
+| `adt review <file>` | Structured code review with issues, strengths, next step, verdict. |
+| `adt stats [--last N]` | Aggregate supervised learning log: sessions, verdicts, trend, tokens. |
+| `adt guide` | Static quick-reference: commands, modes, levels, agents, skills. |
 | `adt serve` | FastAPI + uvicorn (`[api]`). |
 | `adt config show` / `path` / `set` | `~/.adt/config.toml`. |
 | `adt version` | Package version. |
 | `adt info` | Short feature summary. |
 
 ```bash
-adt --help && adt ask --help && adt serve --help
+adt --help && adt ask --help && adt review --help && adt stats --help
 ```
+
+> **Tip:** `adt guide` does not require `OPENAI_API_KEY` and never hits the
+> network — it is the fastest way to see every feature at a glance.
+
+---
+
+## File layout and state
+
+`adt` keeps all mutable state under `~/.adt/` so your repositories stay clean:
+
+| Path | Written by | Purpose |
+|------|------------|---------|
+| `~/.adt/config.toml` | `adt config set` | Persistent defaults (model, log level, routing). |
+| `~/.adt/cache/` | `ContextBuilder` | Repo tree cache (`--no-cache` or `ADT_CACHE_TTL=0` to disable). |
+| `~/.adt/logs/adt.jsonl` | `log_adt` helper | Structured runtime logs (routing, tool calls, errors). |
+| `~/.adt/logs/learning.jsonl` | `adt ask --mode supervised`, `adt review` | Rotating JSONL (10 MB × 5 backups) consumed by `adt stats`. |
+| `~/.adt/session.json` | `adt ask --mode supervised`, `adt review` | Current supervised step, iteration count, recent feedback. |
+
+Delete any of these to reset the corresponding state — nothing under `~/.adt`
+is required for a fresh install.
+
+---
+
+## Skills
+
+Supervised teaching heuristics live in a **packaged skill** so they can be
+edited and versioned without touching agent code.
+
+```
+src/adt/skills/
+└── supervised_engineering/
+    ├── SKILL.md        # When/when-not/how (teaching heuristics + rubric)
+    ├── loader.py       # load_skill_content() via importlib.resources
+    └── __init__.py
+```
+
+`SupervisedSupervisor` reads the markdown via `importlib.resources` at runtime
+and prepends it to both the step-guidance and code-review prompts. Level
+directives (`beginner`/`intermediate`/`advanced`) come from
+`adt.core.level_config.LEVEL_CONFIGS` and are concatenated after the skill so
+prompt tone, hint count, and step granularity all change with `--level`.
+
+To add a new skill:
+
+1. Create `src/adt/skills/<name>/SKILL.md` and a matching `loader.py`.
+2. Register the skill path in the package wheel (`pyproject.toml` already
+   includes `src/adt/skills/**/*.md`).
+3. Load it from the agent/supervisor that consumes it.
 
 ---
 

--- a/src/adt/analytics/__init__.py
+++ b/src/adt/analytics/__init__.py
@@ -1,0 +1,22 @@
+"""Learning analytics: structured logging of supervised sessions.
+
+The analytics layer builds on Phase 8 tracing but writes to a dedicated
+rotating log at ``~/.adt/logs/learning.jsonl``. This keeps learning signal
+separate from general request traces so stats aggregation stays cheap and
+the main log can be rotated independently.
+"""
+
+from adt.analytics.events import LearningEvent, categorize_issue
+from adt.analytics.logger import log_learning_event, setup_learning_logger
+from adt.analytics.reader import read_learning_events
+from adt.analytics.stats import LearningStats, compute_stats
+
+__all__ = [
+    "LearningEvent",
+    "LearningStats",
+    "categorize_issue",
+    "compute_stats",
+    "log_learning_event",
+    "read_learning_events",
+    "setup_learning_logger",
+]

--- a/src/adt/analytics/events.py
+++ b/src/adt/analytics/events.py
@@ -1,0 +1,103 @@
+"""Structured events for supervised learning analytics."""
+
+from __future__ import annotations
+
+from adt.models.schemas import CodeIssue
+from adt.tracing.events import TraceEvent
+
+_CATEGORY_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "off_by_one",
+        ("off-by-one", "off by one", "boundary", "inclusive", "<=", ">="),
+    ),
+    (
+        "edge_case",
+        ("edge case", "empty", "null", "none", "zero", "negative", "overflow"),
+    ),
+    (
+        "naming",
+        ("name", "naming", "variable name", "rename", "descriptive"),
+    ),
+    (
+        "type_annotation",
+        ("type", "annotation", "typing", "hint"),
+    ),
+    (
+        "docstring",
+        ("docstring", "documentation", "doc comment"),
+    ),
+    (
+        "error_handling",
+        ("error", "exception", "try", "except", "raise", "handle"),
+    ),
+    (
+        "logic",
+        ("logic", "incorrect", "wrong", "bug", "condition"),
+    ),
+    (
+        "style",
+        ("style", "idiomatic", "pythonic", "readability", "format"),
+    ),
+    (
+        "performance",
+        ("performance", "slow", "complexity", "big o", "efficient"),
+    ),
+    (
+        "testing",
+        ("test", "coverage", "assertion", "case"),
+    ),
+)
+
+
+def categorize_issue(issue: CodeIssue) -> str:
+    """Classify a :class:`CodeIssue` into a coarse category string.
+
+    The classification is a simple keyword match against the issue
+    description. It is intentionally approximate: the goal is to cluster
+    recurring themes in stats ("5 off-by-one errors this week"), not to
+    build a full taxonomy. Falls back to ``"other"`` when no keyword
+    matches.
+    """
+    text = (issue.description or "").lower()
+    if not text:
+        return "other"
+    for label, keywords in _CATEGORY_KEYWORDS:
+        for kw in keywords:
+            if kw in text:
+                return label
+    return "other"
+
+
+class LearningEvent(TraceEvent):
+    """Trace event specific to supervised learning sessions.
+
+    Extends :class:`~adt.tracing.events.TraceEvent` with fields describing
+    a single pedagogical interaction. Each supervised ``ask`` emits one
+    ``supervised_step`` event and each ``review`` emits one ``code_review``
+    event. They share a trace id per CLI invocation but can be correlated
+    across invocations via ``problem_summary``.
+
+    Attributes:
+        step_id: 1-based step the user is on in the current supervised
+            session. ``0`` when not applicable (e.g. session not started).
+        iteration_count: Number of commands executed against this session
+            so far, including the current one.
+        assessment: Review verdict (``needs_work`` / ``on_track`` /
+            ``excellent``) for review events; ``"n/a"`` for pure
+            step-guidance events.
+        error_types: Coarse categories of issues found during a review
+            (empty for non-review events).
+        completion_time_ms: Wall clock time taken to produce this event's
+            payload, in milliseconds. ``None`` when unavailable.
+        problem_summary: Free-text restatement of the problem the user is
+            working on. Used to group events into sessions.
+        level: Difficulty level at the moment the event was emitted.
+    """
+
+    step_id: int = 0
+    iteration_count: int = 0
+    assessment: str = "n/a"
+    error_types: list[str] = []  # noqa: RUF012 — Pydantic default
+    completion_time_ms: int | None = None
+    problem_summary: str = ""
+    level: str = "intermediate"

--- a/src/adt/analytics/logger.py
+++ b/src/adt/analytics/logger.py
@@ -1,0 +1,96 @@
+"""Rotating JSON line logger for supervised learning events."""
+
+from __future__ import annotations
+
+import json
+import logging
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from adt.analytics.events import LearningEvent
+
+LEARNING_LOG_NAME = "learning.jsonl"
+_MAX_BYTES = 10 * 1024 * 1024  # 10 MB
+_BACKUP_COUNT = 5
+_LOGGER_NAME = "adt.learning"
+
+
+def learning_log_path(log_dir: Path | None = None) -> Path:
+    """Return the absolute path to ``learning.jsonl``."""
+    base = log_dir if log_dir is not None else Path.home() / ".adt" / "logs"
+    return base / LEARNING_LOG_NAME
+
+
+class _LearningFormatter(logging.Formatter):
+    """Serialize a log record payload directly as JSON."""
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - trivial
+        payload = getattr(record, "learning", None)
+        if isinstance(payload, str):
+            return payload
+        return record.getMessage()
+
+
+def setup_learning_logger(
+    *,
+    log_dir: Path | None = None,
+    max_bytes: int = _MAX_BYTES,
+    backup_count: int = _BACKUP_COUNT,
+) -> Path:
+    """Attach a :class:`RotatingFileHandler` for the learning logger.
+
+    Args:
+        log_dir: Directory that should contain ``learning.jsonl``; defaults
+            to ``~/.adt/logs``.
+        max_bytes: Per-file size before rollover (default 10 MB).
+        backup_count: Number of rotated files to retain (default 5).
+
+    Returns:
+        The absolute path to the active log file.
+
+    Idempotent: repeated calls reuse the existing handler instead of
+    stacking duplicates, so ``log_learning_event`` can call this lazily.
+    """
+    base = log_dir if log_dir is not None else Path.home() / ".adt" / "logs"
+    base.mkdir(parents=True, exist_ok=True)
+    path = learning_log_path(base)
+
+    log = logging.getLogger(_LOGGER_NAME)
+    log.setLevel(logging.INFO)
+    log.propagate = False
+
+    for handler in log.handlers:
+        if (
+            isinstance(handler, RotatingFileHandler)
+            and Path(handler.baseFilename).resolve() == path.resolve()
+        ):
+            return path
+
+    handler = RotatingFileHandler(
+        path,
+        maxBytes=max_bytes,
+        backupCount=backup_count,
+        encoding="utf-8",
+    )
+    handler.setFormatter(_LearningFormatter())
+    log.addHandler(handler)
+    return path
+
+
+def log_learning_event(
+    event: LearningEvent,
+    *,
+    log_dir: Path | None = None,
+) -> None:
+    """Append one :class:`LearningEvent` to the rotating learning log.
+
+    Failures are swallowed (the analytics layer is best-effort; a write
+    failure must never break the user-facing command).
+    """
+    try:
+        setup_learning_logger(log_dir=log_dir)
+        log = logging.getLogger(_LOGGER_NAME)
+        serialized = json.dumps(event.model_dump(mode="json"), default=str)
+        log.info("", extra={"learning": serialized})
+    except Exception:  # noqa: BLE001 - best-effort analytics
+        return

--- a/src/adt/analytics/reader.py
+++ b/src/adt/analytics/reader.py
@@ -1,0 +1,67 @@
+"""Reader for the rotating learning log."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from adt.analytics import logger as _logger_mod
+from adt.analytics.events import LearningEvent
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_line(line: str) -> LearningEvent | None:
+    line = line.strip()
+    if not line:
+        return None
+    try:
+        data = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    try:
+        return LearningEvent.model_validate(data)
+    except Exception:  # noqa: BLE001 — tolerate schema drift
+        return None
+
+
+def read_learning_events(
+    *,
+    log_dir: Path | None = None,
+    path: Path | None = None,
+    limit: int | None = None,
+) -> list[LearningEvent]:
+    """Load learning events from ``learning.jsonl`` (oldest first).
+
+    Args:
+        log_dir: Directory containing the log; defaults to ``~/.adt/logs``.
+        path: Explicit path override for tests. Takes precedence over
+            ``log_dir``.
+        limit: When set, return only the most recent ``limit`` events.
+
+    Returns:
+        A list of validated :class:`LearningEvent` instances. Missing file,
+        corrupted lines, and schema mismatches are silently skipped so the
+        stats command stays resilient to partial writes.
+    """
+    target = path if path is not None else _logger_mod.learning_log_path(log_dir)
+    if not target.exists():
+        return []
+    try:
+        content = target.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("learning_log_read_failed: %s", exc)
+        return []
+
+    events: list[LearningEvent] = []
+    for raw in content.splitlines():
+        event = _parse_line(raw)
+        if event is not None:
+            events.append(event)
+
+    if limit is not None and limit > 0:
+        events = events[-limit:]
+    return events

--- a/src/adt/analytics/stats.py
+++ b/src/adt/analytics/stats.py
@@ -1,0 +1,152 @@
+"""Aggregate :class:`LearningEvent` streams into a :class:`LearningStats`."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+
+from adt.analytics.events import LearningEvent
+
+
+@dataclass(frozen=True)
+class LearningStats:
+    """Summary metrics computed from a list of learning events.
+
+    Attributes:
+        sessions: Number of distinct supervised problems encountered.
+        reviews: Number of code review events recorded.
+        supervised_steps: Number of supervised step-guidance events.
+        avg_steps_per_session: Mean of each session's highest step index.
+        avg_iterations_per_step: Mean iterations observed per session.
+        common_issues: List of ``(category, count)`` tuples ordered by
+            descending frequency. Categories come from
+            :func:`~adt.analytics.events.categorize_issue`.
+        improvement_trend: Rolling average iterations-per-session, split
+            into at most three equal buckets (earliest → latest). Empty
+            when there are fewer than three events.
+        total_tokens: Sum of ``prompt_tokens`` + ``completion_tokens``
+            extracted from each event's ``data`` dict. ``0`` when events
+            did not carry token counts.
+        assessments: Count of each ``assessment`` value across reviews.
+    """
+
+    sessions: int = 0
+    reviews: int = 0
+    supervised_steps: int = 0
+    avg_steps_per_session: float = 0.0
+    avg_iterations_per_step: float = 0.0
+    common_issues: list[tuple[str, int]] = field(default_factory=list)
+    improvement_trend: list[float] = field(default_factory=list)
+    total_tokens: int = 0
+    assessments: dict[str, int] = field(default_factory=dict)
+
+
+def _round(value: float, digits: int = 2) -> float:
+    return round(value, digits)
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _session_key(event: LearningEvent) -> str:
+    key = (event.problem_summary or "").strip().lower()
+    return key or f"trace:{event.trace_id}"
+
+
+def compute_stats(
+    events: list[LearningEvent],
+    *,
+    last_n: int | None = None,
+) -> LearningStats:
+    """Derive :class:`LearningStats` from a list of events.
+
+    Args:
+        events: Events in chronological order (oldest first).
+        last_n: When set and positive, only consider the last ``last_n``
+            sessions (grouped by ``problem_summary``). Sessions are
+            identified in the order their first event appears.
+
+    Returns:
+        A frozen :class:`LearningStats` dataclass ready for rendering.
+    """
+    if not events:
+        return LearningStats()
+
+    # Group into sessions in first-seen order so ``last_n`` is meaningful.
+    session_order: list[str] = []
+    session_events: dict[str, list[LearningEvent]] = {}
+    for ev in events:
+        key = _session_key(ev)
+        if key not in session_events:
+            session_order.append(key)
+            session_events[key] = []
+        session_events[key].append(ev)
+
+    if last_n is not None and last_n > 0:
+        selected_keys = session_order[-last_n:]
+    else:
+        selected_keys = session_order
+    selected_events: list[LearningEvent] = [
+        ev for key in selected_keys for ev in session_events[key]
+    ]
+
+    sessions = len(selected_keys)
+    reviews = sum(1 for ev in selected_events if ev.event_type == "code_review")
+    supervised_steps = sum(
+        1 for ev in selected_events if ev.event_type == "supervised_step"
+    )
+
+    # Steps per session = highest step_id observed per session.
+    per_session_steps: list[float] = []
+    per_session_iterations: list[float] = []
+    for key in selected_keys:
+        evs = session_events[key]
+        max_step = max((ev.step_id for ev in evs), default=0)
+        max_iter = max((ev.iteration_count for ev in evs), default=0)
+        if max_step:
+            per_session_steps.append(float(max_step))
+        if max_iter:
+            per_session_iterations.append(float(max_iter))
+
+    # Common issues: flatten error_types from every event.
+    counter: Counter[str] = Counter()
+    for ev in selected_events:
+        counter.update(ev.error_types)
+    common_issues = counter.most_common(5)
+
+    # Improvement trend: bucket iterations_per_session into up to 3 slices.
+    trend: list[float] = []
+    if len(per_session_iterations) >= 3:
+        n = len(per_session_iterations)
+        third = n // 3
+        buckets = [
+            per_session_iterations[:third],
+            per_session_iterations[third : 2 * third],
+            per_session_iterations[2 * third :],
+        ]
+        trend = [_round(_mean(b)) for b in buckets if b]
+
+    assessments: dict[str, int] = {}
+    for ev in selected_events:
+        if ev.event_type != "code_review":
+            continue
+        assessments[ev.assessment] = assessments.get(ev.assessment, 0) + 1
+
+    total_tokens = 0
+    for ev in selected_events:
+        data = ev.data or {}
+        total_tokens += int(data.get("prompt_tokens", 0) or 0)
+        total_tokens += int(data.get("completion_tokens", 0) or 0)
+
+    return LearningStats(
+        sessions=sessions,
+        reviews=reviews,
+        supervised_steps=supervised_steps,
+        avg_steps_per_session=_round(_mean(per_session_steps)),
+        avg_iterations_per_step=_round(_mean(per_session_iterations)),
+        common_issues=common_issues,
+        improvement_trend=trend,
+        total_tokens=total_tokens,
+        assessments=assessments,
+    )

--- a/src/adt/ask_session.py
+++ b/src/adt/ask_session.py
@@ -142,6 +142,7 @@ def run_ask(
 
     supervised_resp: SupervisedResponse | None = None
     if mode == "supervised":
+        from adt.analytics import LearningEvent, log_learning_event
         from adt.core.supervised_supervisor import parse_supervised_response
 
         supervised_resp = parse_supervised_response(response.answer)
@@ -149,6 +150,30 @@ def run_ask(
             sess = SessionContext.load()
             sess.update_from_supervised(supervised_resp)
             sess.save()
+
+            usage = runner.last_token_usage or {}
+            trace_id = trace_ctx.trace_id if trace_ctx is not None else ""
+            completion_ms: int | None = None
+            if trace_ctx is not None:
+                completion_ms = int(trace_ctx.elapsed_ms())
+            event = LearningEvent(
+                trace_id=trace_id,
+                component="supervisor",
+                event_type="supervised_step",
+                step_id=supervised_resp.current_step.step_number,
+                iteration_count=sess.iteration_count,
+                assessment="n/a",
+                error_types=[],
+                completion_time_ms=completion_ms,
+                problem_summary=supervised_resp.problem_summary,
+                level=level,
+                data={
+                    "total_steps": supervised_resp.total_steps,
+                    "prompt_tokens": int(usage.get("prompt_tokens", 0) or 0),
+                    "completion_tokens": int(usage.get("completion_tokens", 0) or 0),
+                },
+            )
+            log_learning_event(event)
 
     return AskExecution(
         response=response,

--- a/src/adt/cli/app.py
+++ b/src/adt/cli/app.py
@@ -92,6 +92,19 @@ def info_cmd() -> None:
     )
 
 
+@app.command("guide")
+def guide_cmd() -> None:
+    """Print a static quick-reference: commands, modes, levels, agents, skills.
+
+    This command does not hit the network and does not require an API key.
+    Use it as a fast "what can adt do?" cheat sheet (think of it as the
+    ``?`` prompt in Claude Code).
+    """
+    from adt.cli.guide_renderer import GuideRenderer
+
+    GuideRenderer(console).render()
+
+
 @config_app.command("path")
 def config_path_cmd() -> None:
     """Print the config file path."""
@@ -376,6 +389,29 @@ def review_cmd(
             f"[dim]Session:[/dim] step {result.session.current_step}/"
             f"{result.session.total_steps} — {result.session.problem_summary}",
         )
+
+
+@app.command("stats")
+def stats_cmd(
+    last: Annotated[
+        int | None,
+        typer.Option(
+            "--last",
+            help="Only aggregate the most recent N supervised sessions.",
+        ),
+    ] = None,
+) -> None:
+    """Summarize supervised learning progress from ``~/.adt/logs/learning.jsonl``."""
+    from adt.analytics import compute_stats, read_learning_events
+    from adt.cli.stats_renderer import StatsRenderer
+
+    if last is not None and last <= 0:
+        console.print("[red]--last must be a positive integer.[/red]")
+        raise typer.Exit(code=1)
+
+    events = read_learning_events()
+    stats = compute_stats(events, last_n=last)
+    StatsRenderer(console).render(stats)
 
 
 @app.command("serve")

--- a/src/adt/cli/guide_renderer.py
+++ b/src/adt/cli/guide_renderer.py
@@ -1,0 +1,294 @@
+"""Static quick-reference renderer for ``adt guide``.
+
+The guide is rendered entirely from in-process data (no API calls, no
+environment variables required). It is intentionally short — think of it as
+the equivalent of ``?`` in Claude Code: a concise tour of the commands,
+modes, levels, agents, and skills that ship with ``adt``.
+"""
+
+from __future__ import annotations
+
+from importlib import metadata
+
+from rich.console import Console, Group
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+_TAGLINE = (
+    "Portfolio-grade CLI that routes natural-language questions to "
+    "specialized agents, with supervised learning, code review, tracing, "
+    "and learning analytics."
+)
+
+_COMMANDS: tuple[tuple[str, str, str], ...] = (
+    (
+        "ask",
+        "Run an agent on a question.",
+        'adt ask "Explain src/ layout" --repo .',
+    ),
+    (
+        "ask --mode supervised",
+        "Guided, step-by-step learning instead of a solution.",
+        'adt ask "Implement binary search" --mode supervised --level beginner',
+    ),
+    (
+        "review",
+        "Send a code file to the reviewer LLM for structured feedback.",
+        "adt review src/mymod/solution.py --context 'binary search'",
+    ),
+    (
+        "stats",
+        "Summarize supervised learning progress from the local log.",
+        "adt stats --last 10",
+    ),
+    (
+        "serve",
+        "Start the optional FastAPI server (requires the [api] extra).",
+        "adt serve --port 8765",
+    ),
+    (
+        "config show|set|path",
+        "Inspect or edit ~/.adt/config.toml.",
+        "adt config show",
+    ),
+    (
+        "guide",
+        "Print this quick-reference (no API key needed).",
+        "adt guide",
+    ),
+    (
+        "version / info",
+        "Print package version / short feature line.",
+        "adt version",
+    ),
+)
+
+_MODES: tuple[tuple[str, str, str], ...] = (
+    (
+        "execution",
+        "Default. Solves the task end-to-end using the routed agent.",
+        "adt ask '...' --repo .",
+    ),
+    (
+        "supervised",
+        "Teaches instead of solving. Emits steps, hints, and checkpoints "
+        "via the supervised_engineering skill.",
+        "adt ask '...' --mode supervised --level intermediate",
+    ),
+)
+
+_LEVELS: tuple[tuple[str, str, str], ...] = (
+    (
+        "beginner",
+        "Small steps, more hints, explicit type guidance.",
+        "green",
+    ),
+    (
+        "intermediate",
+        "Balanced granularity and hinting (default for supervised).",
+        "cyan",
+    ),
+    (
+        "advanced",
+        "Larger steps, design trade-offs, minimal hand-holding.",
+        "magenta",
+    ),
+)
+
+_AGENTS: tuple[tuple[str, str], ...] = (
+    (
+        "repo_agent",
+        "Reads local trees and files, explains architecture, compares repos.",
+    ),
+    (
+        "project_agent",
+        "GitHub issues + milestones + local markdown roadmap/CHANGELOG.",
+    ),
+    (
+        "research_agent",
+        "arXiv search + HTTP fetch for technical topics.",
+    ),
+)
+
+_SKILLS: tuple[tuple[str, str], ...] = (
+    (
+        "supervised_engineering",
+        "Teaching heuristics, decomposition patterns, and review rubric "
+        "injected into supervised + review prompts.",
+    ),
+)
+
+_ENV: tuple[tuple[str, str, str], ...] = (
+    ("OPENAI_API_KEY", "required", "Used by ask / review / serve."),
+    (
+        "GITHUB_TOKEN",
+        "optional",
+        "Higher GitHub API limits for project_agent (or pass --token).",
+    ),
+    (
+        "ADT_*",
+        "optional",
+        "Override config.toml at runtime (see `adt config show`).",
+    ),
+)
+
+
+def _package_version() -> str:
+    try:
+        return metadata.version("agentic-dev-tool")
+    except metadata.PackageNotFoundError:
+        return "dev"
+
+
+def _commands_table() -> Table:
+    table = Table(
+        title="Commands",
+        title_style="bold",
+        title_justify="left",
+        show_header=True,
+        header_style="bold",
+        expand=True,
+    )
+    table.add_column("Command", style="cyan", no_wrap=True)
+    table.add_column("What it does")
+    table.add_column("Example", style="dim")
+    for name, purpose, example in _COMMANDS:
+        table.add_row(name, purpose, example)
+    return table
+
+
+def _modes_table() -> Table:
+    table = Table(
+        title="Modes",
+        title_style="bold",
+        title_justify="left",
+        show_header=True,
+        header_style="bold",
+        expand=True,
+    )
+    table.add_column("Mode", style="bold", no_wrap=True)
+    table.add_column("Purpose")
+    table.add_column("Example", style="dim")
+    for name, purpose, example in _MODES:
+        table.add_row(name, purpose, example)
+    return table
+
+
+def _levels_table() -> Table:
+    table = Table(
+        title="Difficulty Levels (supervised mode)",
+        title_style="bold",
+        title_justify="left",
+        show_header=True,
+        header_style="bold",
+        expand=True,
+    )
+    table.add_column("Level", no_wrap=True)
+    table.add_column("Effect on teaching")
+    for name, effect, color in _LEVELS:
+        table.add_row(Text(name, style=f"bold {color}"), effect)
+    return table
+
+
+def _agents_table() -> Table:
+    table = Table(
+        title="Agents",
+        title_style="bold",
+        title_justify="left",
+        show_header=True,
+        header_style="bold",
+        expand=True,
+    )
+    table.add_column("Agent", style="cyan", no_wrap=True)
+    table.add_column("Specialty")
+    for name, spec in _AGENTS:
+        table.add_row(name, spec)
+    return table
+
+
+def _skills_table() -> Table:
+    table = Table(
+        title="Skills",
+        title_style="bold",
+        title_justify="left",
+        show_header=True,
+        header_style="bold",
+        expand=True,
+    )
+    table.add_column("Skill", style="cyan", no_wrap=True)
+    table.add_column("What it provides")
+    for name, desc in _SKILLS:
+        table.add_row(name, desc)
+    return table
+
+
+def _env_table() -> Table:
+    table = Table(
+        title="Environment",
+        title_style="bold",
+        title_justify="left",
+        show_header=True,
+        header_style="bold",
+        expand=True,
+    )
+    table.add_column("Variable", style="cyan", no_wrap=True)
+    table.add_column("Status", no_wrap=True)
+    table.add_column("Purpose")
+    for name, status, purpose in _ENV:
+        style = "bold red" if status == "required" else "dim"
+        table.add_row(name, Text(status, style=style), purpose)
+    return table
+
+
+def _footer() -> Text:
+    text = Text()
+    text.append("Tips: ", style="bold")
+    text.append("`adt <command> --help` shows every flag. ")
+    text.append("`adt ask --trace` adds a routing/LLM trace panel. ")
+    text.append("`adt stats` shows your supervised learning history.\n")
+    text.append("Docs: ", style="bold")
+    text.append("README.md · docs/architecture.md · docs/mcp.md · docs/agents.md")
+    return text
+
+
+class GuideRenderer:
+    """Render the static ``adt guide`` quick-reference."""
+
+    def __init__(self, console: Console | None = None) -> None:
+        self._console = console or Console()
+
+    def render(self) -> None:
+        """Print the quick-reference panel."""
+        header = Text()
+        header.append("adt ", style="bold cyan")
+        header.append(f"v{_package_version()}", style="dim")
+        header.append("\n")
+        header.append(_TAGLINE)
+
+        body = Group(
+            header,
+            Text(),
+            _commands_table(),
+            Text(),
+            _modes_table(),
+            Text(),
+            _levels_table(),
+            Text(),
+            _agents_table(),
+            Text(),
+            _skills_table(),
+            Text(),
+            _env_table(),
+            Text(),
+            _footer(),
+        )
+
+        self._console.print(
+            Panel(
+                body,
+                title="adt — Quick Reference",
+                border_style="cyan",
+                title_align="left",
+            ),
+        )

--- a/src/adt/cli/stats_renderer.py
+++ b/src/adt/cli/stats_renderer.py
@@ -1,0 +1,99 @@
+"""Rich-based renderer for :class:`LearningStats`."""
+
+from __future__ import annotations
+
+from rich.console import Console, Group
+from rich.panel import Panel
+from rich.text import Text
+
+from adt.analytics.stats import LearningStats
+
+
+class StatsRenderer:
+    """Render a :class:`LearningStats` summary as a terminal panel."""
+
+    def __init__(self, console: Console | None = None) -> None:
+        self._console = console or Console()
+
+    def render(self, stats: LearningStats) -> None:
+        """Print the stats panel."""
+        header = Text()
+        header.append(f"Sessions: {stats.sessions}".ljust(22), style="bold")
+        header.append(
+            f"Avg steps/session: {stats.avg_steps_per_session}",
+            style="bold",
+        )
+        header.append("\n")
+        header.append(f"Reviews:  {stats.reviews}".ljust(22), style="bold")
+        header.append(
+            f"Avg iterations/session: {stats.avg_iterations_per_step}",
+            style="bold",
+        )
+
+        sections: list[Text] = [header]
+
+        if stats.common_issues:
+            issues = Text()
+            issues.append("\n")
+            issues.append("Common Issues:\n", style="bold")
+            for rank, (name, count) in enumerate(stats.common_issues, start=1):
+                issues.append(f"  {rank}. ")
+                issues.append(name, style="yellow")
+                noun = "occurrence" if count == 1 else "occurrences"
+                issues.append(f" ({count} {noun})\n", style="dim")
+            sections.append(issues)
+
+        if stats.assessments:
+            verdict = Text()
+            verdict.append("\n")
+            verdict.append("Review Verdicts:\n", style="bold")
+            for name, count in sorted(stats.assessments.items(), key=lambda kv: -kv[1]):
+                verdict.append("  - ")
+                verdict.append(name, style=_verdict_style(name))
+                verdict.append(f" x{count}\n", style="dim")
+            sections.append(verdict)
+
+        if stats.improvement_trend:
+            trend = Text()
+            trend.append("\n")
+            trend.append("Improvement Trend:\n", style="bold")
+            trend.append("  Iterations per session: ")
+            arrow = " -> ".join(str(v) for v in stats.improvement_trend)
+            trend.append(arrow, style="cyan")
+            sections.append(trend)
+
+        if stats.total_tokens:
+            tokens = Text()
+            tokens.append("\n")
+            tokens.append("Total LLM tokens: ", style="bold")
+            tokens.append(f"{stats.total_tokens:,}", style="dim")
+            sections.append(tokens)
+
+        if stats.sessions == 0:
+            empty = Text()
+            empty.append("\n")
+            empty.append(
+                "No supervised learning events recorded yet. Run "
+                "`adt ask ... --mode supervised` or `adt review` first.",
+                style="dim",
+            )
+            sections.append(empty)
+
+        self._console.print(
+            Panel(
+                Group(*sections),
+                title="Learning Stats",
+                border_style="blue",
+                title_align="left",
+            ),
+        )
+
+
+def _verdict_style(name: str) -> str:
+    if name == "needs_work":
+        return "red"
+    if name == "on_track":
+        return "yellow"
+    if name == "excellent":
+        return "green"
+    return "white"

--- a/src/adt/review_session.py
+++ b/src/adt/review_session.py
@@ -157,6 +157,27 @@ def run_review(
         sess.record_feedback(feedback.overall_assessment)
         sess.save()
 
+        from adt.analytics import LearningEvent, categorize_issue, log_learning_event
+
+        error_types = [categorize_issue(issue) for issue in feedback.issues]
+        event = LearningEvent(
+            trace_id="",
+            component="reviewer",
+            event_type="code_review",
+            step_id=sess.current_step,
+            iteration_count=sess.iteration_count,
+            assessment=feedback.overall_assessment,
+            error_types=error_types,
+            completion_time_ms=None,
+            problem_summary=sess.problem_summary,
+            level=level,
+            data={
+                "issue_count": len(feedback.issues),
+                "file": str(path),
+            },
+        )
+        log_learning_event(event)
+
     log_adt(
         logger,
         logging.INFO,

--- a/tests/integration/test_learning_flow.py
+++ b/tests/integration/test_learning_flow.py
@@ -1,0 +1,190 @@
+"""Integration tests: supervised ask/review writes learning events."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from adt.analytics import read_learning_events
+from adt.ask_session import run_ask
+from adt.core.session import SessionContext
+from adt.models.schemas import (
+    AgentResponse,
+    CodeIssue,
+    LLMMessage,
+    ReviewFeedback,
+)
+from adt.review_session import run_review
+
+
+def _session_file(tmp_path: Path) -> Path:
+    return tmp_path / "session.json"
+
+
+def _redirect_adt_home(tmp_path: Path, monkeypatch) -> Path:
+    """Point the learning log + session file at a temporary directory."""
+    import logging as _logging
+
+    log_dir = tmp_path / "adt" / "logs"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_path = log_dir / "learning.jsonl"
+
+    # Drop any prior learning logger so a fresh handler binds to log_path.
+    learning_logger = _logging.getLogger("adt.learning")
+    for handler in list(learning_logger.handlers):
+        handler.close()
+        learning_logger.removeHandler(handler)
+
+    # Redirect the default log path into tmp.
+    monkeypatch.setattr(
+        "adt.analytics.logger.learning_log_path",
+        lambda lg_dir=None: log_path,
+    )
+
+    # Make session persistence point into tmp as well.
+    session_path = tmp_path / "session.json"
+    monkeypatch.setattr("adt.core.session.session_file_path", lambda: session_path)
+    if session_path.exists():
+        session_path.unlink()
+    return log_dir
+
+
+@patch.dict(os.environ, {"OPENAI_API_KEY": "sk-test"}, clear=False)
+@patch("adt.ask_session.build_runner")
+def test_supervised_ask_emits_learning_event(
+    mock_build: MagicMock, tmp_path: Path, monkeypatch
+) -> None:
+    log_dir = _redirect_adt_home(tmp_path, monkeypatch)
+
+    import json as _json
+
+    supervised_answer = _json.dumps(
+        {
+            "problem_summary": "Reverse a linked list in place.",
+            "total_steps": 3,
+            "current_step": {
+                "step_number": 1,
+                "goal": "Track the previous pointer",
+                "requirements": ["Use a while loop"],
+                "hints": ["What does prev point to after one iteration?"],
+                "questions": ["What is the loop invariant?"],
+            },
+            "progress_note": "",
+        }
+    )
+
+    mock_runner = MagicMock()
+    mock_runner.run.return_value = AgentResponse(
+        answer=supervised_answer,
+        tools_used=[],
+        context_summary="",
+        routed_agent="repo_agent",
+    )
+    mock_runner.last_token_usage = {"prompt_tokens": 120, "completion_tokens": 80}
+    mock_build.return_value = mock_runner
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    exe = run_ask(
+        query="Help me reverse a linked list",
+        repo=[str(repo)],
+        configure_logging=False,
+        mode="supervised",
+        level="beginner",
+    )
+    assert exe.supervised_response is not None
+
+    events = read_learning_events(path=log_dir / "learning.jsonl")
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.event_type == "supervised_step"
+    assert ev.component == "supervisor"
+    assert ev.step_id == 1
+    assert ev.level == "beginner"
+    assert "linked list" in ev.problem_summary.lower()
+    assert ev.data.get("prompt_tokens") == 120
+    assert ev.data.get("completion_tokens") == 80
+
+
+def _fake_llm_reply(feedback: ReviewFeedback) -> LLMMessage:
+    import json
+
+    payload = {
+        "issues": [i.model_dump() for i in feedback.issues],
+        "improvements": feedback.improvements,
+        "strengths": feedback.strengths,
+        "next_step": feedback.next_step,
+        "overall_assessment": feedback.overall_assessment,
+    }
+    return LLMMessage(role="assistant", content=json.dumps(payload))
+
+
+class _FakeLLM:
+    def __init__(self, reply: LLMMessage) -> None:
+        self._reply = reply
+
+    def chat(
+        self, messages: list[LLMMessage], tools: object
+    ) -> LLMMessage:  # pragma: no cover - trivial
+        return self._reply
+
+
+def test_review_emits_code_review_learning_event(tmp_path: Path, monkeypatch) -> None:
+    log_dir = _redirect_adt_home(tmp_path, monkeypatch)
+
+    # Preload a session so the event carries problem + step.
+    sess = SessionContext(
+        problem_summary="Implement binary search",
+        current_step=2,
+        total_steps=4,
+        iteration_count=1,
+    )
+
+    feedback = ReviewFeedback(
+        issues=[
+            CodeIssue(
+                line=7,
+                severity="warning",
+                description="Off-by-one error on the upper bound",
+                fix_hint="Should the right index be inclusive?",
+            ),
+            CodeIssue(
+                line=10,
+                severity="suggestion",
+                description="Variable name `x` is not descriptive",
+                fix_hint="What does `x` represent?",
+            ),
+        ],
+        improvements=["Consider an iterative version."],
+        strengths=["Function signature is clear."],
+        next_step="Fix the upper bound and rerun the test.",
+        overall_assessment="needs_work",
+    )
+    llm = _FakeLLM(_fake_llm_reply(feedback))
+
+    target = tmp_path / "solution.py"
+    target.write_text("def search(): pass\n", encoding="utf-8")
+
+    result = run_review(
+        file=target,
+        level="intermediate",
+        configure_logging=False,
+        llm=llm,
+        session=sess,
+    )
+    assert result.feedback is not None
+    assert result.feedback.overall_assessment == "needs_work"
+
+    events = read_learning_events(path=log_dir / "learning.jsonl")
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.event_type == "code_review"
+    assert ev.component == "reviewer"
+    assert ev.assessment == "needs_work"
+    assert ev.step_id == 2
+    assert ev.problem_summary == "Implement binary search"
+    assert "off_by_one" in ev.error_types
+    assert "naming" in ev.error_types
+    assert ev.data.get("issue_count") == 2

--- a/tests/unit/test_cli_guide.py
+++ b/tests/unit/test_cli_guide.py
@@ -1,0 +1,57 @@
+"""Smoke tests for the static ``adt guide`` quick-reference command."""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+from typer.testing import CliRunner
+
+from adt.cli.app import app
+from adt.cli.guide_renderer import GuideRenderer
+
+
+def test_guide_renderer_contains_all_sections() -> None:
+    buf = io.StringIO()
+    console = Console(file=buf, color_system=None, width=120, record=False)
+    GuideRenderer(console).render()
+    out = buf.getvalue()
+
+    # Top-level
+    assert "Quick Reference" in out
+    assert "supervised learning" in out.lower()
+
+    # Commands: one row per entry
+    for cmd in ("ask", "review", "stats", "serve", "guide", "config"):
+        assert cmd in out
+
+    # Modes
+    assert "execution" in out
+    assert "supervised" in out
+
+    # Levels
+    for lvl in ("beginner", "intermediate", "advanced"):
+        assert lvl in out
+
+    # Agents
+    for agent in ("repo_agent", "project_agent", "research_agent"):
+        assert agent in out
+
+    # Skills
+    assert "supervised_engineering" in out
+
+    # Environment
+    assert "OPENAI_API_KEY" in out
+    assert "GITHUB_TOKEN" in out
+
+
+def test_cli_guide_command_runs_without_api_key(monkeypatch) -> None:
+    # The guide must work even without any OpenAI key in the environment.
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    runner = CliRunner()
+    result = runner.invoke(app, ["guide"])
+    assert result.exit_code == 0
+    assert "Quick Reference" in result.stdout
+    assert "ask" in result.stdout
+    assert "supervised" in result.stdout
+    assert "stats" in result.stdout

--- a/tests/unit/test_cli_stats.py
+++ b/tests/unit/test_cli_stats.py
@@ -1,0 +1,77 @@
+"""Smoke tests for the ``adt stats`` CLI command."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from adt.analytics.events import LearningEvent
+from adt.cli.app import app
+
+
+def _write_sample_log(path: Path) -> None:
+    events = [
+        LearningEvent(
+            trace_id="t1",
+            component="supervisor",
+            event_type="supervised_step",
+            step_id=1,
+            iteration_count=1,
+            problem_summary="Reverse a linked list",
+            level="intermediate",
+        ),
+        LearningEvent(
+            trace_id="t2",
+            component="reviewer",
+            event_type="code_review",
+            step_id=1,
+            iteration_count=2,
+            assessment="needs_work",
+            error_types=["off_by_one"],
+            problem_summary="Reverse a linked list",
+            level="intermediate",
+        ),
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "\n".join(json.dumps(ev.model_dump(mode="json"), default=str) for ev in events)
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_cli_stats_empty_log(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        "adt.analytics.logger.learning_log_path",
+        lambda log_dir=None: tmp_path / "learning.jsonl",
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, ["stats"])
+    assert result.exit_code == 0
+    assert "Learning Stats" in result.stdout
+    assert "No supervised learning events" in result.stdout
+
+
+def test_cli_stats_with_events(tmp_path, monkeypatch) -> None:
+    target = tmp_path / "learning.jsonl"
+    _write_sample_log(target)
+    monkeypatch.setattr(
+        "adt.analytics.logger.learning_log_path",
+        lambda log_dir=None: target,
+    )
+    runner = CliRunner()
+    result = runner.invoke(app, ["stats"])
+    assert result.exit_code == 0
+    assert "Sessions: 1" in result.stdout
+    assert "Reviews:  1" in result.stdout
+    assert "off_by_one" in result.stdout
+    assert "needs_work" in result.stdout
+
+
+def test_cli_stats_rejects_non_positive_last() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["stats", "--last", "0"])
+    assert result.exit_code == 1
+    assert "positive" in result.stdout.lower()

--- a/tests/unit/test_learning_event.py
+++ b/tests/unit/test_learning_event.py
@@ -1,0 +1,75 @@
+"""Unit tests for :class:`LearningEvent` and ``categorize_issue``."""
+
+from __future__ import annotations
+
+from adt.analytics.events import LearningEvent, categorize_issue
+from adt.models.schemas import CodeIssue
+
+
+def _issue(description: str, severity: str = "warning") -> CodeIssue:
+    return CodeIssue(line=1, severity=severity, description=description, fix_hint="")
+
+
+def test_learning_event_defaults() -> None:
+    event = LearningEvent(
+        trace_id="t1",
+        component="supervisor",
+        event_type="supervised_step",
+    )
+    assert event.step_id == 0
+    assert event.iteration_count == 0
+    assert event.assessment == "n/a"
+    assert event.error_types == []
+    assert event.completion_time_ms is None
+    assert event.problem_summary == ""
+    assert event.level == "intermediate"
+
+
+def test_learning_event_full_payload_roundtrip() -> None:
+    event = LearningEvent(
+        trace_id="t2",
+        component="reviewer",
+        event_type="code_review",
+        step_id=3,
+        iteration_count=5,
+        assessment="on_track",
+        error_types=["off_by_one", "naming"],
+        completion_time_ms=1234,
+        problem_summary="Implement binary search",
+        level="advanced",
+        data={"issue_count": 2},
+    )
+    raw = event.model_dump(mode="json")
+    restored = LearningEvent.model_validate(raw)
+    assert restored.assessment == "on_track"
+    assert restored.error_types == ["off_by_one", "naming"]
+    assert restored.step_id == 3
+    assert restored.data["issue_count"] == 2
+
+
+def test_categorize_off_by_one() -> None:
+    assert categorize_issue(_issue("classic off-by-one error on loop bounds")) == (
+        "off_by_one"
+    )
+    assert categorize_issue(_issue("boundary condition missing")) == "off_by_one"
+
+
+def test_categorize_edge_case() -> None:
+    assert categorize_issue(_issue("does not handle empty list")) == "edge_case"
+    assert categorize_issue(_issue("negative input not considered")) == "edge_case"
+
+
+def test_categorize_naming_and_types() -> None:
+    assert categorize_issue(_issue("variable name is unclear")) == "naming"
+    assert categorize_issue(_issue("missing type hint on return")) == "type_annotation"
+
+
+def test_categorize_error_handling() -> None:
+    assert categorize_issue(_issue("should raise ValueError on bad input")) == (
+        "error_handling"
+    )
+
+
+def test_categorize_fallback_to_other() -> None:
+    assert categorize_issue(_issue("something weird going on")) == "other"
+    assert categorize_issue(_issue("")) == "other"

--- a/tests/unit/test_learning_logger.py
+++ b/tests/unit/test_learning_logger.py
@@ -1,0 +1,73 @@
+"""Unit tests for the rotating learning logger."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from adt.analytics.events import LearningEvent
+from adt.analytics.logger import (
+    LEARNING_LOG_NAME,
+    learning_log_path,
+    log_learning_event,
+    setup_learning_logger,
+)
+
+
+def _fresh_logger(tmp_path: Path) -> Path:
+    # Drop any cached handlers so each test starts with a clean logger.
+    log = logging.getLogger("adt.learning")
+    for handler in list(log.handlers):
+        handler.close()
+        log.removeHandler(handler)
+    return setup_learning_logger(log_dir=tmp_path)
+
+
+def test_learning_log_path_returns_name(tmp_path: Path) -> None:
+    assert learning_log_path(tmp_path).name == LEARNING_LOG_NAME
+
+
+def test_setup_learning_logger_is_idempotent(tmp_path: Path) -> None:
+    first = _fresh_logger(tmp_path)
+    second = setup_learning_logger(log_dir=tmp_path)
+    assert first == second
+    log = logging.getLogger("adt.learning")
+    # Only one rotating handler should be attached.
+    assert len(log.handlers) == 1
+
+
+def test_log_learning_event_writes_jsonl(tmp_path: Path) -> None:
+    _fresh_logger(tmp_path)
+    event = LearningEvent(
+        trace_id="t1",
+        component="supervisor",
+        event_type="supervised_step",
+        step_id=2,
+        iteration_count=1,
+        problem_summary="FizzBuzz",
+        level="beginner",
+    )
+    log_learning_event(event, log_dir=tmp_path)
+
+    target = tmp_path / LEARNING_LOG_NAME
+    assert target.exists()
+    lines = target.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload["trace_id"] == "t1"
+    assert payload["event_type"] == "supervised_step"
+    assert payload["step_id"] == 2
+    assert payload["problem_summary"] == "FizzBuzz"
+
+
+def test_log_learning_event_swallows_errors(tmp_path: Path, monkeypatch) -> None:
+    def boom(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("explode")
+
+    monkeypatch.setattr("adt.analytics.logger.setup_learning_logger", boom)
+    event = LearningEvent(
+        trace_id="t", component="supervisor", event_type="supervised_step"
+    )
+    # Must not raise even though setup blew up.
+    log_learning_event(event, log_dir=tmp_path)

--- a/tests/unit/test_learning_reader.py
+++ b/tests/unit/test_learning_reader.py
@@ -1,0 +1,66 @@
+"""Unit tests for :func:`read_learning_events`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from adt.analytics.events import LearningEvent
+from adt.analytics.reader import read_learning_events
+
+
+def _write_events(path: Path, count: int) -> list[LearningEvent]:
+    events: list[LearningEvent] = []
+    lines: list[str] = []
+    for i in range(count):
+        ev = LearningEvent(
+            trace_id=f"t{i}",
+            component="supervisor",
+            event_type="supervised_step",
+            step_id=i,
+            problem_summary=f"problem {i}",
+        )
+        events.append(ev)
+        lines.append(json.dumps(ev.model_dump(mode="json"), default=str))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return events
+
+
+def test_read_learning_events_missing_file(tmp_path: Path) -> None:
+    assert read_learning_events(path=tmp_path / "nope.jsonl") == []
+
+
+def test_read_learning_events_returns_all(tmp_path: Path) -> None:
+    target = tmp_path / "learning.jsonl"
+    written = _write_events(target, 3)
+    loaded = read_learning_events(path=target)
+    assert len(loaded) == 3
+    assert [e.trace_id for e in loaded] == [e.trace_id for e in written]
+
+
+def test_read_learning_events_limit(tmp_path: Path) -> None:
+    target = tmp_path / "learning.jsonl"
+    _write_events(target, 5)
+    loaded = read_learning_events(path=target, limit=2)
+    assert [e.trace_id for e in loaded] == ["t3", "t4"]
+
+
+def test_read_learning_events_skips_corrupted_lines(tmp_path: Path) -> None:
+    target = tmp_path / "learning.jsonl"
+    good = LearningEvent(
+        trace_id="ok", component="supervisor", event_type="supervised_step"
+    )
+    content = "\n".join(
+        [
+            "",  # blank
+            "{not json",  # malformed
+            "[1,2,3]",  # not a dict
+            json.dumps({"bogus": "shape"}),  # schema mismatch survives the base model
+            json.dumps(good.model_dump(mode="json"), default=str),
+        ]
+    )
+    target.write_text(content, encoding="utf-8")
+    loaded = read_learning_events(path=target)
+    # The bogus one has required fields missing, so it is also skipped.
+    assert len(loaded) == 1
+    assert loaded[0].trace_id == "ok"

--- a/tests/unit/test_learning_stats.py
+++ b/tests/unit/test_learning_stats.py
@@ -1,0 +1,132 @@
+"""Unit tests for :func:`compute_stats`."""
+
+from __future__ import annotations
+
+from adt.analytics.events import LearningEvent
+from adt.analytics.stats import LearningStats, compute_stats
+
+
+def _step(
+    problem: str,
+    *,
+    step_id: int,
+    iteration: int,
+    tokens: int = 0,
+    trace_id: str = "",
+) -> LearningEvent:
+    return LearningEvent(
+        trace_id=trace_id or f"s-{problem}-{step_id}",
+        component="supervisor",
+        event_type="supervised_step",
+        step_id=step_id,
+        iteration_count=iteration,
+        problem_summary=problem,
+        level="intermediate",
+        data={"prompt_tokens": tokens, "completion_tokens": tokens},
+    )
+
+
+def _review(
+    problem: str,
+    *,
+    step_id: int,
+    iteration: int,
+    assessment: str,
+    errors: list[str],
+) -> LearningEvent:
+    return LearningEvent(
+        trace_id=f"r-{problem}-{iteration}",
+        component="reviewer",
+        event_type="code_review",
+        step_id=step_id,
+        iteration_count=iteration,
+        assessment=assessment,
+        error_types=errors,
+        problem_summary=problem,
+        level="intermediate",
+    )
+
+
+def test_compute_stats_empty() -> None:
+    assert compute_stats([]) == LearningStats()
+
+
+def test_compute_stats_basic_grouping() -> None:
+    events = [
+        _step("FizzBuzz", step_id=1, iteration=1, tokens=100),
+        _step("FizzBuzz", step_id=2, iteration=2, tokens=200),
+        _review(
+            "FizzBuzz",
+            step_id=2,
+            iteration=3,
+            assessment="on_track",
+            errors=["off_by_one"],
+        ),
+        _step("Binary search", step_id=1, iteration=1, tokens=150),
+    ]
+    stats = compute_stats(events)
+
+    assert stats.sessions == 2
+    assert stats.reviews == 1
+    assert stats.supervised_steps == 3
+    # FizzBuzz max step = 2, Binary search max step = 1 -> avg 1.5
+    assert stats.avg_steps_per_session == 1.5
+    # FizzBuzz max iterations = 3, Binary search = 1 -> avg 2.0
+    assert stats.avg_iterations_per_step == 2.0
+    assert stats.assessments == {"on_track": 1}
+    # tokens: 100*2 + 200*2 + 150*2 = 900
+    assert stats.total_tokens == 900
+    assert ("off_by_one", 1) in stats.common_issues
+
+
+def test_compute_stats_improvement_trend_three_sessions() -> None:
+    events = [
+        _step("P1", step_id=1, iteration=6),
+        _step("P2", step_id=1, iteration=4),
+        _step("P3", step_id=1, iteration=2),
+    ]
+    stats = compute_stats(events)
+    assert stats.improvement_trend == [6.0, 4.0, 2.0]
+
+
+def test_compute_stats_last_n_filter() -> None:
+    events = [
+        _step("old-1", step_id=1, iteration=1),
+        _step("old-2", step_id=1, iteration=1),
+        _step("recent", step_id=3, iteration=5),
+    ]
+    stats = compute_stats(events, last_n=1)
+    assert stats.sessions == 1
+    assert stats.avg_steps_per_session == 3.0
+    assert stats.avg_iterations_per_step == 5.0
+
+
+def test_compute_stats_counts_common_issues_across_reviews() -> None:
+    events = [
+        _review(
+            "P1",
+            step_id=1,
+            iteration=1,
+            assessment="needs_work",
+            errors=["off_by_one", "naming"],
+        ),
+        _review(
+            "P1",
+            step_id=1,
+            iteration=2,
+            assessment="needs_work",
+            errors=["off_by_one"],
+        ),
+        _review(
+            "P2",
+            step_id=1,
+            iteration=1,
+            assessment="excellent",
+            errors=[],
+        ),
+    ]
+    stats = compute_stats(events)
+    counts = dict(stats.common_issues)
+    assert counts.get("off_by_one") == 2
+    assert counts.get("naming") == 1
+    assert stats.assessments == {"needs_work": 2, "excellent": 1}

--- a/tests/unit/test_stats_renderer.py
+++ b/tests/unit/test_stats_renderer.py
@@ -1,0 +1,63 @@
+"""Unit tests for :class:`StatsRenderer`."""
+
+from __future__ import annotations
+
+import io
+
+from rich.console import Console
+
+from adt.analytics.stats import LearningStats
+from adt.cli.stats_renderer import StatsRenderer
+
+
+def _render(stats: LearningStats) -> str:
+    buf = io.StringIO()
+    console = Console(file=buf, color_system=None, width=100, record=False)
+    StatsRenderer(console).render(stats)
+    return buf.getvalue()
+
+
+def test_stats_renderer_empty() -> None:
+    out = _render(LearningStats())
+    assert "Learning Stats" in out
+    assert "No supervised learning events" in out
+    assert "Sessions: 0" in out
+
+
+def test_stats_renderer_full_payload() -> None:
+    stats = LearningStats(
+        sessions=3,
+        reviews=2,
+        supervised_steps=5,
+        avg_steps_per_session=2.5,
+        avg_iterations_per_step=3.0,
+        common_issues=[("off_by_one", 4), ("naming", 2)],
+        improvement_trend=[5.0, 3.0, 2.0],
+        total_tokens=12345,
+        assessments={"needs_work": 1, "on_track": 1},
+    )
+    out = _render(stats)
+    assert "Sessions: 3" in out
+    assert "Reviews:  2" in out
+    assert "off_by_one" in out
+    assert "naming" in out
+    assert "Review Verdicts" in out
+    assert "needs_work" in out
+    assert "on_track" in out
+    assert "Improvement Trend" in out
+    assert "5.0 -> 3.0 -> 2.0" in out
+    assert "12,345" in out
+
+
+def test_stats_renderer_skips_empty_sections() -> None:
+    stats = LearningStats(
+        sessions=1,
+        reviews=0,
+        supervised_steps=1,
+        avg_steps_per_session=1.0,
+        avg_iterations_per_step=1.0,
+    )
+    out = _render(stats)
+    assert "Common Issues" not in out
+    assert "Review Verdicts" not in out
+    assert "Improvement Trend" not in out


### PR DESCRIPTION
## Summary

Closes **Phase 9.5 — Learning Analytics** from `ROADMAP_EXTENSION.md`
and ships two supporting changes that round out the supervised story:
a static `adt guide` cheat sheet and a full README rewrite covering
every Phase 8 + Phase 9 capability.

### 1. Learning analytics (Phase 9.5)

- New `src/adt/analytics/` package: `LearningEvent` (extends
  `TraceEvent`), `categorize_issue()` classifier, rotating JSONL
  logger at `~/.adt/logs/learning.jsonl`, resilient reader,
  `compute_stats()` aggregator.
- New `adt stats [--last N]` CLI command with a color-coded Rich
  panel (`StatsRenderer`) showing sessions, review verdicts, common
  issue categories, improvement trend, and total tokens.
- `ask_session.run_ask` emits a `supervised_step` event per
  supervised run; `review_session.run_review` emits a `code_review`
  event per review with categorized issues and assessment.
- Best-effort logging: analytics failures never break the user's
  command.

### 2. `adt guide` (offline cheat sheet)

- New `GuideRenderer` prints one Rich panel with six tables
  (Commands, Modes, Levels, Agents, Skills, Environment).
- No network calls, no config reads, no API key required. Think
  of it as `?` in Claude Code — the fastest way to see what `adt`
  can do right after `pip install agentic-dev-tool`.

### 3. README rewrite

- New Mermaid architecture diagram with Supervised and
  Tracing+Analytics subgraphs.
- New Usage sub-sections for supervised mode, code review,
  tracing, stats, and guide.
- New "File layout and state" and "Skills" sections.
- Commands table + Common flags list updated for Phase 8/9.

## Test plan

- [x] `pytest` → 330 passed (+32 new tests), 2 deselected
- [x] `ruff check src/ tests/` → clean
- [x] `ruff format --check src/ tests/` → clean
- [x] `mypy src/` → no issues in 60 source files
- [x] Coverage: 88.10% (new modules at 93-100%)
- [x] Manual smoke: `adt guide`, `adt stats`, `adt stats --last 5`,
  `adt review <file>` (with FakeLLM via integration test)

## Rollout

- Branch: `feat/supervised-observability`
- Merge strategy: **squash** (matches repo convention)
- Milestone: **Phase 9 — Supervised Mode**
- Tag after merge: `v0.9.4-supervised-analytics`
- Release: **No** (internal + docs polish; next user-facing
  release will be the Phase 10 umbrella)