### PR TITLE
feat(api): supervised + stats parity and strict config validation 

### DIFF
--- a/src/adt/analytics/exporter.py
+++ b/src/adt/analytics/exporter.py
@@ -1,0 +1,70 @@
+"""Export :class:`LearningStats` to CSV, JSON, or Markdown."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+from dataclasses import asdict
+
+from adt.analytics.stats import LearningStats
+
+
+def export_json(stats: LearningStats) -> str:
+    """Serialize stats to a JSON string."""
+    data = asdict(stats)
+    return json.dumps(data, indent=2, default=str)
+
+
+def export_csv(stats: LearningStats) -> str:
+    """Serialize stats as a wide-format CSV (one header row + one data row)."""
+    data = asdict(stats)
+    # Flatten complex fields into strings for CSV.
+    flat: dict[str, str] = {}
+    for key, value in data.items():
+        if isinstance(value, (dict, list)):
+            flat[key] = json.dumps(value, default=str)
+        else:
+            flat[key] = str(value)
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=list(flat.keys()))
+    writer.writeheader()
+    writer.writerow(flat)
+    return buf.getvalue()
+
+
+def export_markdown(stats: LearningStats) -> str:
+    """Render stats as a Markdown table."""
+    lines: list[str] = ["# Learning Stats", ""]
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
+    lines.append(f"| Sessions | {stats.sessions} |")
+    lines.append(f"| Reviews | {stats.reviews} |")
+    lines.append(f"| Supervised steps | {stats.supervised_steps} |")
+    lines.append(f"| Avg steps/session | {stats.avg_steps_per_session} |")
+    lines.append(f"| Avg iterations/session | {stats.avg_iterations_per_step} |")
+    lines.append(f"| Total tokens | {stats.total_tokens:,} |")
+
+    if stats.common_issues:
+        lines.append("")
+        lines.append("## Common Issues")
+        lines.append("")
+        for name, count in stats.common_issues:
+            lines.append(f"- **{name}**: {count}")
+
+    if stats.assessments:
+        lines.append("")
+        lines.append("## Review Verdicts")
+        lines.append("")
+        for name, count in sorted(stats.assessments.items(), key=lambda kv: -kv[1]):
+            lines.append(f"- {name}: {count}")
+
+    if stats.improvement_trend:
+        lines.append("")
+        lines.append("## Improvement Trend")
+        lines.append("")
+        arrow = " → ".join(str(v) for v in stats.improvement_trend)
+        lines.append(f"Iterations per session: {arrow}")
+
+    lines.append("")
+    return "\n".join(lines)

--- a/src/adt/api/server.py
+++ b/src/adt/api/server.py
@@ -1,10 +1,12 @@
-"""FastAPI application exposing ``/healthz`` and ``/ask``."""
+"""FastAPI application exposing ask, review, stats, and session endpoints."""
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from dataclasses import asdict
 from typing import Any
 
 from fastapi import FastAPI, HTTPException
@@ -33,6 +35,9 @@ app = FastAPI(
 )
 
 
+# ── /ask models ────────────────────────────────────────────────────────
+
+
 class AskRequest(BaseModel):
     """JSON body for ``POST /ask``."""
 
@@ -51,6 +56,22 @@ class AskRequest(BaseModel):
     )
     no_cache: bool = Field(default=False, description="Disable repo tree disk cache.")
     model: str | None = Field(default=None, description="OpenAI model override.")
+    mode: str = Field(
+        default="execution",
+        description="Operational mode: 'execution' or 'supervised'.",
+    )
+    level: str = Field(
+        default="intermediate",
+        description="Difficulty for supervised mode: beginner, intermediate, advanced.",
+    )
+    trace: bool = Field(
+        default=False,
+        description="When true, return trace events in the response.",
+    )
+    session: str = Field(
+        default="default",
+        description="Named session for supervised mode.",
+    )
 
 
 class AskResponse(BaseModel):
@@ -61,6 +82,89 @@ class AskResponse(BaseModel):
     tools_used: list[str]
     context_summary: str
     token_usage: dict[str, int] = Field(default_factory=dict)
+    supervised_response: dict[str, Any] | None = Field(
+        default=None,
+        description="Parsed SupervisedResponse when mode=supervised.",
+    )
+    trace_events: list[dict[str, Any]] | None = Field(
+        default=None,
+        description="Serialized trace events when trace=true.",
+    )
+
+
+# ── /review models ─────────────────────────────────────────────────────
+
+
+class ReviewRequest(BaseModel):
+    """JSON body for ``POST /review``."""
+
+    file_content: str = Field(
+        ...,
+        min_length=1,
+        description="Full source code to review.",
+    )
+    file_path: str = Field(
+        default="submitted_code.py",
+        description="Display name for the file being reviewed.",
+    )
+    context: str | None = Field(
+        default=None,
+        description="Optional description of what the code should do.",
+    )
+    level: str = Field(
+        default="intermediate",
+        description="Difficulty: beginner, intermediate, advanced.",
+    )
+    model: str | None = Field(default=None, description="OpenAI model override.")
+    session: str = Field(
+        default="default",
+        description="Named session for review context.",
+    )
+    max_bytes: int | None = Field(
+        default=None,
+        description="Override the maximum file size for review (in bytes).",
+    )
+
+
+class ReviewResponse(BaseModel):
+    """Structured review result."""
+
+    feedback: dict[str, Any] | None = Field(
+        default=None,
+        description="Parsed ReviewFeedback or null on parse failure.",
+    )
+    raw_answer: str
+    session: dict[str, Any]
+
+
+# ── /stats and /sessions models ────────────────────────────────────────
+
+
+class StatsResponse(BaseModel):
+    """Aggregated learning statistics."""
+
+    sessions: int = 0
+    reviews: int = 0
+    supervised_steps: int = 0
+    avg_steps_per_session: float = 0.0
+    avg_iterations_per_step: float = 0.0
+    common_issues: list[list[Any]] = Field(default_factory=list)
+    improvement_trend: list[float] = Field(default_factory=list)
+    total_tokens: int = 0
+    assessments: dict[str, int] = Field(default_factory=dict)
+
+
+class SessionResponse(BaseModel):
+    """Serialized SessionContext."""
+
+    problem_summary: str = ""
+    current_step: int = 0
+    total_steps: int = 0
+    previous_feedback: list[str] = Field(default_factory=list)
+    iteration_count: int = 0
+
+
+# ── endpoints ──────────────────────────────────────────────────────────
 
 
 @app.get("/healthz", tags=["meta"])
@@ -83,6 +187,10 @@ def post_ask(body: AskRequest) -> AskResponse:
             no_cache=body.no_cache,
             model=body.model,
             configure_logging=False,
+            trace=body.trace,
+            mode=body.mode,
+            level=body.level,
+            session_name=body.session,
         )
     except AskConfigurationError as exc:
         detail: Any = str(exc)
@@ -95,13 +203,139 @@ def post_ask(body: AskRequest) -> AskResponse:
     r = exe.response
     usage = getattr(exe.runner, "last_token_usage", None)
     tok = usage if isinstance(usage, dict) else {}
+
+    supervised = None
+    if exe.supervised_response is not None:
+        supervised = exe.supervised_response.model_dump(mode="json")
+
+    trace_events = None
+    if exe.trace_context is not None:
+        trace_events = [ev.model_dump(mode="json") for ev in exe.trace_context.events]
+
     return AskResponse(
         answer=r.answer,
         routed_agent=r.routed_agent,
         tools_used=list(r.tools_used),
         context_summary=r.context_summary,
         token_usage={k: int(v) for k, v in tok.items() if isinstance(v, int)},
+        supervised_response=supervised,
+        trace_events=trace_events,
     )
+
+
+@app.post("/review", response_model=ReviewResponse, tags=["review"])
+def post_review(body: ReviewRequest) -> ReviewResponse:
+    """Review source code via the supervised reviewer LLM.
+
+    Accepts ``file_content`` directly (no filesystem access needed).
+    """
+    import tempfile
+
+    from adt.review_session import ReviewConfigurationError, run_review
+
+    # Write content to a temp file so run_review can read it.
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            suffix=".py",
+            delete=False,
+            encoding="utf-8",
+        ) as tmp:
+            tmp.write(body.file_content)
+            tmp_path = tmp.name
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=f"temp file: {exc}") from exc
+
+    try:
+        result = run_review(
+            file=tmp_path,
+            extra_context=body.context,
+            level=body.level,
+            model=body.model,
+            verbose=False,
+            configure_logging=False,
+            max_bytes=body.max_bytes,
+            session_name=body.session,
+        )
+    except ReviewConfigurationError as exc:
+        detail_str: Any = str(exc)
+        code = 503 if "OPENAI_API_KEY" in detail_str else 400
+        raise HTTPException(status_code=code, detail=detail_str) from exc
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("review failed")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    finally:
+        import os
+
+        with _suppress_os():
+            os.unlink(tmp_path)
+
+    fb = result.feedback.model_dump(mode="json") if result.feedback else None
+    return ReviewResponse(
+        feedback=fb,
+        raw_answer=result.raw_answer,
+        session=asdict(result.session),
+    )
+
+
+@app.get("/stats", response_model=StatsResponse, tags=["analytics"])
+def get_stats(last: int | None = None) -> StatsResponse:
+    """Return aggregated learning statistics."""
+    from adt.analytics import compute_stats, read_learning_events
+
+    events = read_learning_events()
+    stats = compute_stats(events, last_n=last)
+    return StatsResponse(
+        sessions=stats.sessions,
+        reviews=stats.reviews,
+        supervised_steps=stats.supervised_steps,
+        avg_steps_per_session=stats.avg_steps_per_session,
+        avg_iterations_per_step=stats.avg_iterations_per_step,
+        common_issues=[list(pair) for pair in stats.common_issues],
+        improvement_trend=list(stats.improvement_trend),
+        total_tokens=stats.total_tokens,
+        assessments=dict(stats.assessments),
+    )
+
+
+@app.get("/sessions", tags=["sessions"])
+def list_sessions() -> list[str]:
+    """Return sorted list of named session names."""
+    from adt.core.session_store import SessionStore
+
+    return SessionStore().list()
+
+
+@app.get("/sessions/{name}", response_model=SessionResponse, tags=["sessions"])
+def get_session(name: str) -> SessionResponse:
+    """Return a named session's state."""
+    from adt.core.session_store import SessionStore
+
+    ctx = SessionStore().load(name)
+    return SessionResponse(
+        problem_summary=ctx.problem_summary,
+        current_step=ctx.current_step,
+        total_steps=ctx.total_steps,
+        previous_feedback=list(ctx.previous_feedback),
+        iteration_count=ctx.iteration_count,
+    )
+
+
+@app.delete("/sessions/{name}", tags=["sessions"])
+def delete_session(name: str) -> dict[str, str]:
+    """Delete a named session."""
+    from adt.core.session_store import SessionStore
+
+    store = SessionStore()
+    if not store.path(name).exists():
+        raise HTTPException(status_code=404, detail=f"Session '{name}' not found.")
+    store.delete(name)
+    return {"status": "deleted", "session": name}
+
+
+def _suppress_os() -> contextlib.AbstractContextManager[None]:
+    """Context manager that suppresses :class:`OSError`."""
+    return contextlib.suppress(OSError)
 
 
 def create_app() -> FastAPI:

