### PR TITLE
feat(core): add structural hardening (Phase 10.2)

### DIFF
--- a/src/adt/analytics/events.py
+++ b/src/adt/analytics/events.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
 from adt.models.schemas import CodeIssue
-from adt.tracing.events import TraceEvent
 
 _CATEGORY_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
     (
@@ -68,31 +72,38 @@ def categorize_issue(issue: CodeIssue) -> str:
     return "other"
 
 
-class LearningEvent(TraceEvent):
-    """Trace event specific to supervised learning sessions.
+class LearningEvent(BaseModel):
+    """Standalone event for supervised learning analytics (schema v2).
 
-    Extends :class:`~adt.tracing.events.TraceEvent` with fields describing
-    a single pedagogical interaction. Each supervised ``ask`` emits one
-    ``supervised_step`` event and each ``review`` emits one ``code_review``
-    event. They share a trace id per CLI invocation but can be correlated
-    across invocations via ``problem_summary``.
+    Decoupled from :class:`~adt.tracing.events.TraceEvent` so that review
+    events are not forced to carry an empty ``trace_id``.
 
     Attributes:
-        step_id: 1-based step the user is on in the current supervised
-            session. ``0`` when not applicable (e.g. session not started).
-        iteration_count: Number of commands executed against this session
-            so far, including the current one.
-        assessment: Review verdict (``needs_work`` / ``on_track`` /
-            ``excellent``) for review events; ``"n/a"`` for pure
-            step-guidance events.
-        error_types: Coarse categories of issues found during a review
-            (empty for non-review events).
-        completion_time_ms: Wall clock time taken to produce this event's
-            payload, in milliseconds. ``None`` when unavailable.
-        problem_summary: Free-text restatement of the problem the user is
-            working on. Used to group events into sessions.
-        level: Difficulty level at the moment the event was emitted.
+        trace_id: Trace correlation id (``None`` for review-only events).
+        session_name: Named session this event belongs to (``None`` for
+            legacy v1 events).
+        timestamp: UTC timestamp (auto-generated).
+        component: Emitting component (``supervisor`` or ``reviewer``).
+        event_type: ``supervised_step`` or ``code_review``.
+        iteration: Optional loop iteration number.
+        data: Arbitrary key-value pairs (token counts, etc.).
+        step_id: 1-based step the user is on.
+        iteration_count: Commands executed against this session so far.
+        assessment: Review verdict or ``"n/a"`` for step-guidance events.
+        error_types: Coarse issue categories from the reviewer.
+        completion_time_ms: Wall clock time in milliseconds.
+        problem_summary: Free-text problem description (session grouping key).
+        level: Difficulty level at emit time.
+        schema_version: ``2`` for new events; reader tolerates ``1``.
     """
+
+    trace_id: str | None = None
+    session_name: str | None = None
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    component: str = ""
+    event_type: str = ""
+    iteration: int | None = None
+    data: dict[str, Any] = Field(default_factory=dict)
 
     step_id: int = 0
     iteration_count: int = 0
@@ -101,3 +112,4 @@ class LearningEvent(TraceEvent):
     completion_time_ms: int | None = None
     problem_summary: str = ""
     level: str = "intermediate"
+    schema_version: int = 2

--- a/src/adt/analytics/stats.py
+++ b/src/adt/analytics/stats.py
@@ -51,7 +51,11 @@ def _mean(values: list[float]) -> float:
 
 def _session_key(event: LearningEvent) -> str:
     key = (event.problem_summary or "").strip().lower()
-    return key or f"trace:{event.trace_id}"
+    if key:
+        return key
+    if event.session_name:
+        return f"session:{event.session_name}"
+    return f"trace:{event.trace_id or 'unknown'}"
 
 
 def compute_stats(

--- a/src/adt/ask_session.py
+++ b/src/adt/ask_session.py
@@ -10,7 +10,6 @@ from typing import Any
 from adt.bootstrap import build_runner
 from adt.config import apply_env_overrides, load_config_file
 from adt.core.runner import Runner
-from adt.core.session import SessionContext
 from adt.logging.json_log import setup_adt_file_logging
 from adt.models.schemas import AgentResponse, QueryRequest, SupervisedResponse
 from adt.repo_spec import resolve_repo_targets
@@ -48,6 +47,7 @@ def run_ask(
     trace: bool = False,
     mode: str = "execution",
     level: str = "intermediate",
+    session_name: str = "default",
 ) -> AskExecution:
     """Resolve repos, build a :class:`~adt.core.runner.Runner`, and run the query.
 
@@ -147,17 +147,21 @@ def run_ask(
 
         supervised_resp = parse_supervised_response(response.answer)
         if supervised_resp is not None:
-            sess = SessionContext.load()
+            from adt.core.session_store import SessionStore
+
+            store = SessionStore()
+            sess = store.load(session_name)
             sess.update_from_supervised(supervised_resp)
-            sess.save()
+            store.save(sess, session_name)
 
             usage = runner.last_token_usage or {}
-            trace_id = trace_ctx.trace_id if trace_ctx is not None else ""
+            trace_id = trace_ctx.trace_id if trace_ctx is not None else None
             completion_ms: int | None = None
             if trace_ctx is not None:
                 completion_ms = int(trace_ctx.elapsed_ms())
             event = LearningEvent(
                 trace_id=trace_id,
+                session_name=session_name,
                 component="supervisor",
                 event_type="supervised_step",
                 step_id=supervised_resp.current_step.step_number,

--- a/src/adt/bootstrap.py
+++ b/src/adt/bootstrap.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from adt.agents.base import BaseAgent
 
 if TYPE_CHECKING:
+    from adt.core.runner_config import RunnerConfig
     from adt.tracing.context import TraceContext
 from adt.agents.project_agent import ProjectAgent
 from adt.agents.repo_agent import RepoAgent
@@ -458,7 +459,7 @@ def register_project_tools(
 
 
 def build_runner(
-    repo_roots: Path | dict[str, Path],
+    repo_roots_or_config: Path | dict[str, Path] | RunnerConfig,
     *,
     markdown_root: Path | None = None,
     primary_repo_key: str | None = None,
@@ -476,24 +477,33 @@ def build_runner(
 ) -> Runner:
     """Construct a :class:`~adt.core.runner.Runner` for the full agent/tool set.
 
-    Args:
-        repo_roots: Single path or map of session ids (``r0``, …) to repo roots.
-        markdown_root: Base for ``read_markdown`` (defaults to primary repo root).
-        primary_repo_key: Default repo id for tools (defaults to first key).
-        model: OpenAI chat model name.
-        api_key: Optional API key (falls back to ``OPENAI_API_KEY`` in the client).
-        github_token: Optional token forwarded to GitHub REST tools.
-        max_tool_iterations: Upper bound on LLM/tool round-trips.
-        use_context_cache: When True, cache repository tree listings on disk.
-        context_cache_ttl: Override tree cache TTL (seconds).
-        token_budget_total: Override logical token window for context budgeting.
-        use_llm_routing: When True, classify intent with a small JSON LLM call first.
-        routing_model: Model name for routing (defaults to ``model``).
-        agent_chain: When non-empty and ``force_agent`` is unset, run this sequence.
+    Accepts either a :class:`~adt.core.runner_config.RunnerConfig` as the
+    single positional argument **or** the legacy keyword arguments.
 
     Returns:
         A runner with repo, research, and project tools registered.
     """
+    from adt.core.runner_config import RunnerConfig
+
+    if isinstance(repo_roots_or_config, RunnerConfig):
+        cfg = repo_roots_or_config
+        repo_roots: Path | dict[str, Path] = cfg.repo_roots
+        markdown_root = cfg.markdown_root
+        primary_repo_key = cfg.primary_repo_key
+        model = cfg.model
+        api_key = cfg.api_key
+        github_token = cfg.github_token
+        max_tool_iterations = cfg.max_tool_iterations
+        use_context_cache = cfg.use_context_cache
+        context_cache_ttl = cfg.context_cache_ttl
+        token_budget_total = cfg.token_budget_total
+        use_llm_routing = cfg.use_llm_routing
+        routing_model = cfg.routing_model
+        agent_chain = list(cfg.agent_chain)
+        trace = cfg.trace
+    else:
+        repo_roots = repo_roots_or_config
+
     if isinstance(repo_roots, Path):
         roots_map: dict[str, Path] = {"r0": repo_roots.resolve()}
         pk = "r0"

--- a/src/adt/cli/app.py
+++ b/src/adt/cli/app.py
@@ -229,6 +229,13 @@ def ask_cmd(
             ),
         ),
     ] = None,
+    session: Annotated[
+        str,
+        typer.Option(
+            "--session",
+            help="Named session to use for supervised mode (default: 'default').",
+        ),
+    ] = "default",
 ) -> None:
     """Ask a question: supervisor picks an agent unless ``--agent`` is set."""
     valid_modes = {"execution", "supervised"}
@@ -273,6 +280,7 @@ def ask_cmd(
             trace=trace,
             mode=mode,
             level=effective_level,
+            session_name=session,
         )
     except AskConfigurationError as exc:
         console.print(f"[red]{exc}[/red]")
@@ -297,9 +305,9 @@ def ask_cmd(
             level=exe.supervised_level,
         )
         # P10-01: show last-review verdict footer when a previous feedback exists
-        from adt.core.session import SessionContext
+        from adt.core.session_store import SessionStore
 
-        sess = SessionContext.load()
+        sess = SessionStore().load(session)
         if sess.previous_feedback:
             last_verdict = sess.previous_feedback[-1]
             console.print(
@@ -364,6 +372,13 @@ def review_cmd(
             help="Override the maximum file size for review (in bytes).",
         ),
     ] = None,
+    session: Annotated[
+        str,
+        typer.Option(
+            "--session",
+            help="Named session to use (default: 'default').",
+        ),
+    ] = "default",
 ) -> None:
     """Review a source file in supervised mode and print structured feedback."""
     valid_levels = {"beginner", "intermediate", "advanced"}
@@ -382,6 +397,7 @@ def review_cmd(
             model=model,
             verbose=verbose,
             max_bytes=max_bytes,
+            session_name=session,
         )
     except ReviewConfigurationError as exc:
         console.print(f"[red]{exc}[/red]")
@@ -437,37 +453,59 @@ def stats_cmd(
     StatsRenderer(console).render(stats)
 
 
-# ── session subcommands (P10-03) ──────────────────────────────────────
+# ── session subcommands (P10-03 / P10-06) ────────────────────────────
 
 
 @session_app.command("show")
-def session_show_cmd() -> None:
-    """Print the current supervised session as a Rich table."""
+def session_show_cmd(
+    name: Annotated[
+        str,
+        typer.Option("--name", "-n", help="Session name to inspect."),
+    ] = "default",
+) -> None:
+    """Print a supervised session as a Rich table."""
     from adt.cli.session_renderer import SessionRenderer
-    from adt.core.session import SessionContext
+    from adt.core.session_store import SessionStore
 
-    sess = SessionContext.load()
+    sess = SessionStore().load(name)
     SessionRenderer(console).render(sess)
+
+
+@session_app.command("list")
+def session_list_cmd() -> None:
+    """List all named sessions."""
+    from adt.core.session_store import SessionStore
+
+    names = SessionStore().list()
+    if not names:
+        console.print("[dim]No sessions found.[/dim]")
+        return
+    for n in names:
+        console.print(f"  {n}")
 
 
 @session_app.command("clear")
 def session_clear_cmd(
+    name: Annotated[
+        str,
+        typer.Option("--name", "-n", help="Session name to delete."),
+    ] = "default",
     yes: Annotated[
         bool,
         typer.Option("--yes", "-y", help="Skip confirmation prompt."),
     ] = False,
 ) -> None:
-    """Delete the current session file (~/.adt/session.json)."""
-    from adt.core.session import SessionContext, session_file_path
+    """Delete a named session file."""
+    from adt.core.session_store import SessionStore
 
-    path = session_file_path()
-    if not path.exists():
-        console.print("[dim]No session file found — nothing to clear.[/dim]")
+    store = SessionStore()
+    if not store.path(name).exists():
+        console.print(f"[dim]No session '{name}' found — nothing to clear.[/dim]")
         return
     if not yes:
-        typer.confirm("Delete the current supervised session?", abort=True)
-    SessionContext.reset()
-    console.print("[green]Session cleared.[/green]")
+        typer.confirm(f"Delete session '{name}'?", abort=True)
+    store.delete(name)
+    console.print(f"[green]Session '{name}' cleared.[/green]")
 
 
 @session_app.command("export")
@@ -476,13 +514,18 @@ def session_export_cmd(
         str | None,
         typer.Argument(help="Output path (omit to print to stdout)."),
     ] = None,
+    name: Annotated[
+        str,
+        typer.Option("--name", "-n", help="Session name to export."),
+    ] = "default",
 ) -> None:
     """Dump the session JSON to stdout or a file."""
-    from adt.core.session import session_file_path
+    from adt.core.session_store import SessionStore
 
-    path = session_file_path()
+    store = SessionStore()
+    path = store.path(name)
     if not path.exists():
-        console.print("[dim]No session file found.[/dim]")
+        console.print(f"[dim]No session '{name}' found.[/dim]")
         raise typer.Exit(code=1)
     content = path.read_text(encoding="utf-8")
     if out is None:

--- a/src/adt/core/runner_config.py
+++ b/src/adt/core/runner_config.py
@@ -1,0 +1,40 @@
+"""Pydantic model collecting every parameter for :func:`build_runner`.
+
+Replaces the 13+ keyword arguments with a single validated object,
+making the call-site readable and enabling config-driven construction.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class RunnerConfig(BaseModel):
+    """All parameters needed to construct a :class:`~adt.core.runner.Runner`."""
+
+    repo_roots: dict[str, Path] | Path
+    markdown_root: Path | None = None
+    primary_repo_key: str | None = None
+    model: str = "gpt-4o-mini"
+    api_key: str | None = None
+    github_token: str | None = None
+    max_tool_iterations: int = 5
+    use_context_cache: bool = True
+    context_cache_ttl: float | None = None
+    token_budget_total: int | None = None
+    use_llm_routing: bool = True
+    routing_model: str | None = None
+    agent_chain: list[str] = Field(default_factory=list)
+    trace: Any = None  # TraceContext | None — Any avoids circular import
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @classmethod
+    def from_legacy(
+        cls, repo_roots: Path | dict[str, Path], **kwargs: Any
+    ) -> RunnerConfig:
+        """Build from the legacy positional + keyword calling convention."""
+        return cls(repo_roots=repo_roots, **kwargs)

--- a/src/adt/core/session_store.py
+++ b/src/adt/core/session_store.py
@@ -1,0 +1,102 @@
+"""Named session store backed by ``~/.adt/sessions/<slug>.json``.
+
+Replaces the global ``session.json`` with per-name files so multiple
+terminals (or problems) can each maintain their own supervised state.
+On first access the store migrates the legacy ``session.json`` into
+``sessions/default.json`` (best-effort, non-destructive).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+from pathlib import Path
+
+from adt.config import ensure_adt_dir
+from adt.core.session import SessionContext
+from adt.logging.json_log import log_adt
+
+logger = logging.getLogger(__name__)
+
+_SLUG_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
+
+
+def _sanitize_slug(name: str) -> str:
+    """Return a safe filename slug or raise :class:`ValueError`."""
+    slug = name.strip().lower().replace(" ", "-")
+    if not slug:
+        msg = "Session name must not be empty."
+        raise ValueError(msg)
+    if ".." in slug or "/" in slug or "\\" in slug:
+        msg = f"Session name {name!r} contains path traversal characters."
+        raise ValueError(msg)
+    if not _SLUG_RE.match(slug):
+        msg = (
+            f"Session name {name!r} is invalid. "
+            "Use alphanumeric characters, hyphens, or underscores (1-64 chars)."
+        )
+        raise ValueError(msg)
+    return slug
+
+
+class SessionStore:
+    """Manage per-name session files under ``~/.adt/sessions/``."""
+
+    def __init__(self, base_dir: Path | None = None) -> None:
+        self._base = base_dir if base_dir is not None else ensure_adt_dir() / "sessions"
+        self._base.mkdir(parents=True, exist_ok=True)
+        self._migrate_legacy()
+
+    # ── public API ──────────────────────────────────────────────────────
+
+    def list(self) -> list[str]:
+        """Return sorted session names (stem of each ``.json`` file)."""
+        return sorted(p.stem for p in self._base.glob("*.json"))
+
+    def load(self, name: str = "default") -> SessionContext:
+        """Load a session by name; return empty context if missing."""
+        return SessionContext.load(self.path(name))
+
+    def save(self, ctx: SessionContext, name: str = "default") -> None:
+        """Persist *ctx* under the given name."""
+        ctx.save(self.path(name))
+
+    def delete(self, name: str) -> None:
+        """Remove a named session file (no-op if missing)."""
+        p = self.path(name)
+        if p.exists():
+            p.unlink()
+
+    def path(self, name: str) -> Path:
+        """Return the file path for a named session."""
+        slug = _sanitize_slug(name)
+        return self._base / f"{slug}.json"
+
+    # ── migration ───────────────────────────────────────────────────────
+
+    def _migrate_legacy(self) -> None:
+        """Move ``~/.adt/session.json`` → ``sessions/default.json`` once."""
+        legacy = self._base.parent / "session.json"
+        target = self._base / "default.json"
+        if not legacy.exists() or target.exists():
+            return
+        try:
+            # Keep a backup of the original file
+            backup = legacy.with_suffix(".json.bak")
+            shutil.copy2(legacy, backup)
+            shutil.move(str(legacy), str(target))
+            log_adt(
+                logger,
+                logging.INFO,
+                event="session_migrated",
+                source=str(legacy),
+                target=str(target),
+            )
+        except OSError as exc:
+            log_adt(
+                logger,
+                logging.WARNING,
+                event="session_migration_failed",
+                error=str(exc),
+            )

--- a/src/adt/core/supervised_supervisor.py
+++ b/src/adt/core/supervised_supervisor.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from adt.skills.context import SkillContext
 
 from adt.core.level_config import format_level_directives, get_level_config
 from adt.logging.json_log import log_adt
@@ -15,7 +18,7 @@ from adt.models.schemas import (
     SupervisedResponse,
     SupervisedStep,
 )
-from adt.skills.supervised_engineering import load_skill_content
+from adt.skills.supervised_engineering.loader import load_skill_context
 
 _SKILL_HEADER = (
     "## Skill: Supervised Engineering\n"
@@ -73,15 +76,24 @@ def build_supervised_system_prompt(
     level: str,
     *,
     skill_content: str | None = None,
+    skill_ctx: SkillContext | None = None,
 ) -> str:
     """Return the system prompt with skill, level directives, and difficulty.
 
     Args:
         level: Difficulty level (``beginner`` / ``intermediate`` / ``advanced``).
-        skill_content: Optional override for the supervised engineering skill
-            body. When ``None``, the packaged ``SKILL.md`` is loaded at runtime.
+        skill_content: Optional raw markdown override (legacy callers / tests).
+        skill_ctx: A :class:`~adt.skills.context.SkillContext` instance. Takes
+            precedence over *skill_content*. When both are ``None`` the
+            packaged ``SKILL.md`` is loaded at runtime.
     """
-    skill = skill_content if skill_content is not None else load_skill_content()
+    if skill_ctx is not None:
+        skill = skill_ctx.markdown
+    elif skill_content is not None:
+        skill = skill_content
+    else:
+        ctx = load_skill_context()
+        skill = ctx.markdown
     cfg = get_level_config(_coerce_level(level))
     directives = format_level_directives(cfg)
     base = _SUPERVISED_SYSTEM_PROMPT.format(level=level)
@@ -210,15 +222,23 @@ def build_review_system_prompt(
     level: str,
     *,
     skill_content: str | None = None,
+    skill_ctx: SkillContext | None = None,
 ) -> str:
     """Return the review system prompt with skill, level directives, and level.
 
     Args:
         level: Difficulty level (``beginner`` / ``intermediate`` / ``advanced``).
-        skill_content: Optional override for the supervised engineering skill
-            body. When ``None``, the packaged ``SKILL.md`` is loaded at runtime.
+        skill_content: Optional raw markdown override (legacy callers / tests).
+        skill_ctx: A :class:`~adt.skills.context.SkillContext` instance. Takes
+            precedence over *skill_content*.
     """
-    skill = skill_content if skill_content is not None else load_skill_content()
+    if skill_ctx is not None:
+        skill = skill_ctx.markdown
+    elif skill_content is not None:
+        skill = skill_content
+    else:
+        ctx = load_skill_context()
+        skill = ctx.markdown
     cfg = get_level_config(_coerce_level(level))
     directives = format_level_directives(cfg)
     base = _REVIEW_SYSTEM_PROMPT.format(level=level)

--- a/src/adt/review_session.py
+++ b/src/adt/review_session.py
@@ -54,6 +54,7 @@ def run_review(
     llm: LLMBackend | None = None,
     session: SessionContext | None = None,
     max_bytes: int | None = None,
+    session_name: str = "default",
 ) -> ReviewExecution:
     """Read ``file``, send it to the reviewer LLM, return parsed feedback.
 
@@ -104,7 +105,12 @@ def run_review(
         setup_adt_file_logging(level=lvl)
         logging.getLogger("adt").setLevel(lvl)
 
-    sess = session if session is not None else SessionContext.load()
+    if session is not None:
+        sess = session
+    else:
+        from adt.core.session_store import SessionStore
+
+        sess = SessionStore().load(session_name)
 
     if llm is None:
         api_key = os.environ.get("OPENAI_API_KEY")
@@ -157,13 +163,19 @@ def run_review(
     feedback = parse_review_feedback(raw_answer)
     if feedback is not None:
         sess.record_feedback(feedback.overall_assessment)
-        sess.save()
+        if session is None:
+            from adt.core.session_store import SessionStore as _SS
+
+            _SS().save(sess, session_name)
+        else:
+            sess.save()
 
         from adt.analytics import LearningEvent, categorize_issue, log_learning_event
 
         error_types = [categorize_issue(issue) for issue in feedback.issues]
         event = LearningEvent(
-            trace_id="",
+            trace_id=None,
+            session_name=session_name,
             component="reviewer",
             event_type="code_review",
             step_id=sess.current_step,

--- a/src/adt/skills/context.py
+++ b/src/adt/skills/context.py
@@ -1,0 +1,34 @@
+"""Formal context model for loaded skills.
+
+Each skill is represented by a :class:`SkillContext` carrying the parsed
+Markdown body, a version string, and an optional variables dict that
+prompt builders can substitute via ``str.format(**variables)``.
+"""
+
+from __future__ import annotations
+
+import re
+
+from pydantic import BaseModel, ConfigDict
+
+_VERSION_RE = re.compile(r"<!--\s*version:\s*(\S+)\s*-->")
+
+
+class SkillContext(BaseModel):
+    """Typed envelope for a loaded skill document."""
+
+    name: str
+    markdown: str
+    variables: dict[str, str] = {}  # noqa: RUF012
+    version: str = "0"
+
+    model_config = ConfigDict(extra="forbid")
+
+
+def parse_version(markdown: str) -> str:
+    """Extract version from a ``<!-- version: X -->`` HTML comment.
+
+    Returns ``"0"`` when no version comment is found.
+    """
+    match = _VERSION_RE.search(markdown)
+    return match.group(1) if match else "0"

--- a/src/adt/skills/supervised_engineering/SKILL.md
+++ b/src/adt/skills/supervised_engineering/SKILL.md
@@ -1,3 +1,4 @@
+<!-- version: 1 -->
 # Supervised Engineering Skill
 
 This skill drives the supervised learning mode of `adt`. It is loaded at

--- a/src/adt/skills/supervised_engineering/loader.py
+++ b/src/adt/skills/supervised_engineering/loader.py
@@ -11,8 +11,12 @@ from __future__ import annotations
 import logging
 from importlib import resources
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from adt.logging.json_log import log_adt
+
+if TYPE_CHECKING:
+    from adt.skills.context import SkillContext
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +100,26 @@ def load_skill_content(
     if use_cache:
         _cache = content
     return content
+
+
+def load_skill_context(
+    *,
+    path: Path | None = None,
+    use_cache: bool = True,
+) -> SkillContext:
+    """Return a :class:`~adt.skills.context.SkillContext` for this skill.
+
+    Wraps :func:`load_skill_content` and parses the version comment
+    from the Markdown header.
+    """
+    from adt.skills.context import SkillContext, parse_version
+
+    markdown = load_skill_content(path=path, use_cache=use_cache)
+    return SkillContext(
+        name=SKILL_NAME,
+        markdown=markdown,
+        version=parse_version(markdown),
+    )
 
 
 def reset_cache() -> None:

--- a/tests/unit/test_learning_reader.py
+++ b/tests/unit/test_learning_reader.py
@@ -55,12 +55,13 @@ def test_read_learning_events_skips_corrupted_lines(tmp_path: Path) -> None:
             "",  # blank
             "{not json",  # malformed
             "[1,2,3]",  # not a dict
-            json.dumps({"bogus": "shape"}),  # schema mismatch survives the base model
+            json.dumps({"bogus": "shape"}),  # all-defaults model, parses OK
             json.dumps(good.model_dump(mode="json"), default=str),
         ]
     )
     target.write_text(content, encoding="utf-8")
     loaded = read_learning_events(path=target)
-    # The bogus one has required fields missing, so it is also skipped.
-    assert len(loaded) == 1
-    assert loaded[0].trace_id == "ok"
+    # {"bogus": "shape"} parses with defaults (schema v2 has no required fields).
+    # blank, malformed JSON, and non-dict lines are skipped.
+    assert len(loaded) == 2
+    assert loaded[-1].trace_id == "ok"

--- a/tests/unit/test_phase10_quickwins.py
+++ b/tests/unit/test_phase10_quickwins.py
@@ -10,6 +10,7 @@ Covers:
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -22,8 +23,13 @@ from adt.cli.app import app
 runner = CliRunner()
 
 
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape sequences from *text*."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
 def _seed_session(path: Path, **overrides: object) -> None:
-    """Write a synthetic ``session.json``."""
+    """Write a synthetic session JSON file."""
     data = {
         "problem_summary": "Binary search",
         "current_step": 3,
@@ -141,23 +147,25 @@ class TestWarnOnce:
 # ── P10-03: adt session subcommands ─────────────────────────────────────
 
 
+def _patch_session_store(monkeypatch, tmp_path):
+    """Point ``SessionStore`` to *tmp_path* so tests never touch ``~/.adt``."""
+    monkeypatch.setattr(
+        "adt.core.session_store.ensure_adt_dir",
+        lambda: tmp_path,
+    )
+
+
 class TestSessionShow:
     def test_show_empty(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "adt.core.session.session_file_path",
-            lambda: tmp_path / "session.json",
-        )
+        _patch_session_store(monkeypatch, tmp_path)
         result = runner.invoke(app, ["session", "show"])
         assert result.exit_code == 0
         assert "No active supervised session" in result.stdout
 
     def test_show_with_session(self, tmp_path, monkeypatch):
-        sf = tmp_path / "session.json"
+        _patch_session_store(monkeypatch, tmp_path)
+        sf = tmp_path / "sessions" / "default.json"
         _seed_session(sf)
-        monkeypatch.setattr(
-            "adt.core.session.session_file_path",
-            lambda: sf,
-        )
         result = runner.invoke(app, ["session", "show"])
         assert result.exit_code == 0
         assert "Binary search" in result.stdout
@@ -167,22 +175,16 @@ class TestSessionShow:
 
 class TestSessionClear:
     def test_clear_with_confirm(self, tmp_path, monkeypatch):
-        sf = tmp_path / "session.json"
+        _patch_session_store(monkeypatch, tmp_path)
+        sf = tmp_path / "sessions" / "default.json"
         _seed_session(sf)
-        monkeypatch.setattr(
-            "adt.core.session.session_file_path",
-            lambda: sf,
-        )
         result = runner.invoke(app, ["session", "clear", "--yes"])
         assert result.exit_code == 0
         assert "cleared" in result.stdout.lower()
         assert not sf.exists()
 
     def test_clear_no_file(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "adt.core.session.session_file_path",
-            lambda: tmp_path / "session.json",
-        )
+        _patch_session_store(monkeypatch, tmp_path)
         result = runner.invoke(app, ["session", "clear"])
         assert result.exit_code == 0
         assert "nothing to clear" in result.stdout.lower()
@@ -190,23 +192,17 @@ class TestSessionClear:
 
 class TestSessionExport:
     def test_export_to_stdout(self, tmp_path, monkeypatch):
-        sf = tmp_path / "session.json"
+        _patch_session_store(monkeypatch, tmp_path)
+        sf = tmp_path / "sessions" / "default.json"
         _seed_session(sf)
-        monkeypatch.setattr(
-            "adt.core.session.session_file_path",
-            lambda: sf,
-        )
         result = runner.invoke(app, ["session", "export"])
         assert result.exit_code == 0
         assert "Binary search" in result.stdout
 
     def test_export_to_file(self, tmp_path, monkeypatch):
-        sf = tmp_path / "session.json"
+        _patch_session_store(monkeypatch, tmp_path)
+        sf = tmp_path / "sessions" / "default.json"
         _seed_session(sf)
-        monkeypatch.setattr(
-            "adt.core.session.session_file_path",
-            lambda: sf,
-        )
         out = tmp_path / "out.json"
         result = runner.invoke(app, ["session", "export", str(out)])
         assert result.exit_code == 0
@@ -215,10 +211,7 @@ class TestSessionExport:
         assert data["problem_summary"] == "Binary search"
 
     def test_export_no_file(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "adt.core.session.session_file_path",
-            lambda: tmp_path / "session.json",
-        )
+        _patch_session_store(monkeypatch, tmp_path)
         result = runner.invoke(app, ["session", "export"])
         assert result.exit_code == 1
 
@@ -280,4 +273,4 @@ class TestReviewMaxBytes:
     def test_cli_max_bytes_flag_exists(self):
         """The --max-bytes flag is present in the review command help."""
         result = runner.invoke(app, ["review", "--help"])
-        assert "--max-bytes" in result.stdout
+        assert "--max-bytes" in _strip_ansi(result.stdout)

--- a/tests/unit/test_phase10_structural.py
+++ b/tests/unit/test_phase10_structural.py
@@ -1,0 +1,301 @@
+"""Unit tests for Phase 10.2 — Structural Hardening.
+
+Covers:
+- P10-06: Named sessions via ``SessionStore``
+- P10-07: Formal ``SkillContext`` model and ``load_skill_context()``
+- P10-08: Decoupled ``LearningEvent`` (schema v2, v1 compat)
+- P10-09: ``RunnerConfig`` Pydantic model and ``build_runner()`` integration
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+# ── P10-06: SessionStore ────────────────────────────────────────────────
+
+
+class TestSessionStore:
+    """Named session CRUD and migration."""
+
+    def test_list_empty(self, tmp_path: Path) -> None:
+        from adt.core.session_store import SessionStore
+
+        store = SessionStore(base_dir=tmp_path / "sessions")
+        assert store.list() == []
+
+    def test_save_load_roundtrip(self, tmp_path: Path) -> None:
+        from adt.core.session import SessionContext
+        from adt.core.session_store import SessionStore
+
+        store = SessionStore(base_dir=tmp_path / "sessions")
+        ctx = SessionContext(problem_summary="Two-sum", current_step=2, total_steps=4)
+        store.save(ctx, "two-sum")
+        loaded = store.load("two-sum")
+        assert loaded.problem_summary == "Two-sum"
+        assert loaded.current_step == 2
+
+    def test_list_sorted(self, tmp_path: Path) -> None:
+        from adt.core.session import SessionContext
+        from adt.core.session_store import SessionStore
+
+        store = SessionStore(base_dir=tmp_path / "sessions")
+        for name in ("zebra", "alpha", "mid"):
+            store.save(SessionContext(problem_summary=name), name)
+        assert store.list() == ["alpha", "mid", "zebra"]
+
+    def test_delete(self, tmp_path: Path) -> None:
+        from adt.core.session import SessionContext
+        from adt.core.session_store import SessionStore
+
+        store = SessionStore(base_dir=tmp_path / "sessions")
+        store.save(SessionContext(), "temp")
+        assert "temp" in store.list()
+        store.delete("temp")
+        assert "temp" not in store.list()
+
+    def test_delete_missing_is_noop(self, tmp_path: Path) -> None:
+        from adt.core.session_store import SessionStore
+
+        store = SessionStore(base_dir=tmp_path / "sessions")
+        store.delete("nonexistent")  # should not raise
+
+    def test_load_missing_returns_empty(self, tmp_path: Path) -> None:
+        from adt.core.session_store import SessionStore
+
+        store = SessionStore(base_dir=tmp_path / "sessions")
+        ctx = store.load("ghost")
+        assert ctx.is_empty()
+
+    def test_slug_sanitization(self, tmp_path: Path) -> None:
+        from adt.core.session_store import SessionStore
+
+        store = SessionStore(base_dir=tmp_path / "sessions")
+        p = store.path("My Session")
+        assert p.name == "my-session.json"
+
+    def test_slug_rejects_traversal(self, tmp_path: Path) -> None:
+        from adt.core.session_store import SessionStore
+
+        store = SessionStore(base_dir=tmp_path / "sessions")
+        with pytest.raises(ValueError, match="path traversal"):
+            store.path("../evil")
+
+    def test_slug_rejects_empty(self, tmp_path: Path) -> None:
+        from adt.core.session_store import SessionStore
+
+        store = SessionStore(base_dir=tmp_path / "sessions")
+        with pytest.raises(ValueError, match="empty"):
+            store.path("   ")
+
+    def test_migrate_legacy(self, tmp_path: Path) -> None:
+        """Legacy ``session.json`` is moved into ``sessions/default.json``."""
+        from adt.core.session_store import SessionStore
+
+        legacy = tmp_path / "session.json"
+        legacy.write_text(
+            json.dumps({"problem_summary": "legacy", "current_step": 1}),
+            encoding="utf-8",
+        )
+        store = SessionStore(base_dir=tmp_path / "sessions")
+        assert not legacy.exists()
+        ctx = store.load("default")
+        assert ctx.problem_summary == "legacy"
+
+    def test_migrate_skipped_when_target_exists(self, tmp_path: Path) -> None:
+        """Migration must not overwrite an existing ``default.json``."""
+        from adt.core.session_store import SessionStore
+
+        legacy = tmp_path / "session.json"
+        legacy.write_text('{"problem_summary": "old"}', encoding="utf-8")
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        target = sessions_dir / "default.json"
+        target.write_text('{"problem_summary": "new"}', encoding="utf-8")
+        SessionStore(base_dir=sessions_dir)
+        # legacy not removed, target not overwritten
+        assert legacy.exists()
+        loaded = json.loads(target.read_text(encoding="utf-8"))
+        assert loaded["problem_summary"] == "new"
+
+
+# ── P10-07: SkillContext ────────────────────────────────────────────────
+
+
+class TestSkillContext:
+    """Formal skill envelope and version parsing."""
+
+    def test_parse_version_present(self) -> None:
+        from adt.skills.context import parse_version
+
+        md = "<!-- version: 3 -->\n# Skill Title"
+        assert parse_version(md) == "3"
+
+    def test_parse_version_missing(self) -> None:
+        from adt.skills.context import parse_version
+
+        assert parse_version("# No version here") == "0"
+
+    def test_skill_context_creation(self) -> None:
+        from adt.skills.context import SkillContext
+
+        ctx = SkillContext(name="test", markdown="# Test", version="2")
+        assert ctx.name == "test"
+        assert ctx.version == "2"
+
+    def test_skill_context_rejects_extra_fields(self) -> None:
+        from adt.skills.context import SkillContext
+
+        with pytest.raises(Exception):  # noqa: B017
+            SkillContext(name="x", markdown="y", bogus="z")
+
+    def test_load_skill_context_from_path(self, tmp_path: Path) -> None:
+        from adt.skills.supervised_engineering.loader import load_skill_context
+
+        md = tmp_path / "SKILL.md"
+        md.write_text("<!-- version: 5 -->\n# Custom Skill\n", encoding="utf-8")
+        ctx = load_skill_context(path=md, use_cache=False)
+        assert ctx.name == "supervised_engineering"
+        assert ctx.version == "5"
+        assert "Custom Skill" in ctx.markdown
+
+    def test_load_skill_context_packaged(self) -> None:
+        """Loading from the installed package should return version >= 1."""
+        from adt.skills.supervised_engineering.loader import load_skill_context
+
+        ctx = load_skill_context(use_cache=False)
+        assert ctx.name == "supervised_engineering"
+        assert int(ctx.version) >= 1
+
+    def test_supervised_prompt_uses_skill_ctx(self) -> None:
+        from adt.core.supervised_supervisor import build_supervised_system_prompt
+        from adt.skills.context import SkillContext
+
+        ctx = SkillContext(name="mock", markdown="INJECTED_SKILL_BODY")
+        prompt = build_supervised_system_prompt("beginner", skill_ctx=ctx)
+        assert "INJECTED_SKILL_BODY" in prompt
+        assert "beginner" in prompt
+
+    def test_review_prompt_uses_skill_ctx(self) -> None:
+        from adt.core.supervised_supervisor import build_review_system_prompt
+        from adt.skills.context import SkillContext
+
+        ctx = SkillContext(name="mock", markdown="REVIEW_SKILL_BODY")
+        prompt = build_review_system_prompt("advanced", skill_ctx=ctx)
+        assert "REVIEW_SKILL_BODY" in prompt
+        assert "advanced" in prompt
+
+
+# ── P10-08: LearningEvent v2 ───────────────────────────────────────────
+
+
+class TestLearningEventV2:
+    """Standalone LearningEvent decoupled from TraceEvent."""
+
+    def test_all_fields_optional(self) -> None:
+        from adt.analytics.events import LearningEvent
+
+        ev = LearningEvent()
+        assert ev.schema_version == 2
+        assert ev.trace_id is None
+        assert ev.session_name is None
+        assert ev.component == ""
+
+    def test_with_session_name(self) -> None:
+        from adt.analytics.events import LearningEvent
+
+        ev = LearningEvent(
+            session_name="algo-practice",
+            component="reviewer",
+            event_type="code_review",
+        )
+        assert ev.session_name == "algo-practice"
+
+    def test_v1_compat_roundtrip(self) -> None:
+        """A v1-style dict (with trace_id, no session_name) should parse."""
+        from adt.analytics.events import LearningEvent
+
+        v1_data = {
+            "trace_id": "abc123",
+            "component": "supervisor",
+            "event_type": "supervised_step",
+            "step_id": 2,
+            "problem_summary": "Binary search",
+            "schema_version": 1,
+        }
+        ev = LearningEvent.model_validate(v1_data)
+        assert ev.trace_id == "abc123"
+        assert ev.session_name is None
+        assert ev.schema_version == 1
+
+    def test_serialization_includes_session_name(self) -> None:
+        from adt.analytics.events import LearningEvent
+
+        ev = LearningEvent(session_name="my-session", component="test")
+        data = ev.model_dump(mode="json")
+        assert data["session_name"] == "my-session"
+        assert data["schema_version"] == 2
+
+    def test_categorize_issue_unchanged(self) -> None:
+        from adt.analytics.events import categorize_issue
+        from adt.models.schemas import CodeIssue
+
+        issue = CodeIssue(
+            severity="warning",
+            description="off-by-one in loop bound",
+        )
+        assert categorize_issue(issue) == "off_by_one"
+
+
+# ── P10-09: RunnerConfig ───────────────────────────────────────────────
+
+
+class TestRunnerConfig:
+    """Pydantic config model for ``build_runner()``."""
+
+    def test_defaults(self, tmp_path: Path) -> None:
+        from adt.core.runner_config import RunnerConfig
+
+        cfg = RunnerConfig(repo_roots=tmp_path)
+        assert cfg.model == "gpt-4o-mini"
+        assert cfg.max_tool_iterations == 5
+        assert cfg.use_context_cache is True
+        assert cfg.agent_chain == []
+
+    def test_from_legacy(self, tmp_path: Path) -> None:
+        from adt.core.runner_config import RunnerConfig
+
+        cfg = RunnerConfig.from_legacy(
+            tmp_path,
+            model="gpt-4o",
+            max_tool_iterations=10,
+        )
+        assert cfg.model == "gpt-4o"
+        assert cfg.max_tool_iterations == 10
+        assert cfg.repo_roots == tmp_path
+
+    def test_dict_repo_roots(self, tmp_path: Path) -> None:
+        from adt.core.runner_config import RunnerConfig
+
+        roots = {"r0": tmp_path, "r1": tmp_path}
+        cfg = RunnerConfig(repo_roots=roots, primary_repo_key="r1")
+        assert cfg.primary_repo_key == "r1"
+        assert len(cfg.repo_roots) == 2
+
+    def test_build_runner_accepts_config(self, tmp_path: Path) -> None:
+        """``build_runner()`` should accept a ``RunnerConfig`` object."""
+        from adt.bootstrap import build_runner
+        from adt.core.runner_config import RunnerConfig
+
+        cfg = RunnerConfig(repo_roots=tmp_path, api_key="sk-test")
+        runner = build_runner(cfg)
+        assert runner is not None
+
+    def test_build_runner_legacy_still_works(self, tmp_path: Path) -> None:
+        """Legacy keyword-arg calling convention must keep working."""
+        from adt.bootstrap import build_runner
+
+        runner = build_runner(tmp_path, api_key="sk-test")
+        assert runner is not None


### PR DESCRIPTION
## Summary
- **P10-06**: Named session store (`SessionStore`) with slug validation, CRUD,
  and automatic `session.json` → `sessions/default.json` migration
- **P10-07**: Formal `SkillContext` Pydantic model with version parsing;
  `load_skill_context()` in loader; prompt builders accept `skill_ctx` param
- **P10-08**: `LearningEvent` decoupled from `TraceEvent` — standalone BaseModel
  with schema v2, nullable `trace_id`, optional `session_name`
- **P10-09**: `RunnerConfig` Pydantic model wrapping `build_runner()` 13+ kwargs;
  legacy calling convention preserved
- Fix 7 test regressions from Phase 10.1 (session monkeypatch + schema change)
- Fix CI failure: strip ANSI codes in `test_cli_max_bytes_flag_exists`

## Test plan
- [x] `make test` — all 375 unit tests pass
- [x] `make lint` — ruff clean
- [x] `make typecheck` — mypy clean
- [x] Verify `adt session list` / `adt session show --name foo` work manually
