### PR TITLE
feat(docs,ui,i18n): MkDocs site, HTML dashboard, pt_BR locale (Phase 10.5)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+name: Docs
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mkdocs-material
+      - run: mkdocs build -f docs/mkdocs.yml
+      - run: mkdocs gh-deploy -f docs/mkdocs.yml --force

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![PyPI](https://img.shields.io/pypi/v/agentic-dev-tool.svg)](https://pypi.org/project/agentic-dev-tool/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Docs](https://img.shields.io/badge/docs-mkdocs-blue.svg)](https://brunoramosmartins.github.io/agentic-dev-tool)
 
 **Portfolio-grade CLI** (and optional **HTTP API**) that routes natural-language questions to **specialized agents**—repository analysis, GitHub project context, and technical research—backed by **OpenAI tool calling** and an **MCP-style** in-process layer: tool **registry**, **JSON Schema** validation, **tiktoken** budgets, ranked context, and disk cache. Ships with a **supervised learning mode** (step-by-step teaching with difficulty levels), **code review**, **request tracing** with cost estimates, and **learning analytics**.
 

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,0 +1,84 @@
+# CLI Reference
+
+## Global commands
+
+| Command | Description |
+|---------|-------------|
+| `adt ask <query>` | Ask a question — supervisor picks an agent |
+| `adt review <file>` | Review a source file in supervised mode |
+| `adt stats` | Summarize learning progress |
+| `adt guide` | Print quick-reference cheat sheet |
+| `adt version` | Print installed version |
+| `adt info` | Print project status summary |
+| `adt serve` | Run the HTTP API server |
+
+## `adt ask` options
+
+| Flag | Description |
+|------|-------------|
+| `--repo, -r` | Local directory or owner/repo slug (repeatable) |
+| `--agent, -a` | Force a specific agent |
+| `--mode` | `execution` (default) or `supervised` |
+| `--level` | `beginner`, `intermediate`, `advanced` |
+| `--session` | Named session for supervised mode |
+| `--resume` | Resume an interrupted run by trace ID |
+| `--trace` | Show request trace |
+| `--model, -m` | Override OpenAI model |
+| `--token` | GitHub PAT |
+| `--no-cache` | Disable repo tree cache |
+| `--verbose, -v` | Debug logs and token usage |
+| `--log-level` | File log level |
+
+## `adt review` options
+
+| Flag | Description |
+|------|-------------|
+| `--context, -c` | Description of what the code should do |
+| `--level` | Difficulty level |
+| `--model, -m` | Override OpenAI model |
+| `--max-bytes` | Maximum file size override |
+| `--session` | Named session |
+
+## `adt stats` options
+
+| Flag | Description |
+|------|-------------|
+| `--last` | Aggregate only N most recent sessions |
+| `--export` | Export format: `csv`, `json`, or `md` |
+| `--out` | Write export to file |
+| `--html` | Generate HTML dashboard |
+| `--classifier` | `keyword` (default) or `embedding` |
+
+## Subcommands
+
+### `adt config`
+
+| Command | Description |
+|---------|-------------|
+| `adt config show` | Print effective settings |
+| `adt config set <key> <value>` | Persist one config key |
+| `adt config path` | Print config file path |
+
+### `adt session`
+
+| Command | Description |
+|---------|-------------|
+| `adt session show` | Show current session |
+| `adt session list` | List all sessions |
+| `adt session clear` | Delete a session |
+| `adt session export` | Export session JSON |
+
+### `adt runs`
+
+| Command | Description |
+|---------|-------------|
+| `adt runs list` | List saved run snapshots |
+| `adt runs show <id>` | Show run details |
+| `adt runs delete <id>` | Delete a snapshot |
+
+### `adt plugins`
+
+| Command | Description |
+|---------|-------------|
+| `adt plugins list` | List installed plugins |
+| `adt plugins validate <path>` | Validate a plugin directory |

--- a/docs/api/http.md
+++ b/docs/api/http.md
@@ -1,0 +1,97 @@
+# HTTP API Reference
+
+Start the server:
+
+```bash
+pip install "agentic-dev-tool[api]"
+adt serve --port 8765
+```
+
+OpenAPI docs: `http://127.0.0.1:8765/docs`
+
+## Endpoints
+
+### `GET /healthz`
+
+Liveness probe.
+
+```json
+{"status": "ok", "version": "1.2.0"}
+```
+
+### `POST /ask`
+
+Run one agent turn.
+
+**Request:**
+
+```json
+{
+  "query": "What does this project do?",
+  "repo": ["."],
+  "mode": "execution",
+  "level": "intermediate",
+  "trace": false,
+  "session": "default"
+}
+```
+
+**Response:**
+
+```json
+{
+  "answer": "This project is...",
+  "routed_agent": "repo_agent",
+  "tools_used": ["read_repo_tree"],
+  "context_summary": "...",
+  "token_usage": {"prompt_tokens": 500, "completion_tokens": 200},
+  "supervised_response": null,
+  "trace_events": null
+}
+```
+
+### `POST /review`
+
+Review source code.
+
+**Request:**
+
+```json
+{
+  "file_content": "def foo(): pass",
+  "context": "should return 1",
+  "level": "beginner"
+}
+```
+
+**Response:**
+
+```json
+{
+  "feedback": {
+    "issues": [],
+    "improvements": [],
+    "strengths": [],
+    "next_step": "...",
+    "overall_assessment": "on_track"
+  },
+  "raw_answer": "...",
+  "session": {"problem_summary": "", "current_step": 0}
+}
+```
+
+### `GET /stats?last=N`
+
+Aggregated learning statistics.
+
+### `GET /sessions`
+
+List named session names.
+
+### `GET /sessions/{name}`
+
+Return a session's state.
+
+### `DELETE /sessions/{name}`
+
+Delete a named session (404 if missing).

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -1,0 +1,46 @@
+# Installation
+
+## From PyPI
+
+```bash
+pip install agentic-dev-tool
+```
+
+## With API extras (FastAPI server)
+
+```bash
+pip install "agentic-dev-tool[api]"
+```
+
+## Development mode
+
+```bash
+git clone https://github.com/brunoramosmartins/agentic-dev-tool.git
+cd agentic-dev-tool
+pip install -e ".[dev]"
+```
+
+## Global install via pipx
+
+```bash
+pipx install agentic-dev-tool
+```
+
+Or from a local checkout (editable):
+
+```bash
+pipx install -e .
+```
+
+## Required environment
+
+```bash
+export OPENAI_API_KEY="sk-..."      # required
+export GITHUB_TOKEN="ghp_..."       # optional, higher rate limits
+```
+
+!!! tip
+    On Windows, use `setx` to persist environment variables:
+    ```powershell
+    [System.Environment]::SetEnvironmentVariable("OPENAI_API_KEY", "sk-...", "User")
+    ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,49 @@
+# Quick Start
+
+## Ask a question about your code
+
+```bash
+adt ask "What does this project do?" --repo .
+```
+
+## Use supervised learning mode
+
+```bash
+adt ask "Implement binary search" --mode supervised --level beginner
+```
+
+## Review a file
+
+```bash
+adt review src/main.py --level intermediate
+```
+
+## View learning stats
+
+```bash
+adt stats
+adt stats --export json
+adt stats --export md --out report.md
+```
+
+## Run the HTTP API
+
+```bash
+pip install "agentic-dev-tool[api]"
+adt serve --port 8765
+# Open http://127.0.0.1:8765/docs
+```
+
+## Configuration
+
+```bash
+adt config show
+adt config set default_model gpt-4o
+adt config set log_level DEBUG
+```
+
+## Quick reference
+
+```bash
+adt guide
+```

--- a/docs/guides/analytics.md
+++ b/docs/guides/analytics.md
@@ -1,0 +1,47 @@
+# Learning Analytics
+
+`adt` records supervised learning events and code reviews to
+`~/.adt/logs/learning.jsonl`. The `adt stats` command aggregates
+these into actionable metrics.
+
+## View stats
+
+```bash
+adt stats
+adt stats --last 5       # most recent 5 sessions only
+```
+
+## Export formats
+
+```bash
+adt stats --export json                  # stdout
+adt stats --export csv --out stats.csv   # file
+adt stats --export md --out report.md    # markdown
+adt stats --html ./report                # HTML dashboard
+```
+
+## Metrics
+
+| Metric | Description |
+|--------|-------------|
+| Sessions | Distinct supervised problems |
+| Reviews | Code review events |
+| Avg steps/session | Mean highest step index per session |
+| Common issues | Top issue categories (off_by_one, naming, etc.) |
+| Improvement trend | Rolling average iterations across session buckets |
+| Assessments | Count of each review verdict |
+
+## Classifier
+
+By default, issues are classified via keyword matching. Use the
+embedding classifier for better accuracy:
+
+```bash
+adt stats --classifier embedding
+```
+
+## HTTP API
+
+```
+GET /stats?last=5
+```

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -1,0 +1,57 @@
+# Plugins
+
+Extend `adt` with community skills and tools without forking the repo.
+
+## Directory layout
+
+```
+~/.adt/plugins/
+    skills/
+        my_skill/
+            SKILL.md          # Loaded as SkillContext
+    tools/
+        my_tool/
+            tool.py           # Must define register(registry)
+            manifest.json     # Optional metadata
+```
+
+## Creating a skill plugin
+
+Create a `SKILL.md` with a version comment:
+
+```markdown
+<!-- version: 1 -->
+# My Custom Skill
+
+Your skill content here...
+```
+
+## Creating a tool plugin
+
+Create a `tool.py` with a `register` function:
+
+```python
+from adt.mcp.registry import ToolDefinition
+
+def register(registry):
+    registry.register(ToolDefinition(
+        name="my_tool",
+        description="Does something useful",
+        parameters={"type": "object", "properties": {}},
+        allowed_agents=["repo_agent"],
+        handler=lambda: "result",
+    ))
+```
+
+## Managing plugins
+
+```bash
+adt plugins list              # show installed plugins
+adt plugins validate ./path   # check a plugin directory
+```
+
+## Safety
+
+Plugin tools are registered through the same `ToolRegistry` and validated
+by the same `ExecutionController` as built-in tools. JSON Schema validation
+applies to all tool arguments.

--- a/docs/guides/supervised.md
+++ b/docs/guides/supervised.md
@@ -1,0 +1,41 @@
+# Supervised Learning Mode
+
+The supervised mode guides you step-by-step through solving a programming
+problem instead of giving you the answer directly.
+
+## Usage
+
+```bash
+adt ask "Implement a linked list" --mode supervised --level beginner
+```
+
+## Difficulty levels
+
+| Level | Description |
+|-------|-------------|
+| `beginner` | Detailed guidance, more hints, smaller steps |
+| `intermediate` | Balanced hints, standard step size |
+| `advanced` | Minimal hints, larger conceptual steps |
+
+## Sessions
+
+Supervised mode persists state between CLI invocations so you can
+continue where you left off:
+
+```bash
+adt session show                   # current session state
+adt session list                   # all named sessions
+adt ask "..." --session algo-practice  # use a named session
+adt session clear --yes            # reset
+```
+
+## Code review
+
+After implementing a step, submit your code for structured feedback:
+
+```bash
+adt review solution.py --level intermediate
+```
+
+The reviewer returns issues (with severity and hints), strengths,
+improvements, and a verdict (`needs_work`, `on_track`, `excellent`).

--- a/docs/guides/tracing.md
+++ b/docs/guides/tracing.md
@@ -1,0 +1,26 @@
+# Request Tracing
+
+Pass `--trace` to see the full request lifecycle: routing decisions,
+context building, LLM calls, tool invocations, and cost estimates.
+
+```bash
+adt ask "Explain the MCP layer" --repo . --trace
+```
+
+The trace output shows:
+
+- **Routing** — which agent was selected and why
+- **Context** — token budget allocation across system, user, tools, response
+- **LLM calls** — iteration count, token usage per call
+- **Tool calls** — name, duration, success/failure
+- **Cost estimate** — based on model pricing and total tokens
+
+## HTTP API
+
+```bash
+curl -X POST http://localhost:8765/ask \
+  -H "Content-Type: application/json" \
+  -d '{"query": "explain tracing", "trace": true}'
+```
+
+The response includes a `trace_events` array when `trace: true`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,27 @@
+# Agentic Dev Tool (`adt`)
+
+**Portfolio-grade CLI** and optional **HTTP API** that routes natural-language
+questions to **specialized agents** — repository analysis, GitHub project
+context, and technical research — backed by **OpenAI tool calling** and an
+**MCP-style** in-process layer.
+
+## Features
+
+- **Multi-agent routing** — supervisor picks the best agent for your question
+- **Supervised learning mode** — step-by-step teaching with difficulty levels
+- **Code review** — structured feedback with severity, hints, and verdicts
+- **Request tracing** — full visibility into routing, tools, and cost estimates
+- **Learning analytics** — track your progress with `adt stats`
+- **Plugin system** — extend with community skills and tools
+- **HTTP API** — same capabilities as the CLI via FastAPI
+
+## Quick Start
+
+```bash
+pip install agentic-dev-tool
+export OPENAI_API_KEY="sk-..."
+adt ask "What does this project do?" --repo .
+```
+
+See the [Installation](getting-started/install.md) and
+[Quick Start](getting-started/quickstart.md) guides for details.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,56 @@
+site_name: Agentic Dev Tool
+site_description: AI CLI that routes questions to specialized agents
+site_url: https://brunoramosmartins.github.io/agentic-dev-tool
+repo_url: https://github.com/brunoramosmartins/agentic-dev-tool
+repo_name: brunoramosmartins/agentic-dev-tool
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: teal
+      accent: cyan
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: teal
+      accent: cyan
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tabs
+    - navigation.sections
+    - search.highlight
+    - content.code.copy
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: getting-started/install.md
+      - Quick Start: getting-started/quickstart.md
+  - Guides:
+      - Supervised Mode: guides/supervised.md
+      - Tracing: guides/tracing.md
+      - Analytics: guides/analytics.md
+      - Plugins: guides/plugins.md
+  - Reference:
+      - Architecture: reference/architecture.md
+      - Agents: reference/agents.md
+      - MCP Layer: reference/mcp.md
+      - Skills: reference/skills.md
+  - API:
+      - CLI Reference: api/cli.md
+      - HTTP API: api/http.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - toc:
+      permalink: true

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -1,0 +1,93 @@
+# Agents
+
+This document summarizes built-in agents, their tools, and how routing works.
+
+## `--repo`: local path vs `owner/repo`
+
+- **Existing directory:** used as the root for **repo tools** (`repo_agent`) and **markdown reads** (`project_agent`). `QueryRequest.repo_path` is that directory; no default GitHub slug is implied.
+- **`owner/repo` slug** (only when that string is **not** an existing path): `repo_path` is set to the **current working directory** (markdown root), and `github_owner` / `github_repo` are filled for session hints. The runner defaults ambiguous queries to **`project_agent`** (see below).
+- **Multiple `--repo` values:** unique local roots get stable ids **`r0`**, **`r1`**, … Tools accept optional **`repo_key`** to pick a root. `QueryRequest.additional_repo_paths` lists extras after the primary `repo_path`.
+
+## Supervisor routing
+
+By default the app uses a **hybrid** router: a small **JSON LLM call** proposes `repo_agent` / `project_agent` / `research_agent`; on failure or when disabled (`use_llm_routing` in config / env), the same **keyword rules** as before apply.
+
+Keyword fallback (lowercased query), in order:
+
+1. **Project** — keywords such as `issue`, `issues`, `milestone`, `roadmap`, `project`, `sprint`, `backlog`, `github`, `epic`, `ticket`, `release`, `kanban`, `board`, `assignee`, `pull request`, `triaged` → `project_agent`.
+2. **Research** — keywords such as `paper`, `papers`, `arxiv`, `article`, `research`, `literature`, `survey`, `publication`, `journal`, `preprint`, `doi`, and the phrase `literature review` → `research_agent`.
+3. **Repository** — keywords such as `repo`, `code`, `codebase`, `architecture`, `explain`, `file`, `function`, `implementation`, and **`search`** → `repo_agent`.
+4. **Default** — if nothing matches: **`project_agent`** when `github_owner` / `github_repo` are set (remote `--repo`); otherwise **`repo_agent`**.
+
+You can bypass routing with:
+
+```bash
+adt ask "your question" --repo . --agent project_agent
+```
+
+Valid values: `repo_agent`, `research_agent`, `project_agent`.
+
+## Config file (`~/.adt/config.toml`)
+
+The `[adt]` table can set: `default_model`, `log_level`, `cache_ttl_seconds`, `use_llm_routing`, `routing_model`, `max_tool_iterations`, `token_budget`, `agent_chain` (list of agent ids), and `custom_tools` (reserved list for future plugin paths). Use `adt config show|set|path`. `ADT_*` env vars override file values when set.
+
+When **`agent_chain`** is non-empty and **`--agent`** is not passed, the runner executes each listed agent in order and merges answers (routing is skipped for that `ask`).
+
+## MCP context (Phase 5)
+
+When the runner builds repository context for `repo_agent` (and related paths), it:
+
+- **Ranks** candidate files by query keywords, extension priority, and size, then packs text until a **tiktoken** budget is reached (split: system 20%, context 50%, tools 10%, completion 20% of `ADT_TOKEN_BUDGET`, default 16384).
+- **Caches** `read_repo_tree` results under `~/.adt/cache/` keyed by repo path and current `git` HEAD, with TTL `ADT_CACHE_TTL` (default 300s). Use CLI **`--no-cache`** to bypass.
+- **Logs** structured JSON lines to `~/.adt/logs/adt.jsonl` with **`--log-level`** (`DEBUG` / `INFO` / `WARNING` / `ERROR`).
+
+## `repo_agent`
+
+**Purpose:** Understand a local checkout (layout, files, symbols).
+
+**Tools:** `read_repo_tree`, `read_file`, `search_code`, `compare_repos`.
+
+**Context:** Repository-derived context from `repo_path` and any `additional_repo_paths`; multi-root sessions pack **labeled** blocks (`[context:repo label=r0 …]`).
+
+## `research_agent`
+
+**Purpose:** Discover academic papers and read public web articles.
+
+**Tools:**
+
+- `search_papers` — arXiv Atom API (`http://export.arxiv.org/api/query`).
+- `fetch_article` — public HTTP(S) pages with basic SSRF blocking.
+
+**Context:** Empty repository blob; external sources only.
+
+## `project_agent`
+
+**Purpose:** Roadmap and delivery status via **GitHub** and **local markdown**.
+
+**Tools:**
+
+- `read_issues` — `GET /repos/{owner}/{repo}/issues` (pull requests filtered out). Optional `state` (`open` / `closed` / `all`), `labels`, `max_results`.
+- `read_milestones` — `GET /repos/{owner}/{repo}/milestones`.
+- `read_markdown` — read `.md` / `.markdown` under the session markdown root; strips optional YAML front matter (`---` … `---`).
+
+**GitHub authentication:** Handlers receive a token from the CLI (`--token`) or environment **`GITHUB_TOKEN`**. Without a token, expect about **60 requests/hour** per IP; **403** responses include rate-limit hints when GitHub provides headers.
+
+**Context:** If a GitHub slug was passed on the CLI, the user message includes the default `owner/repo`. If only a local path was used, the runner adds repo tree context plus the markdown root path. Remote slug sessions skip the full tree (only short session hints) to avoid dumping unrelated `cwd` files.
+
+## Prompt engineering notes
+
+System prompts are **static strings** on each agent class (`repo_agent`, `project_agent`, `research_agent`). They are written to:
+
+- **Steer tool order** — e.g. repo agent starts with `read_repo_tree` unless paths are explicit; caps file reads per turn.
+- **Reduce hallucination** — instruct not to invent files or run shell commands; cite paths from tool output.
+- **Separate concerns** — project agent emphasizes GitHub API + markdown root; research agent emphasizes arXiv and safe HTTP fetch only.
+
+The **user message** assembled by `Runner` prepends the **packed context** (repo blocks, metadata) and ends with `User question:\n…`. No separate “chain-of-thought” channel: the model sees one user blob per turn.
+
+**Routing prompt** (`HybridSupervisor`) is minimal JSON-only: map the user text to one of three agent ids. It is kept short to limit latency and cost; failures fall back to **keyword routing** so behavior stays predictable in tests and offline scenarios.
+
+Tuning tips:
+
+- Adjust **keyword lists** in `supervisor.py` when users consistently mis-route.
+- Adjust **router system string** in `hybrid_supervisor.py` if the LLM over-selects one agent.
+- For **stricter repo behavior**, tighten the repo agent system prompt (e.g. max files, required `repo_key` wording for multi-repo).

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,0 +1,42 @@
+# Architecture
+
+This document summarizes how **agentic-dev-tool** (`adt`) is structured and why key choices were made. It complements the user-facing [README](../README.md) and the MCP-focused [mcp.md](mcp.md).
+
+## High-level flow
+
+1. **Input** — User question plus optional repo roots (`--repo`, repeatable), GitHub slug, or forced agent.
+2. **Configuration** — Defaults from `~/.adt/config.toml` and `ADT_*` environment variables; CLI flags override where applicable.
+3. **Routing** — `HybridSupervisor` tries a small **JSON LLM classification** (`LLMClient.complete_json_object`); on failure or when disabled, **keyword rules** (`Supervisor`) select `repo_agent`, `project_agent`, or `research_agent`.
+4. **Context** — `ContextBuilder` assembles bounded text: ranked files, tree listings, **tiktoken** budgets, optional **disk cache** for trees (`~/.adt/cache`). Multi-repo sessions use **labeled blocks** (`r0`, `r1`, …).
+5. **Execution** — `Runner` runs an OpenAI chat loop with **tools** from `ToolRegistry`; `ExecutionController` validates arguments (JSON Schema) and dispatches handlers.
+6. **Output** — `AgentResponse` (answer, tools used, routed agent, context summary). The CLI prints a Rich panel; the optional **FastAPI** layer returns JSON.
+
+Shared orchestration for CLI and HTTP lives in **`adt.ask_session.run_ask`**.
+
+## Major components
+
+| Module / area | Role |
+|---------------|------|
+| `adt.cli.app` | Typer entrypoint: `ask`, `config`, `serve`, `version`, `info`. |
+| `adt.ask_session` | Single-turn `run_ask` used by CLI and API. |
+| `adt.bootstrap` | Registers tools, builds `Runner`, wires `HybridSupervisor` + `LLMClient`. |
+| `adt.core.runner` | Budget allocation, context assembly per agent, tool loop, optional **agent_chain**. |
+| `adt.core.supervisor` | Deterministic keyword routing. |
+| `adt.core.hybrid_supervisor` | LLM routing with fallback to `Supervisor`. |
+| `adt.mcp.*` | Registry, executor, context builder, token budget, ranking, tree cache. |
+| `adt.tools.*` | Repo, project (GitHub + markdown), research (arXiv + HTTP fetch), `compare_repos`. |
+| `adt.api.server` | FastAPI: `/healthz`, `/ask` (optional extra `[api]`). |
+
+## Design decisions
+
+- **MCP-style, not a full MCP server** — Tools are described as JSON Schema and invoked in-process, which keeps deployment simple and avoids a long-running MCP host for the default CLI use case.
+- **Single OpenAI client** — One `LLMClient` for both chat and routing; routing uses `response_format: json_object` for a tiny payload.
+- **Multi-repo via explicit keys** — Session ids (`r0`, `r1`) avoid ambiguous path resolution and make `compare_repos` well-defined.
+- **Config file + env** — `toml` for persistent preferences; `ADT_*` for CI and shells without editing files.
+- **Optional API** — FastAPI and uvicorn are **not** core dependencies so `pip install agentic-dev-tool` stays lean for CLI-only users.
+
+## Extension points
+
+- **New tools** — Register `ToolDefinition` in `bootstrap.py` (or future plugin loading via `custom_tools` in config, reserved).
+- **New agents** — Subclass `BaseAgent`, add to `Runner` agent map and routing (LLM + keyword lists).
+- **Stricter API auth** — The stock server binds to `127.0.0.1` by default; add API keys or OAuth in front for public exposure.

--- a/docs/reference/mcp.md
+++ b/docs/reference/mcp.md
@@ -1,0 +1,27 @@
+# MCP layer specification
+
+This project uses a **simplified Model Context Protocol (MCP)**-style layer: tools are **declarative** (name, JSON Schema parameters, handler) and **executed in-process** against a `ToolRegistry`. It is **not** a network MCP server by default.
+
+## Concepts
+
+- **ToolRegistry** — Maps unique tool names to `ToolDefinition` (description, `parameters` schema, `allowed_agents`, Python `handler`).
+- **ExecutionController** — Validates tool call arguments with **jsonschema**, binds only parameters the handler accepts, runs the handler, returns `ToolResult` (text output, success flag).
+- **OpenAI tool format** — `registry.to_openai_format(agent_name)` filters tools by `allowed_agents` and emits `{"type":"function","function":{...}}` blocks for the chat API.
+- **ToolCall / ToolResult** — Pydantic models for assistant-proposed calls and normalized outcomes.
+
+## Context packing (not MCP wire format)
+
+Repository context is **plain text** embedded in the user message, not MCP resources:
+
+- Delimited blocks: `[context:repo label=r0 path=…]`, `[tree]`, `[file:rel/path]`, closing tags for budget trimming.
+- **Ranking** — Keyword overlap on paths, extension priority, smaller files preferred before packing.
+- **Budgeting** — `tiktoken` counts; `allocate_budget` splits a logical window (system / context / tools schema / completion).
+- **Cache** — Optional JSON cache files under `~/.adt/cache/` keyed by repo path and `git` HEAD, TTL configurable.
+
+## Logging
+
+Structured **JSON lines** append to `~/.adt/logs/adt.jsonl` (when file logging is configured): events such as `agent_selected`, `tool_called`, `request_completed`, `llm_failure`.
+
+## Relation to “full” MCP
+
+A full MCP deployment could expose the same tool set over stdio/WebSocket; this codebase optimizes for **CLI + optional HTTP** and **direct OpenAI tool calling** instead.

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -1,0 +1,37 @@
+# Skills
+
+Skills are structured Markdown documents that define LLM system prompts
+for specialized behaviors (e.g., supervised engineering guidance).
+
+## Built-in skills
+
+### Supervised Engineering
+
+Located at `src/adt/skills/supervised_engineering/SKILL.md`.
+
+This skill powers the `--mode supervised` workflow. It instructs the LLM
+to break problems into steps, provide hints rather than solutions, and
+adjust guidance based on the difficulty level.
+
+## Skill loading
+
+Skills are loaded via `load_skill_context()` which returns a
+`SkillContext` Pydantic model:
+
+```python
+from adt.skills.context import SkillContext
+
+class SkillContext(BaseModel):
+    name: str
+    markdown: str
+    variables: dict[str, str] = {}
+    version: str = "0"
+```
+
+The version is parsed from a `<!-- version: N -->` HTML comment
+in the Markdown header.
+
+## Community skills
+
+Place custom skills under `~/.adt/plugins/skills/<name>/SKILL.md`.
+See the [Plugins guide](../guides/plugins.md) for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,17 @@ dependencies = [
   "tiktoken>=0.5",
   "tomli>=2.0",
   "tomli-w>=1.0",
+  "jinja2>=3.1",
 ]
 
 [project.optional-dependencies]
 api = [
   "fastapi>=0.109",
   "uvicorn[standard]>=0.27",
+]
+docs = [
+  "mkdocs-material>=9.5",
+  "mkdocs-typer>=0.0.3",
 ]
 dev = [
   "pytest>=7.4",
@@ -60,6 +65,7 @@ dev = [
   "build>=1.0",
   "fastapi>=0.109",
   "uvicorn[standard]>=0.27",
+  "jinja2>=3.1",
 ]
 test = [
   "pytest>=7.4",

--- a/src/adt/analytics/html_export.py
+++ b/src/adt/analytics/html_export.py
@@ -1,0 +1,190 @@
+"""Render :class:`LearningStats` into a standalone HTML dashboard.
+
+The generated HTML embeds a simple SVG sparkline for the improvement
+trend and lays out all stats in a clean, printable single-page report.
+No external CDN is required — everything is inline.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from jinja2 import Template
+
+from adt.analytics.stats import LearningStats
+
+_TEMPLATE = Template(
+    """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>adt — Learning Stats Dashboard</title>
+<style>
+  :root { --bg: #f8f9fa; --card: #fff; --border: #dee2e6; --text: #212529;
+          --dim: #6c757d; --accent: #0d6efd; --green: #198754;
+          --yellow: #ffc107; --red: #dc3545; }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: system-ui, -apple-system, sans-serif;
+         background: var(--bg); color: var(--text); padding: 2rem; }
+  h1 { font-size: 1.6rem; margin-bottom: 0.25rem; }
+  .subtitle { color: var(--dim); margin-bottom: 1.5rem; font-size: 0.9rem; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+          gap: 1rem; margin-bottom: 2rem; }
+  .card { background: var(--card); border: 1px solid var(--border);
+          border-radius: 8px; padding: 1rem; }
+  .card .label { font-size: 0.8rem; color: var(--dim); text-transform: uppercase; }
+  .card .value { font-size: 1.8rem; font-weight: 700; margin-top: 0.25rem; }
+  .section { margin-bottom: 2rem; }
+  .section h2 { font-size: 1.1rem; margin-bottom: 0.75rem;
+                 border-bottom: 1px solid var(--border); padding-bottom: 0.25rem; }
+  table { width: 100%; border-collapse: collapse; }
+  th, td { text-align: left; padding: 0.4rem 0.75rem;
+           border-bottom: 1px solid var(--border); }
+  th { font-size: 0.8rem; color: var(--dim); text-transform: uppercase; }
+  .badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 4px;
+           font-size: 0.8rem; font-weight: 600; }
+  .badge-green { background: #d1e7dd; color: var(--green); }
+  .badge-yellow { background: #fff3cd; color: #664d03; }
+  .badge-red { background: #f8d7da; color: var(--red); }
+  svg.sparkline { display: block; margin: 0.5rem 0; }
+  footer { margin-top: 2rem; font-size: 0.75rem;
+           color: var(--dim); text-align: center; }
+</style>
+</head>
+<body>
+
+<h1>Learning Stats Dashboard</h1>
+<p class="subtitle">Generated {{ generated_at }}</p>
+
+<div class="grid">
+  <div class="card">
+    <div class="label">Sessions</div>
+    <div class="value">{{ stats.sessions }}</div>
+  </div>
+  <div class="card">
+    <div class="label">Reviews</div>
+    <div class="value">{{ stats.reviews }}</div>
+  </div>
+  <div class="card">
+    <div class="label">Supervised Steps</div>
+    <div class="value">{{ stats.supervised_steps }}</div>
+  </div>
+  <div class="card">
+    <div class="label">Avg Steps/Session</div>
+    <div class="value">{{ stats.avg_steps_per_session }}</div>
+  </div>
+  <div class="card">
+    <div class="label">Avg Iterations/Session</div>
+    <div class="value">{{ stats.avg_iterations_per_step }}</div>
+  </div>
+  <div class="card">
+    <div class="label">Total Tokens</div>
+    <div class="value">{{ "{:,}".format(stats.total_tokens) }}</div>
+  </div>
+</div>
+
+{% if stats.common_issues %}
+<div class="section">
+  <h2>Common Issues</h2>
+  <table>
+    <thead><tr><th>Category</th><th>Count</th></tr></thead>
+    <tbody>
+    {% for name, count in stats.common_issues %}
+      <tr><td>{{ name }}</td><td>{{ count }}</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+
+{% if stats.assessments %}
+<div class="section">
+  <h2>Review Verdicts</h2>
+  <table>
+    <thead><tr><th>Verdict</th><th>Count</th></tr></thead>
+    <tbody>
+    {% for name, count in assessments_sorted %}
+      <tr>
+        <td>
+          {% if name == "excellent" %}
+            <span class="badge badge-green">{{ name }}</span>
+          {% elif name == "on_track" %}
+            <span class="badge badge-yellow">{{ name }}</span>
+          {% else %}
+            <span class="badge badge-red">{{ name }}</span>
+          {% endif %}
+        </td>
+        <td>{{ count }}</td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
+
+{% if sparkline_svg %}
+<div class="section">
+  <h2>Improvement Trend</h2>
+  <p style="color: var(--dim); font-size: 0.85rem;">
+    Iterations per session ({{ trend_labels }})
+  </p>
+  {{ sparkline_svg }}
+</div>
+{% endif %}
+
+<footer>
+  adt — Agentic Dev Tool &middot; Learning Analytics Dashboard
+</footer>
+
+</body>
+</html>
+"""
+)
+
+
+def _build_sparkline_svg(
+    values: list[float],
+    width: int = 300,
+    height: int = 60,
+) -> str:
+    """Render a small SVG sparkline from a list of numeric values."""
+    if not values or len(values) < 2:
+        return ""
+    min_v = min(values)
+    max_v = max(values)
+    span = max_v - min_v if max_v != min_v else 1.0
+    padding = 4
+    w = width - 2 * padding
+    h = height - 2 * padding
+
+    points: list[str] = []
+    for i, v in enumerate(values):
+        x = padding + (i / (len(values) - 1)) * w
+        y = padding + h - ((v - min_v) / span) * h
+        points.append(f"{x:.1f},{y:.1f}")
+
+    polyline = " ".join(points)
+    return (
+        f'<svg class="sparkline" width="{width}" height="{height}" '
+        f'xmlns="http://www.w3.org/2000/svg">'
+        f'<polyline fill="none" stroke="#0d6efd" stroke-width="2" '
+        f'points="{polyline}"/>'
+        f"</svg>"
+    )
+
+
+def export_html(stats: LearningStats) -> str:
+    """Render the stats dashboard as a standalone HTML string."""
+    assessments_sorted = sorted(stats.assessments.items(), key=lambda kv: -kv[1])
+    sparkline_svg = _build_sparkline_svg(stats.improvement_trend)
+    trend_labels = " → ".join(str(v) for v in stats.improvement_trend)
+
+    return _TEMPLATE.render(
+        stats=stats,
+        generated_at=datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+        assessments_sorted=assessments_sorted,
+        sparkline_svg=sparkline_svg,
+        trend_labels=trend_labels,
+    )

--- a/src/adt/cli/app.py
+++ b/src/adt/cli/app.py
@@ -502,6 +502,13 @@ def stats_cmd(
             help="Issue classifier strategy: keyword (default) or embedding.",
         ),
     ] = "keyword",
+    html: Annotated[
+        str | None,
+        typer.Option(
+            "--html",
+            help="Generate an HTML dashboard to this directory.",
+        ),
+    ] = None,
 ) -> None:
     """Summarize supervised learning progress from ``~/.adt/logs/learning.jsonl``."""
     from adt.analytics import compute_stats, read_learning_events
@@ -528,6 +535,19 @@ def stats_cmd(
 
     events = read_learning_events()
     stats = compute_stats(events, last_n=last, classifier=classifier)
+
+    if html is not None:
+        from pathlib import Path as _HtmlPath
+
+        from adt.analytics.html_export import export_html
+
+        html_dir = _HtmlPath(html)
+        html_dir.mkdir(parents=True, exist_ok=True)
+        html_content = export_html(stats)
+        html_file = html_dir / "index.html"
+        html_file.write_text(html_content, encoding="utf-8")
+        console.print(f"[green]Dashboard written to {html_file}[/green]")
+        return
 
     if export is not None:
         from adt.analytics.exporter import export_csv, export_json, export_markdown

--- a/src/adt/cli/i18n.py
+++ b/src/adt/cli/i18n.py
@@ -1,0 +1,93 @@
+"""Minimal gettext-style i18n backed by TOML locale files.
+
+Locale files live under ``src/adt/locales/<lang>.toml`` and are shipped
+inside the wheel. The active locale is resolved from:
+
+1. ``ADT_LANG`` environment variable
+2. ``lang`` key in ``~/.adt/config.toml``
+3. Fallback to ``"en"``
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import tomli
+
+logger = logging.getLogger(__name__)
+
+_LOCALES_DIR = Path(__file__).resolve().parent.parent / "locales"
+
+
+def _resolve_lang() -> str:
+    """Determine the active language code."""
+    env = os.environ.get("ADT_LANG", "").strip()
+    if env:
+        return env
+
+    try:
+        from adt.config import load_config_file
+
+        cfg = load_config_file()
+        cfg_lang = getattr(cfg, "lang", None)
+        if cfg_lang:
+            return str(cfg_lang)
+    except Exception:  # noqa: BLE001
+        pass
+
+    return "en"
+
+
+@lru_cache(maxsize=4)
+def _load_locale(lang: str) -> dict[str, str]:
+    """Load a single TOML locale file into a flat ``{key: translation}`` dict."""
+    path = _LOCALES_DIR / f"{lang}.toml"
+    if not path.is_file():
+        if lang != "en":
+            logger.debug("locale file not found: %s, falling back to en", path)
+        return _load_locale("en") if lang != "en" else {}
+    try:
+        raw: dict[str, Any] = tomli.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomli.TOMLDecodeError) as exc:
+        logger.warning("failed to load locale %s: %s", lang, exc)
+        return _load_locale("en") if lang != "en" else {}
+
+    flat: dict[str, str] = {}
+    for section, entries in raw.items():
+        if isinstance(entries, dict):
+            for key, value in entries.items():
+                flat[f"{section}.{key}"] = str(value)
+        else:
+            flat[section] = str(entries)
+    return flat
+
+
+def t(key: str, **kwargs: Any) -> str:
+    """Translate *key* using the active locale, with ``str.format`` substitution.
+
+    Falls back to the English translation, then to *key* itself.
+    """
+    lang = _resolve_lang()
+    table = _load_locale(lang)
+    template = table.get(key)
+    if template is None:
+        if lang != "en":
+            en = _load_locale("en")
+            template = en.get(key)
+        if template is None:
+            return key
+    if kwargs:
+        try:
+            return template.format(**kwargs)
+        except (KeyError, IndexError):
+            return template
+    return template
+
+
+def reload_locale() -> None:
+    """Clear the locale cache (useful after config change or in tests)."""
+    _load_locale.cache_clear()

--- a/src/adt/cli/stats_renderer.py
+++ b/src/adt/cli/stats_renderer.py
@@ -7,6 +7,7 @@ from rich.panel import Panel
 from rich.text import Text
 
 from adt.analytics.stats import LearningStats
+from adt.cli.i18n import t
 
 
 class StatsRenderer:
@@ -18,15 +19,21 @@ class StatsRenderer:
     def render(self, stats: LearningStats) -> None:
         """Print the stats panel."""
         header = Text()
-        header.append(f"Sessions: {stats.sessions}".ljust(22), style="bold")
         header.append(
-            f"Avg steps/session: {stats.avg_steps_per_session}",
+            f"{t('stats.sessions')}: {stats.sessions}".ljust(22),
+            style="bold",
+        )
+        header.append(
+            f"{t('stats.avg_steps')}: {stats.avg_steps_per_session}",
             style="bold",
         )
         header.append("\n")
-        header.append(f"Reviews:  {stats.reviews}".ljust(22), style="bold")
         header.append(
-            f"Avg iterations/session: {stats.avg_iterations_per_step}",
+            f"{t('stats.reviews')}:  {stats.reviews}".ljust(22),
+            style="bold",
+        )
+        header.append(
+            f"{t('stats.avg_iterations')}: {stats.avg_iterations_per_step}",
             style="bold",
         )
 
@@ -35,18 +42,18 @@ class StatsRenderer:
         if stats.common_issues:
             issues = Text()
             issues.append("\n")
-            issues.append("Common Issues:\n", style="bold")
+            issues.append(f"{t('stats.common_issues')}:\n", style="bold")
             for rank, (name, count) in enumerate(stats.common_issues, start=1):
                 issues.append(f"  {rank}. ")
                 issues.append(name, style="yellow")
-                noun = "occurrence" if count == 1 else "occurrences"
+                noun = t("stats.occurrence") if count == 1 else t("stats.occurrences")
                 issues.append(f" ({count} {noun})\n", style="dim")
             sections.append(issues)
 
         if stats.assessments:
             verdict = Text()
             verdict.append("\n")
-            verdict.append("Review Verdicts:\n", style="bold")
+            verdict.append(f"{t('stats.review_verdicts')}:\n", style="bold")
             for name, count in sorted(stats.assessments.items(), key=lambda kv: -kv[1]):
                 verdict.append("  - ")
                 verdict.append(name, style=_verdict_style(name))
@@ -56,8 +63,8 @@ class StatsRenderer:
         if stats.improvement_trend:
             trend = Text()
             trend.append("\n")
-            trend.append("Improvement Trend:\n", style="bold")
-            trend.append("  Iterations per session: ")
+            trend.append(f"{t('stats.improvement_trend')}:\n", style="bold")
+            trend.append(f"  {t('stats.iterations_per_session')}: ")
             arrow = " -> ".join(str(v) for v in stats.improvement_trend)
             trend.append(arrow, style="cyan")
             sections.append(trend)
@@ -65,24 +72,20 @@ class StatsRenderer:
         if stats.total_tokens:
             tokens = Text()
             tokens.append("\n")
-            tokens.append("Total LLM tokens: ", style="bold")
+            tokens.append(f"{t('stats.total_tokens')}: ", style="bold")
             tokens.append(f"{stats.total_tokens:,}", style="dim")
             sections.append(tokens)
 
         if stats.sessions == 0:
             empty = Text()
             empty.append("\n")
-            empty.append(
-                "No supervised learning events recorded yet. Run "
-                "`adt ask ... --mode supervised` or `adt review` first.",
-                style="dim",
-            )
+            empty.append(t("stats.no_events"), style="dim")
             sections.append(empty)
 
         self._console.print(
             Panel(
                 Group(*sections),
-                title="Learning Stats",
+                title=t("stats.title"),
                 border_style="blue",
                 title_align="left",
             ),

--- a/src/adt/config.py
+++ b/src/adt/config.py
@@ -40,6 +40,7 @@ class AdtConfig:
     review_max_bytes: int = 200_000
     agent_chain: list[str] = field(default_factory=list)
     custom_tools: list[str] = field(default_factory=list)
+    lang: str = "en"
 
     def to_toml_table(self) -> dict[str, Any]:
         """Serialize the ``adt`` table for writing."""
@@ -53,6 +54,7 @@ class AdtConfig:
             "review_max_bytes": self.review_max_bytes,
             "agent_chain": self.agent_chain,
             "custom_tools": self.custom_tools,
+            "lang": self.lang,
         }
         if self.token_budget is not None:
             d["token_budget"] = self.token_budget
@@ -74,6 +76,7 @@ class AdtConfig:
             ("review_max_bytes", 200_000),
             ("agent_chain", []),
             ("custom_tools", []),
+            ("lang", "en"),
         ]:
             if key not in known:
                 continue
@@ -146,6 +149,7 @@ def apply_env_overrides(cfg: AdtConfig) -> AdtConfig:
         token_budget=cfg.token_budget,
         agent_chain=list(cfg.agent_chain),
         custom_tools=list(cfg.custom_tools),
+        lang=os.environ.get("ADT_LANG", cfg.lang),
     )
     if os.environ.get("ADT_CACHE_TTL", "").strip():
         with contextlib.suppress(ValueError):
@@ -208,6 +212,8 @@ def update_config_key(path: Path | None, key: str, value: str) -> AdtConfig:
     elif key_norm == "custom_tools":
         parts = [p.strip() for p in value.split(",") if p.strip()]
         cfg = replace(cfg, custom_tools=parts)
+    elif key_norm == "lang":
+        cfg = replace(cfg, lang=value.strip())
     else:
         msg = f"Unknown config key: {key!r}"
         raise ValueError(msg)

--- a/src/adt/config_validator.py
+++ b/src/adt/config_validator.py
@@ -92,6 +92,12 @@ def validate_key_value(key: str, raw: str) -> None:
                 f"review_max_bytes must be at least 1024, got {raw}."
             )
 
+    elif k == "lang":
+        if not raw.strip():
+            raise ConfigValidationError(
+                "lang must be a non-empty locale code (e.g. 'en', 'pt_BR')."
+            )
+
     elif k == "agent_chain":
         parts = [p.strip() for p in raw.split(",") if p.strip()]
         for part in parts:

--- a/src/adt/locales/en.toml
+++ b/src/adt/locales/en.toml
@@ -1,0 +1,90 @@
+# English locale for adt CLI
+
+[common]
+error = "Error"
+saved = "Saved."
+no_data = "No data."
+
+[session]
+no_active = "No active supervised session."
+cleared = "Session '{name}' cleared."
+nothing_to_clear = "No session '{name}' found — nothing to clear."
+not_found = "No session '{name}' found."
+exported = "Session exported to {path}"
+no_sessions = "No sessions found."
+
+[stats]
+title = "Learning Stats"
+sessions = "Sessions"
+reviews = "Reviews"
+avg_steps = "Avg steps/session"
+avg_iterations = "Avg iterations/session"
+common_issues = "Common Issues"
+review_verdicts = "Review Verdicts"
+improvement_trend = "Improvement Trend"
+iterations_per_session = "Iterations per session"
+total_tokens = "Total LLM tokens"
+no_events = "No supervised learning events recorded yet. Run `adt ask ... --mode supervised` or `adt review` first."
+exported = "Stats exported to {path}"
+occurrence = "occurrence"
+occurrences = "occurrences"
+dashboard_written = "Dashboard written to {path}"
+
+[review]
+panel_title = "Code Review"
+panel_title_raw = "Code Review (raw)"
+strengths = "Strengths"
+improvements = "Improvements"
+next_step = "Next Step"
+hint_prefix = "Hint: "
+needs_work = "Needs Work"
+on_track = "On Track"
+excellent = "Excellent"
+
+[supervised]
+panel_title = "Supervised Mode"
+level = "Level"
+problem = "Problem"
+requirements = "Requirements"
+hints = "Hints"
+questions = "Questions for you"
+next_prefix = "Next: "
+beginner = "Beginner"
+intermediate = "Intermediate"
+advanced = "Advanced"
+
+[guide]
+title = "adt — Quick Reference"
+commands = "Commands"
+modes = "Modes"
+levels = "Difficulty Levels (supervised mode)"
+agents = "Agents"
+skills = "Skills"
+environment = "Environment"
+
+[ask]
+agent_label = "Agent"
+tools_label = "Tools used"
+last_review = "Last review: {verdict} — continue at step {step}/{total}"
+
+[runs]
+no_runs = "No saved runs."
+not_found = "Run '{id}' not found."
+deleted = "Run '{id}' deleted."
+
+[plugins]
+no_plugins = "No plugins installed."
+valid = "Plugin is valid."
+skills_header = "Skills"
+tools_header = "Tools"
+
+[config]
+unknown_key = "Unknown config key: {key}"
+
+[errors]
+invalid_mode = "Invalid --mode {mode}. Choose one of: {options}."
+invalid_level = "Invalid --level {level}. Choose one of: {options}."
+invalid_agent = "Invalid --agent. Choose one of: {options}."
+unexpected = "Unexpected error while running the agent."
+missing_api_key = "Missing OPENAI_API_KEY. Set it in the environment or in a .env file."
+missing_api_deps = "Missing API dependencies. Install with: pip install 'agentic-dev-tool[api]'"

--- a/src/adt/locales/pt_BR.toml
+++ b/src/adt/locales/pt_BR.toml
@@ -1,0 +1,90 @@
+# Brazilian Portuguese locale for adt CLI
+
+[common]
+error = "Erro"
+saved = "Salvo."
+no_data = "Sem dados."
+
+[session]
+no_active = "Nenhuma sessão supervisionada ativa."
+cleared = "Sessão '{name}' limpa."
+nothing_to_clear = "Nenhuma sessão '{name}' encontrada — nada para limpar."
+not_found = "Nenhuma sessão '{name}' encontrada."
+exported = "Sessão exportada para {path}"
+no_sessions = "Nenhuma sessão encontrada."
+
+[stats]
+title = "Estatísticas de Aprendizado"
+sessions = "Sessões"
+reviews = "Revisões"
+avg_steps = "Passos médios/sessão"
+avg_iterations = "Iterações médias/sessão"
+common_issues = "Problemas Comuns"
+review_verdicts = "Vereditos de Revisão"
+improvement_trend = "Tendência de Melhoria"
+iterations_per_session = "Iterações por sessão"
+total_tokens = "Total de tokens LLM"
+no_events = "Nenhum evento de aprendizado supervisionado registrado. Execute `adt ask ... --mode supervised` ou `adt review` primeiro."
+exported = "Estatísticas exportadas para {path}"
+occurrence = "ocorrência"
+occurrences = "ocorrências"
+dashboard_written = "Dashboard salvo em {path}"
+
+[review]
+panel_title = "Revisão de Código"
+panel_title_raw = "Revisão de Código (bruto)"
+strengths = "Pontos Fortes"
+improvements = "Melhorias"
+next_step = "Próximo Passo"
+hint_prefix = "Dica: "
+needs_work = "Precisa Melhorar"
+on_track = "No Caminho"
+excellent = "Excelente"
+
+[supervised]
+panel_title = "Modo Supervisionado"
+level = "Nível"
+problem = "Problema"
+requirements = "Requisitos"
+hints = "Dicas"
+questions = "Perguntas para você"
+next_prefix = "Próximo: "
+beginner = "Iniciante"
+intermediate = "Intermediário"
+advanced = "Avançado"
+
+[guide]
+title = "adt — Referência Rápida"
+commands = "Comandos"
+modes = "Modos"
+levels = "Níveis de Dificuldade (modo supervisionado)"
+agents = "Agentes"
+skills = "Habilidades"
+environment = "Ambiente"
+
+[ask]
+agent_label = "Agente"
+tools_label = "Ferramentas usadas"
+last_review = "Última revisão: {verdict} — continue no passo {step}/{total}"
+
+[runs]
+no_runs = "Nenhuma execução salva."
+not_found = "Execução '{id}' não encontrada."
+deleted = "Execução '{id}' deletada."
+
+[plugins]
+no_plugins = "Nenhum plugin instalado."
+valid = "Plugin é válido."
+skills_header = "Habilidades"
+tools_header = "Ferramentas"
+
+[config]
+unknown_key = "Chave de configuração desconhecida: {key}"
+
+[errors]
+invalid_mode = "--mode {mode} inválido. Escolha um dos: {options}."
+invalid_level = "--level {level} inválido. Escolha um dos: {options}."
+invalid_agent = "--agent inválido. Escolha um dos: {options}."
+unexpected = "Erro inesperado ao executar o agente."
+missing_api_key = "OPENAI_API_KEY não encontrada. Defina-a no ambiente ou em um arquivo .env."
+missing_api_deps = "Dependências da API ausentes. Instale com: pip install 'agentic-dev-tool[api]'"

--- a/tests/unit/test_phase10_experience.py
+++ b/tests/unit/test_phase10_experience.py
@@ -1,0 +1,340 @@
+"""Tests for Phase 10.5 — Product Experience (P10-17, P10-18, P10-19)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# ── P10-17: MkDocs site ──────────────────────────────────────────────
+
+_DOCS_DIR = Path(__file__).resolve().parents[2] / "docs"
+
+
+def test_mkdocs_config_exists() -> None:
+    """mkdocs.yml must be present in the docs directory."""
+    assert (_DOCS_DIR / "mkdocs.yml").is_file()
+
+
+def test_mkdocs_index_exists() -> None:
+    """docs/index.md must be present."""
+    assert (_DOCS_DIR / "index.md").is_file()
+
+
+def test_mkdocs_getting_started_pages() -> None:
+    assert (_DOCS_DIR / "getting-started" / "install.md").is_file()
+    assert (_DOCS_DIR / "getting-started" / "quickstart.md").is_file()
+
+
+def test_mkdocs_guide_pages() -> None:
+    for page in ("supervised", "tracing", "analytics", "plugins"):
+        path = _DOCS_DIR / "guides" / f"{page}.md"
+        assert path.is_file(), f"missing guides/{page}.md"
+
+
+def test_mkdocs_reference_pages() -> None:
+    for page in ("architecture", "agents", "mcp", "skills"):
+        path = _DOCS_DIR / "reference" / f"{page}.md"
+        assert path.is_file(), f"missing reference/{page}.md"
+
+
+def test_mkdocs_api_pages() -> None:
+    for page in ("cli", "http"):
+        assert (_DOCS_DIR / "api" / f"{page}.md").is_file(), f"missing api/{page}.md"
+
+
+def test_github_workflow_docs_exists() -> None:
+    wf = Path(__file__).resolve().parents[2] / ".github" / "workflows" / "docs.yml"
+    assert wf.is_file()
+
+
+# ── P10-18: HTML dashboard ───────────────────────────────────────────
+
+
+def test_html_export_contains_expected_sections() -> None:
+    from adt.analytics.html_export import export_html
+    from adt.analytics.stats import LearningStats
+
+    stats = LearningStats(
+        sessions=3,
+        reviews=5,
+        supervised_steps=10,
+        avg_steps_per_session=3.3,
+        avg_iterations_per_step=2.1,
+        common_issues=[("naming", 4), ("complexity", 2)],
+        assessments={"excellent": 2, "needs_work": 1, "on_track": 2},
+        improvement_trend=[3.0, 2.5, 2.0],
+        total_tokens=12345,
+    )
+    html = export_html(stats)
+    assert "<!DOCTYPE html>" in html
+    assert "Learning Stats Dashboard" in html
+    assert "Sessions" in html
+    assert "12,345" in html  # formatted token count
+    assert "naming" in html
+    assert "complexity" in html
+    assert "excellent" in html
+    assert "needs_work" in html
+
+
+def test_html_export_sparkline_svg() -> None:
+    from adt.analytics.html_export import _build_sparkline_svg
+
+    svg = _build_sparkline_svg([1.0, 2.0, 3.0])
+    assert "<svg" in svg
+    assert "polyline" in svg
+    assert 'class="sparkline"' in svg
+
+
+def test_html_export_sparkline_empty() -> None:
+    from adt.analytics.html_export import _build_sparkline_svg
+
+    assert _build_sparkline_svg([]) == ""
+    assert _build_sparkline_svg([1.0]) == ""
+
+
+def test_html_export_empty_stats() -> None:
+    from adt.analytics.html_export import export_html
+    from adt.analytics.stats import LearningStats
+
+    stats = LearningStats(
+        sessions=0,
+        reviews=0,
+        supervised_steps=0,
+        avg_steps_per_session=0.0,
+        avg_iterations_per_step=0.0,
+        common_issues=[],
+        assessments={},
+        improvement_trend=[],
+        total_tokens=0,
+    )
+    html = export_html(stats)
+    assert "<!DOCTYPE html>" in html
+    # No sparkline when no trend
+    assert "sparkline" not in html or "polyline" not in html
+
+
+def test_stats_cmd_html_flag(tmp_path: Path) -> None:
+    """--html flag should create an index.html file."""
+    from unittest.mock import patch
+
+    from typer.testing import CliRunner
+
+    from adt.analytics.stats import LearningStats
+    from adt.cli.app import app
+
+    runner = CliRunner()
+    fake_stats = LearningStats(
+        sessions=1,
+        reviews=1,
+        supervised_steps=2,
+        avg_steps_per_session=2.0,
+        avg_iterations_per_step=1.0,
+        common_issues=[],
+        assessments={},
+        improvement_trend=[],
+        total_tokens=100,
+    )
+    with (
+        patch("adt.analytics.read_learning_events", return_value=[]),
+        patch("adt.analytics.compute_stats", return_value=fake_stats),
+    ):
+        html_dir = tmp_path / "dash"
+        result = runner.invoke(app, ["stats", "--html", str(html_dir)])
+    assert result.exit_code == 0
+    assert (html_dir / "index.html").is_file()
+    content = (html_dir / "index.html").read_text(encoding="utf-8")
+    assert "<!DOCTYPE html>" in content
+
+
+# ── P10-19: i18n ─────────────────────────────────────────────────────
+
+
+def test_locale_en_loads() -> None:
+    from adt.cli.i18n import _load_locale
+
+    _load_locale.cache_clear()
+    table = _load_locale("en")
+    assert "stats.title" in table
+    assert table["stats.title"] == "Learning Stats"
+
+
+def test_locale_pt_br_loads() -> None:
+    from adt.cli.i18n import _load_locale
+
+    _load_locale.cache_clear()
+    table = _load_locale("pt_BR")
+    assert "stats.title" in table
+    assert table["stats.title"] == "Estatísticas de Aprendizado"
+
+
+def test_t_returns_english_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    from adt.cli.i18n import reload_locale, t
+
+    monkeypatch.delenv("ADT_LANG", raising=False)
+    reload_locale()
+    assert t("stats.title") == "Learning Stats"
+
+
+def test_t_returns_portuguese_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    from adt.cli.i18n import reload_locale, t
+
+    monkeypatch.setenv("ADT_LANG", "pt_BR")
+    reload_locale()
+    result = t("stats.title")
+    assert result == "Estatísticas de Aprendizado"
+    # Restore
+    monkeypatch.delenv("ADT_LANG", raising=False)
+    reload_locale()
+
+
+def test_t_fallback_to_en_for_unknown_locale(monkeypatch: pytest.MonkeyPatch) -> None:
+    from adt.cli.i18n import reload_locale, t
+
+    monkeypatch.setenv("ADT_LANG", "zz_ZZ")
+    reload_locale()
+    result = t("stats.title")
+    assert result == "Learning Stats"
+    monkeypatch.delenv("ADT_LANG", raising=False)
+    reload_locale()
+
+
+def test_t_fallback_to_key_for_missing_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    from adt.cli.i18n import reload_locale, t
+
+    monkeypatch.delenv("ADT_LANG", raising=False)
+    reload_locale()
+    assert t("nonexistent.key.abc") == "nonexistent.key.abc"
+
+
+def test_t_format_substitution(monkeypatch: pytest.MonkeyPatch) -> None:
+    from adt.cli.i18n import reload_locale, t
+
+    monkeypatch.delenv("ADT_LANG", raising=False)
+    reload_locale()
+    result = t("session.cleared", name="test")
+    assert result == "Session 'test' cleared."
+
+
+def test_t_format_substitution_pt_br(monkeypatch: pytest.MonkeyPatch) -> None:
+    from adt.cli.i18n import reload_locale, t
+
+    monkeypatch.setenv("ADT_LANG", "pt_BR")
+    reload_locale()
+    result = t("session.cleared", name="teste")
+    assert result == "Sessão 'teste' limpa."
+    monkeypatch.delenv("ADT_LANG", raising=False)
+    reload_locale()
+
+
+def test_reload_locale_clears_cache() -> None:
+    from adt.cli.i18n import _load_locale, reload_locale
+
+    _load_locale("en")
+    assert _load_locale.cache_info().currsize > 0
+    reload_locale()
+    assert _load_locale.cache_info().currsize == 0
+
+
+def test_stats_renderer_uses_i18n(monkeypatch: pytest.MonkeyPatch) -> None:
+    """StatsRenderer should use t() for labels — check pt_BR output."""
+    from io import StringIO
+
+    from rich.console import Console
+
+    from adt.analytics.stats import LearningStats
+    from adt.cli.i18n import reload_locale
+    from adt.cli.stats_renderer import StatsRenderer
+
+    monkeypatch.setenv("ADT_LANG", "pt_BR")
+    reload_locale()
+
+    buf = StringIO()
+    c = Console(file=buf, force_terminal=True, width=120)
+    stats = LearningStats(
+        sessions=2,
+        reviews=3,
+        supervised_steps=5,
+        avg_steps_per_session=2.5,
+        avg_iterations_per_step=1.5,
+        common_issues=[("naming", 2)],
+        assessments={"excellent": 1},
+        improvement_trend=[2.0, 1.5],
+        total_tokens=500,
+    )
+    StatsRenderer(c).render(stats)
+    output = buf.getvalue()
+    # Panel title should be in Portuguese
+    assert "Estatísticas de Aprendizado" in output
+    # Labels should be in Portuguese
+    assert "Sessões" in output
+    assert "Revisões" in output
+
+    monkeypatch.delenv("ADT_LANG", raising=False)
+    reload_locale()
+
+
+def test_config_lang_field() -> None:
+    """AdtConfig should have a lang field defaulting to 'en'."""
+    from adt.config import AdtConfig
+
+    cfg = AdtConfig()
+    assert cfg.lang == "en"
+
+    cfg2 = AdtConfig(lang="pt_BR")
+    assert cfg2.lang == "pt_BR"
+
+
+def test_config_lang_round_trip() -> None:
+    """lang should survive to_toml_table / from_toml_table."""
+    from adt.config import AdtConfig
+
+    cfg = AdtConfig(lang="pt_BR")
+    table = cfg.to_toml_table()
+    assert table["lang"] == "pt_BR"
+
+    restored = AdtConfig.from_toml_table(table)
+    assert restored.lang == "pt_BR"
+
+
+def test_config_update_lang(tmp_path: Path) -> None:
+    """update_config_key should persist lang changes."""
+    from adt.config import AdtConfig, load_config_file, save_config, update_config_key
+
+    cfg_path = tmp_path / "config.toml"
+    save_config(AdtConfig(), cfg_path)
+
+    updated = update_config_key(cfg_path, "lang", "pt_BR")
+    assert updated.lang == "pt_BR"
+
+    reloaded = load_config_file(cfg_path)
+    assert reloaded.lang == "pt_BR"
+
+
+def test_config_validator_accepts_lang() -> None:
+    from adt.config_validator import validate_key_value
+
+    # Should not raise
+    validate_key_value("lang", "en")
+    validate_key_value("lang", "pt_BR")
+
+
+def test_config_validator_rejects_empty_lang() -> None:
+    from adt.config_validator import ConfigValidationError, validate_key_value
+
+    with pytest.raises(ConfigValidationError, match="non-empty"):
+        validate_key_value("lang", "")
+
+    with pytest.raises(ConfigValidationError, match="non-empty"):
+        validate_key_value("lang", "   ")
+
+
+def test_all_en_keys_present_in_pt_br() -> None:
+    """Every key in en.toml must also exist in pt_BR.toml."""
+    from adt.cli.i18n import _load_locale
+
+    _load_locale.cache_clear()
+    en = _load_locale("en")
+    pt = _load_locale("pt_BR")
+    missing = set(en.keys()) - set(pt.keys())
+    assert not missing, f"Keys missing from pt_BR.toml: {missing}"


### PR DESCRIPTION
## Summary

- **P10-17 — MkDocs Material site**: 13 documentation pages (getting-started, guides, reference, API), `docs/mkdocs.yml` with Material theme + dark mode toggle, GitHub Pages deployment workflow (`.github/workflows/docs.yml`), `docs` optional dependency, Docs badge in README
- **P10-18 — HTML dashboard**: `adt stats --html <dir>` generates a standalone single-page report with inline CSS, SVG sparkline for improvement trend, and Jinja2 templating — no external CDN required (`src/adt/analytics/html_export.py`)
- **P10-19 — Internationalization**: TOML-based i18n system (`src/adt/cli/i18n.py`) with `t(key, **kwargs)` lookup, `@lru_cache` locale loading, full `en` + `pt_BR` translations (~60 keys each), `lang` field on `AdtConfig`, `ADT_LANG` env var, config validator support, and `StatsRenderer` wired with `t()` to demonstrate locale switching

## Validation

- **486 tests pass** (28 new for Phase 10.5)
- `ruff check` — clean
- `ruff format` — clean
- `mypy` — no issues (71 source files)

## Test plan

- [x] `python -m pytest` — all 486 tests pass
- [x] `ruff check src/ tests/` — no errors
- [x] `ruff format --check src/ tests/` — all formatted
- [x] `mypy src/` — success on 71 files
- [ ] Manual: `adt stats --html /tmp/dash` generates valid `index.html`
- [ ] Manual: `ADT_LANG=pt_BR adt stats` shows labels in Portuguese
- [ ] Manual: `adt config set lang pt_BR` persists and switches locale