--- a/src/adt/cli/app.py
+++ b/src/adt/cli/app.py
@@ -134,6 +134,13 @@ def config_set_cmd(
     ],
 ) -> None:
     """Persist one key under [adt] in config.toml."""
+    from adt.config_validator import ConfigValidationError, validate_key_value
+
+    try:
+        validate_key_value(key, value)
+    except ConfigValidationError as exc:
+        typer.echo(str(exc), err=True)
+        raise typer.Exit(code=1) from exc
     try:
         update_config_key(None, key, value)
     except ValueError as exc:
@@ -439,17 +446,55 @@ def stats_cmd(
             help="Only aggregate the most recent N supervised sessions.",
         ),
     ] = None,
+    export: Annotated[
+        str | None,
+        typer.Option(
+            "--export",
+            help="Export format: csv, json, or md (prints to stdout or --out).",
+        ),
+    ] = None,
+    out: Annotated[
+        str | None,
+        typer.Option(
+            "--out",
+            help="Write export output to this file instead of stdout.",
+        ),
+    ] = None,
 ) -> None:
     """Summarize supervised learning progress from ``~/.adt/logs/learning.jsonl``."""
     from adt.analytics import compute_stats, read_learning_events
-    from adt.cli.stats_renderer import StatsRenderer
 
     if last is not None and last <= 0:
         console.print("[red]--last must be a positive integer.[/red]")
         raise typer.Exit(code=1)
 
+    valid_formats = {"csv", "json", "md"}
+    if export is not None and export not in valid_formats:
+        console.print(
+            f"[red]Invalid --export {export!r}.[/red] "
+            f"Choose one of: {', '.join(sorted(valid_formats))}.",
+        )
+        raise typer.Exit(code=1)
+
     events = read_learning_events()
     stats = compute_stats(events, last_n=last)
+
+    if export is not None:
+        from adt.analytics.exporter import export_csv, export_json, export_markdown
+
+        exporters = {"csv": export_csv, "json": export_json, "md": export_markdown}
+        content = exporters[export](stats)
+        if out is not None:
+            from pathlib import Path as _Path
+
+            _Path(out).write_text(content, encoding="utf-8")
+            console.print(f"[green]Stats exported to {out}[/green]")
+        else:
+            typer.echo(content, nl=False)
+        return
+
+    from adt.cli.stats_renderer import StatsRenderer
+
     StatsRenderer(console).render(stats)
 
 

--- a/src/adt/config_validator.py
+++ b/src/adt/config_validator.py
@@ -1,0 +1,106 @@
+"""Strict validator for ``adt config set`` key-value pairs.
+
+Validates key names against the known :class:`~adt.config.AdtConfig` fields
+and checks value formats before persisting, producing actionable error
+messages on rejection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields as dc_fields
+
+from adt.config import AdtConfig
+
+_KNOWN_KEYS: set[str] = {f.name for f in dc_fields(AdtConfig)}
+
+_VALID_LOG_LEVELS = {"DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"}
+
+_VALID_AGENTS = {"repo_agent", "research_agent", "project_agent"}
+
+
+class ConfigValidationError(ValueError):
+    """Raised when a config key or value is invalid."""
+
+
+def validate_key_value(key: str, raw: str) -> None:
+    """Validate a ``key=value`` pair for ``adt config set``.
+
+    Raises:
+        ConfigValidationError: When the key is unknown or the value is
+            malformed for the expected type.
+    """
+    k = key.strip().lower().replace("-", "_")
+
+    if k not in _KNOWN_KEYS:
+        known = ", ".join(sorted(_KNOWN_KEYS))
+        raise ConfigValidationError(
+            f"Unknown config key: {key!r}. Valid keys: {known}"
+        )
+
+    if k == "log_level":
+        if raw.upper() not in _VALID_LOG_LEVELS:
+            raise ConfigValidationError(
+                f"Invalid log level {raw!r}. "
+                f"Choose one of: {', '.join(sorted(_VALID_LOG_LEVELS))}."
+            )
+
+    elif k == "cache_ttl_seconds":
+        try:
+            val = float(raw)
+        except ValueError:
+            raise ConfigValidationError(
+                f"cache_ttl_seconds must be a number, got {raw!r}."
+            ) from None
+        if val < 0:
+            raise ConfigValidationError(
+                f"cache_ttl_seconds must be non-negative, got {val}."
+            )
+
+    elif k == "use_llm_routing":
+        if raw.lower() not in ("0", "1", "true", "false", "yes", "no"):
+            raise ConfigValidationError(
+                f"use_llm_routing must be a boolean-like value, got {raw!r}. "
+                "Use: true/false, yes/no, or 1/0."
+            )
+
+    elif k == "max_tool_iterations":
+        if not raw.strip().isdigit():
+            raise ConfigValidationError(
+                f"max_tool_iterations must be a positive integer, got {raw!r}."
+            )
+        if int(raw) < 1:
+            raise ConfigValidationError(
+                "max_tool_iterations must be at least 1."
+            )
+
+    elif k == "token_budget":
+        if raw.lower() not in ("none", ""):
+            try:
+                val_int = int(raw)
+            except ValueError:
+                raise ConfigValidationError(
+                    f"token_budget must be an integer or 'none', got {raw!r}."
+                ) from None
+            if val_int < 0:
+                raise ConfigValidationError(
+                    f"token_budget must be non-negative, got {val_int}."
+                )
+
+    elif k == "review_max_bytes":
+        if not raw.strip().isdigit():
+            raise ConfigValidationError(
+                f"review_max_bytes must be a positive integer, got {raw!r}."
+            )
+        if int(raw) < 1024:
+            raise ConfigValidationError(
+                f"review_max_bytes must be at least 1024, got {raw}."
+            )
+
+    elif k == "agent_chain":
+        parts = [p.strip() for p in raw.split(",") if p.strip()]
+        for part in parts:
+            if part not in _VALID_AGENTS:
+                raise ConfigValidationError(
+                    f"Invalid agent in agent_chain: {part!r}. "
+                    f"Valid agents: {', '.join(sorted(_VALID_AGENTS))}."
+                )

--- a/tests/unit/test_phase10_parity.py
+++ b/tests/unit/test_phase10_parity.py
@@ -1,0 +1,450 @@
+"""Unit tests for Phase 10.3 — Reach & Parity.
+
+Covers:
+- P10-10: HTTP parity for supervised + trace (POST /ask, POST /review)
+- P10-11: /stats and /sessions endpoints
+- P10-12: Stats export (CSV / JSON / Markdown)
+- P10-13: Strict ``adt config set`` validator
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+from typer.testing import CliRunner
+
+from adt.api.server import app as api_app
+from adt.cli.app import app as cli_app
+
+client = TestClient(api_app)
+runner = CliRunner()
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+# ── P10-10: HTTP parity ────────────────────────────────────────────────
+
+
+class TestPostAskParity:
+    """POST /ask now accepts mode, level, trace, session."""
+
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}, clear=False)
+    @patch("adt.api.server.run_ask")
+    def test_supervised_fields_in_request(self, mock_run: MagicMock) -> None:
+        from adt.ask_session import AskExecution
+        from adt.models.schemas import AgentResponse
+
+        mock_run.return_value = AskExecution(
+            response=AgentResponse(
+                answer="step guidance",
+                routed_agent="supervisor",
+            ),
+            runner=MagicMock(last_token_usage={}),
+        )
+        res = client.post(
+            "/ask",
+            json={
+                "query": "binary search",
+                "mode": "supervised",
+                "level": "beginner",
+                "session": "algo",
+            },
+        )
+        assert res.status_code == 200
+        mock_run.assert_called_once()
+        call_kw = mock_run.call_args
+        assert call_kw.kwargs["mode"] == "supervised"
+        assert call_kw.kwargs["level"] == "beginner"
+        assert call_kw.kwargs["session_name"] == "algo"
+
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}, clear=False)
+    @patch("adt.api.server.run_ask")
+    def test_supervised_response_in_output(self, mock_run: MagicMock) -> None:
+        from adt.ask_session import AskExecution
+        from adt.models.schemas import (
+            AgentResponse,
+            SupervisedResponse,
+            SupervisedStep,
+        )
+
+        sup = SupervisedResponse(
+            problem_summary="Two-sum",
+            current_step=SupervisedStep(step_number=1, goal="define fn"),
+            total_steps=3,
+        )
+        mock_run.return_value = AskExecution(
+            response=AgentResponse(answer="{}"),
+            runner=MagicMock(last_token_usage={}),
+            supervised_response=sup,
+        )
+        res = client.post("/ask", json={"query": "two-sum", "mode": "supervised"})
+        assert res.status_code == 200
+        body = res.json()
+        assert body["supervised_response"] is not None
+        assert body["supervised_response"]["problem_summary"] == "Two-sum"
+
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}, clear=False)
+    @patch("adt.api.server.run_ask")
+    def test_trace_events_in_output(self, mock_run: MagicMock) -> None:
+        from adt.ask_session import AskExecution
+        from adt.models.schemas import AgentResponse
+        from adt.tracing.context import TraceContext
+
+        tc = TraceContext()
+        tc.emit("test", "test_event", data={"key": "value"})
+        mock_run.return_value = AskExecution(
+            response=AgentResponse(answer="ok"),
+            runner=MagicMock(last_token_usage={}),
+            trace_context=tc,
+        )
+        res = client.post("/ask", json={"query": "x", "trace": True})
+        assert res.status_code == 200
+        body = res.json()
+        assert body["trace_events"] is not None
+        assert len(body["trace_events"]) >= 1
+
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}, clear=False)
+    @patch("adt.api.server.run_ask")
+    def test_defaults_no_supervised_or_trace(self, mock_run: MagicMock) -> None:
+        from adt.ask_session import AskExecution
+        from adt.models.schemas import AgentResponse
+
+        mock_run.return_value = AskExecution(
+            response=AgentResponse(answer="hi"),
+            runner=MagicMock(last_token_usage={}),
+        )
+        res = client.post("/ask", json={"query": "hello"})
+        body = res.json()
+        assert body["supervised_response"] is None
+        assert body["trace_events"] is None
+
+
+class TestPostReview:
+    """POST /review accepts file_content directly."""
+
+    @patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test"}, clear=False)
+    @patch("adt.review_session.run_review")
+    def test_review_success(self, mock_review: MagicMock) -> None:
+        from adt.core.session import SessionContext
+        from adt.models.schemas import ReviewFeedback
+        from adt.review_session import ReviewExecution
+
+        fb = ReviewFeedback(
+            next_step="fix the bug",
+            overall_assessment="on_track",
+        )
+        mock_review.return_value = ReviewExecution(
+            feedback=fb,
+            raw_answer="{}",
+            session=SessionContext(problem_summary="test"),
+        )
+        res = client.post(
+            "/review",
+            json={
+                "file_content": "def foo(): pass",
+                "context": "should return 1",
+                "level": "beginner",
+            },
+        )
+        assert res.status_code == 200
+        body = res.json()
+        assert body["feedback"] is not None
+        assert body["feedback"]["overall_assessment"] == "on_track"
+        assert body["session"]["problem_summary"] == "test"
+
+    @patch("adt.review_session.run_review")
+    def test_review_missing_key(self, mock_review: MagicMock) -> None:
+        from adt.review_session import ReviewConfigurationError
+
+        mock_review.side_effect = ReviewConfigurationError(
+            "Missing OPENAI_API_KEY."
+        )
+        res = client.post("/review", json={"file_content": "x=1"})
+        assert res.status_code == 503
+
+
+# ── P10-11: /stats and /sessions ───────────────────────────────────────
+
+
+class TestGetStats:
+    def test_stats_endpoint_returns_200(self) -> None:
+        """The /stats endpoint returns valid JSON with expected keys."""
+        res = client.get("/stats")
+        assert res.status_code == 200
+        body = res.json()
+        assert "sessions" in body
+        assert "reviews" in body
+        assert "assessments" in body
+
+
+class TestSessions:
+    def test_list_sessions(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "adt.core.session_store.ensure_adt_dir", lambda: tmp_path
+        )
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        (sessions_dir / "alpha.json").write_text("{}", encoding="utf-8")
+        (sessions_dir / "beta.json").write_text("{}", encoding="utf-8")
+        res = client.get("/sessions")
+        assert res.status_code == 200
+        assert res.json() == ["alpha", "beta"]
+
+    def test_get_session(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "adt.core.session_store.ensure_adt_dir", lambda: tmp_path
+        )
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        data = {
+            "problem_summary": "sorting",
+            "current_step": 2,
+            "total_steps": 5,
+            "previous_feedback": ["on_track"],
+            "iteration_count": 3,
+        }
+        (sessions_dir / "algo.json").write_text(
+            json.dumps(data), encoding="utf-8"
+        )
+        res = client.get("/sessions/algo")
+        assert res.status_code == 200
+        body = res.json()
+        assert body["problem_summary"] == "sorting"
+        assert body["current_step"] == 2
+
+    def test_get_session_missing(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "adt.core.session_store.ensure_adt_dir", lambda: tmp_path
+        )
+        res = client.get("/sessions/nonexistent")
+        assert res.status_code == 200  # returns empty session
+        assert res.json()["current_step"] == 0
+
+    def test_delete_session(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "adt.core.session_store.ensure_adt_dir", lambda: tmp_path
+        )
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir()
+        sf = sessions_dir / "temp.json"
+        sf.write_text("{}", encoding="utf-8")
+        res = client.delete("/sessions/temp")
+        assert res.status_code == 200
+        assert res.json()["status"] == "deleted"
+        assert not sf.exists()
+
+    def test_delete_session_missing(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "adt.core.session_store.ensure_adt_dir", lambda: tmp_path
+        )
+        res = client.delete("/sessions/ghost")
+        assert res.status_code == 404
+
+
+# ── P10-12: Stats export ──────────────────────────────────────────────
+
+
+class TestStatsExport:
+    """CSV, JSON, and Markdown export from exporter module."""
+
+    def _sample_stats(self):
+        from adt.analytics.stats import LearningStats
+
+        return LearningStats(
+            sessions=3,
+            reviews=5,
+            supervised_steps=10,
+            avg_steps_per_session=3.5,
+            avg_iterations_per_step=2.0,
+            common_issues=[("off_by_one", 4), ("naming", 2)],
+            improvement_trend=[3.0, 2.5, 1.5],
+            total_tokens=1200,
+            assessments={"on_track": 3, "needs_work": 2},
+        )
+
+    def test_export_json(self) -> None:
+        from adt.analytics.exporter import export_json
+
+        out = export_json(self._sample_stats())
+        data = json.loads(out)
+        assert data["sessions"] == 3
+        assert data["reviews"] == 5
+        assert data["total_tokens"] == 1200
+
+    def test_export_csv(self) -> None:
+        from adt.analytics.exporter import export_csv
+
+        out = export_csv(self._sample_stats())
+        lines = out.strip().split("\n")
+        assert len(lines) == 2  # header + data
+        assert "sessions" in lines[0]
+        assert "3" in lines[1]
+
+    def test_export_markdown(self) -> None:
+        from adt.analytics.exporter import export_markdown
+
+        out = export_markdown(self._sample_stats())
+        assert "# Learning Stats" in out
+        assert "| Sessions | 3 |" in out
+        assert "off_by_one" in out
+        assert "→" in out  # trend arrow
+
+    def test_cli_export_json(self) -> None:
+        result = runner.invoke(cli_app, ["stats", "--export", "json"])
+        assert result.exit_code == 0
+        data = json.loads(result.stdout)
+        assert "sessions" in data
+
+    def test_cli_export_csv(self) -> None:
+        result = runner.invoke(cli_app, ["stats", "--export", "csv"])
+        assert result.exit_code == 0
+        assert "sessions" in result.stdout
+
+    def test_cli_export_md(self) -> None:
+        result = runner.invoke(cli_app, ["stats", "--export", "md"])
+        assert result.exit_code == 0
+        assert "# Learning Stats" in result.stdout
+
+    def test_cli_export_to_file(self, tmp_path: Path) -> None:
+        out = tmp_path / "stats.json"
+        result = runner.invoke(
+            cli_app, ["stats", "--export", "json", "--out", str(out)]
+        )
+        assert result.exit_code == 0
+        assert out.exists()
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert "sessions" in data
+
+    def test_cli_export_invalid_format(self) -> None:
+        result = runner.invoke(cli_app, ["stats", "--export", "xml"])
+        assert result.exit_code == 1
+
+    def test_cli_export_flag_exists(self) -> None:
+        result = runner.invoke(cli_app, ["stats", "--help"])
+        assert "--export" in _strip_ansi(result.stdout)
+
+
+# ── P10-13: Config validator ──────────────────────────────────────────
+
+
+class TestConfigValidator:
+    """Strict validation of ``adt config set`` key-value pairs."""
+
+    def test_unknown_key_rejected(self) -> None:
+        from adt.config_validator import ConfigValidationError, validate_key_value
+
+        with pytest.raises(ConfigValidationError, match="Unknown"):
+            validate_key_value("nonexistent_key", "value")
+
+    def test_valid_log_level(self) -> None:
+        from adt.config_validator import validate_key_value
+
+        validate_key_value("log_level", "DEBUG")  # should not raise
+
+    def test_invalid_log_level(self) -> None:
+        from adt.config_validator import ConfigValidationError, validate_key_value
+
+        with pytest.raises(ConfigValidationError, match="Invalid log level"):
+            validate_key_value("log_level", "VERBOSE")
+
+    def test_valid_cache_ttl(self) -> None:
+        from adt.config_validator import validate_key_value
+
+        validate_key_value("cache_ttl_seconds", "60.5")
+
+    def test_invalid_cache_ttl_nan(self) -> None:
+        from adt.config_validator import ConfigValidationError, validate_key_value
+
+        with pytest.raises(ConfigValidationError, match="number"):
+            validate_key_value("cache_ttl_seconds", "abc")
+
+    def test_negative_cache_ttl(self) -> None:
+        from adt.config_validator import ConfigValidationError, validate_key_value
+
+        with pytest.raises(ConfigValidationError, match="non-negative"):
+            validate_key_value("cache_ttl_seconds", "-1")
+
+    def test_valid_use_llm_routing(self) -> None:
+        from adt.config_validator import validate_key_value
+
+        for val in ("true", "false", "1", "0", "yes", "no"):
+            validate_key_value("use_llm_routing", val)
+
+    def test_invalid_use_llm_routing(self) -> None:
+        from adt.config_validator import ConfigValidationError, validate_key_value
+
+        with pytest.raises(ConfigValidationError, match="boolean"):
+            validate_key_value("use_llm_routing", "maybe")
+
+    def test_valid_max_tool_iterations(self) -> None:
+        from adt.config_validator import validate_key_value
+
+        validate_key_value("max_tool_iterations", "10")
+
+    def test_invalid_max_tool_iterations(self) -> None:
+        from adt.config_validator import ConfigValidationError, validate_key_value
+
+        with pytest.raises(ConfigValidationError, match="positive integer"):
+            validate_key_value("max_tool_iterations", "abc")
+
+    def test_valid_token_budget(self) -> None:
+        from adt.config_validator import validate_key_value
+
+        validate_key_value("token_budget", "50000")
+        validate_key_value("token_budget", "none")
+
+    def test_invalid_token_budget(self) -> None:
+        from adt.config_validator import ConfigValidationError, validate_key_value
+
+        with pytest.raises(ConfigValidationError, match="integer"):
+            validate_key_value("token_budget", "abc")
+
+    def test_valid_review_max_bytes(self) -> None:
+        from adt.config_validator import validate_key_value
+
+        validate_key_value("review_max_bytes", "200000")
+
+    def test_review_max_bytes_too_small(self) -> None:
+        from adt.config_validator import ConfigValidationError, validate_key_value
+
+        with pytest.raises(ConfigValidationError, match="1024"):
+            validate_key_value("review_max_bytes", "512")
+
+    def test_valid_agent_chain(self) -> None:
+        from adt.config_validator import validate_key_value
+
+        validate_key_value("agent_chain", "repo_agent,research_agent")
+
+    def test_invalid_agent_chain(self) -> None:
+        from adt.config_validator import ConfigValidationError, validate_key_value
+
+        with pytest.raises(ConfigValidationError, match="Invalid agent"):
+            validate_key_value("agent_chain", "repo_agent,fake_agent")
+
+    def test_valid_default_model(self) -> None:
+        from adt.config_validator import validate_key_value
+
+        validate_key_value("default_model", "gpt-4o")
+
+    def test_valid_routing_model(self) -> None:
+        from adt.config_validator import validate_key_value
+
+        validate_key_value("routing_model", "gpt-4o-mini")
+
+    def test_cli_rejects_unknown_key(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr("adt.config.adt_config_path", lambda: tmp_path / "c.toml")
+        result = runner.invoke(cli_app, ["config", "set", "bogus_key", "val"])
+        assert result.exit_code == 1
+        assert "Unknown" in result.stdout or "Unknown" in (result.stderr or "")
+
+    def test_cli_rejects_bad_value(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.setattr("adt.config.adt_config_path", lambda: tmp_path / "c.toml")
+        result = runner.invoke(cli_app, ["config", "set", "log_level", "VERBOSE"])
+        assert result.exit_code == 1


### PR DESCRIPTION
## Summary
- **P10-10**: POST /ask now accepts mode, level, trace, session; response
  includes supervised_response and trace_events. New POST /review endpoint.
- **P10-11**: GET /stats, GET /sessions, GET /sessions/{name},
  DELETE /sessions/{name} endpoints with Pydantic response models.
- **P10-12**: `adt stats --export {csv,json,md} [--out path]` for piping
  stats into dashboards or reports.
- **P10-13**: `ConfigValidationError` with actionable messages for unknown
  keys, bad log levels, non-numeric fields, and invalid agent chains.

## Test plan
- [ ] `make test` — all 416 unit tests pass
- [ ] `make lint` — ruff clean
- [ ] `make typecheck` — mypy clean
- [ ] `adt stats --export json | python -m json.tool` produces valid JSON
- [ ] `adt config set bogus_key val` fails with actionable error
