### PR TITLE
feat(cli): streaming output and adt shell interactive REPL (Phase 10.6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Docs](https://img.shields.io/badge/docs-mkdocs-blue.svg)](https://brunoramosmartins.github.io/agentic-dev-tool)
 
-**Portfolio-grade CLI** (and optional **HTTP API**) that routes natural-language questions to **specialized agents**—repository analysis, GitHub project context, and technical research—backed by **OpenAI tool calling** and an **MCP-style** in-process layer: tool **registry**, **JSON Schema** validation, **tiktoken** budgets, ranked context, and disk cache. Ships with a **supervised learning mode** (step-by-step teaching with difficulty levels), **code review**, **request tracing** with cost estimates, and **learning analytics**.
-
-## Demo
+A **production-grade CLI and HTTP API** that turns natural-language questions into actionable answers by routing them to **specialized AI agents** — repository analysis, GitHub project context, and technical research — powered by **OpenAI tool calling** and an **MCP-style** orchestration layer.
 
 <p align="center">
   <img src="docs/assets/demo.gif" alt="adt ask demo" width="800">
@@ -16,144 +14,25 @@
 
 ---
 
-## Contents
+## Highlights
 
-- [Why this project](#why-this-project)
-- [Features](#features)
-- [Architecture](#architecture)
-- [Quick start](#quick-start)
-- [Installation](#installation)
-- [Setup checklist (keys, env, secrets)](#setup-checklist-keys-env-secrets)
-- [Configuration](#configuration)
-- [Usage](#usage)
-- [HTTP API (optional)](#http-api-optional)
-- [Commands](#commands)
-- [File layout and state](#file-layout-and-state)
-- [Skills](#skills)
-- [Development](#development)
-- [Releasing (maintainers: PyPI + GitHub)](#releasing-maintainers-pypi--github)
-- [Portfolio checklist](#portfolio-checklist)
-- [Documentation](#documentation)
-- [License](#license)
+- **Multi-agent routing** — A hybrid supervisor (LLM intent classifier + keyword fallback) picks the best agent for each query
+- **Tool-calling loop** — Agents invoke registered tools (file reading, code search, GitHub API, arXiv) through a validated JSON Schema pipeline with token budgets
+- **Supervised learning mode** — Step-by-step teaching with `beginner` / `intermediate` / `advanced` difficulty levels, session persistence, and structured code review
+- **Learning analytics** — Track progress over time with `adt stats`, export to CSV/JSON/Markdown, or generate a standalone HTML dashboard
+- **Request tracing** — `--trace` reveals the full chain: routing → context build → LLM/tool calls → token + USD cost estimates
+- **Interactive REPL** — `adt shell` opens a persistent terminal with history, autocomplete, slash commands, and supervised practice — all in one session
+- **Internationalization** — Full `en` and `pt_BR` locale support via `ADT_LANG` or `adt config set lang pt_BR`
+- **Extensible** — Community plugins (skills + tools) loaded from `~/.adt/plugins/`, plus an optional FastAPI HTTP surface
 
 ---
 
-## Why this project
-
-This repo demonstrates **agentic architecture** without a toy script: a real **Typer** CLI, **Pydantic** schemas, **hybrid routing** (LLM JSON classification + keyword fallback), **multi-repo** sessions, **CI** (Ruff, mypy, pytest, package smoke install), and an **optional FastAPI** surface. It maps to a full **phase roadmap** ([`ROADMAP.md`](ROADMAP.md)) from bootstrap through **v1.0.0** on PyPI.
-
----
-
-## Features
-
-| Area | What you get |
-|------|----------------|
-| **Agents** | `repo_agent`, `project_agent`, `research_agent` with tool loops |
-| **Routing** | `HybridSupervisor`: cheap LLM JSON intent + keyword-rule fallback |
-| **Repos** | Multi `--repo`, `compare_repos`, tree cache, ranked files |
-| **GitHub** | Issues/milestones via API; optional PAT for rate limits |
-| **Research** | arXiv + HTTP fetch tools |
-| **Supervised mode** | Step-by-step teaching guided by the `supervised_engineering` skill |
-| **Difficulty levels** | `beginner`, `intermediate`, `advanced` reshape hints, granularity, and tone |
-| **Code review** | `adt review <file>` → structured feedback (issues, strengths, next step, verdict) |
-| **Learning analytics** | Rotating `~/.adt/logs/learning.jsonl` + `adt stats` panel with trends, verdicts, common issues, tokens |
-| **Tracing** | `--trace` shows routing → context build → LLM/tool calls with token + USD estimates |
-| **Config** | `~/.adt/config.toml` + `adt config show/set/path` + `ADT_*` env overrides |
-| **Guide** | `adt guide` prints a static cheat sheet (no API key needed) |
-| **API** | `adt serve` — FastAPI `/healthz`, `/ask` ([`[api]`](https://pypi.org/project/agentic-dev-tool/) extra) |
-
----
-
-## Architecture
-
-High-level data flow from terminal or HTTP into one shared pipeline (`adt.ask_session.run_ask`), then the runner, tools, and model. Shaded subsystems (Supervised, Tracing, Analytics) are Phase 8/9 additions that wrap the base agent loop.
-
-```mermaid
-flowchart TB
-  subgraph entry["Entry"]
-    CLI["Typer CLI<br/>ask · review · stats · guide · config · serve"]
-    HTTP["FastAPI optional<br/>POST /ask · GET /healthz"]
-  end
-
-  subgraph orch["Orchestration"]
-    ASK["ask_session.run_ask<br/>review_session.run_review"]
-    BOOT["bootstrap.build_runner"]
-    HYB["HybridSupervisor<br/>LLM JSON + keyword rules"]
-    SUP["SupervisedSupervisor<br/>step + review prompts"]
-    RUN["Runner<br/>chat + tool loop · budgets"]
-  end
-
-  subgraph mcp["MCP-style layer"]
-    REG["ToolRegistry"]
-    EXE["ExecutionController"]
-    CTX["ContextBuilder<br/>ranking · tiktoken · cache"]
-  end
-
-  subgraph agents["Agents"]
-    RA["repo_agent"]
-    PA["project_agent"]
-    RE["research_agent"]
-  end
-
-  subgraph supervised["Supervised (Phase 9)"]
-    SKILL["skills/<br/>supervised_engineering"]
-    LVL["level_config<br/>beginner/intermediate/advanced"]
-    SESS["SessionContext<br/>~/.adt/session.json"]
-  end
-
-  subgraph obs["Tracing + Analytics (Phase 8/9)"]
-    TRC["TraceContext + events<br/>renderer · cost estimator"]
-    ANL["analytics/<br/>LearningEvent · stats · reader"]
-    LOG["~/.adt/logs/<br/>adt.jsonl · learning.jsonl"]
-  end
-
-  LLM["LLMClient<br/>OpenAI"]
-
-  CLI --> ASK
-  HTTP --> ASK
-  ASK --> BOOT
-  ASK --> SUP
-  ASK --> TRC
-  ASK --> ANL
-  SUP --> SKILL
-  SUP --> LVL
-  SUP --> SESS
-  BOOT --> HYB
-  BOOT --> RUN
-  BOOT --> REG
-  BOOT --> CTX
-  HYB --> RUN
-  RUN --> RA
-  RUN --> PA
-  RUN --> RE
-  RUN --> LLM
-  RUN --> EXE
-  EXE --> REG
-  CTX --> RUN
-  TRC --> RUN
-  ANL --> LOG
-  TRC -.render.-> CLI
-```
-
-**Narrative:** the user’s query and repo hints become a `QueryRequest`; the hybrid supervisor picks an agent; `ContextBuilder` packs bounded context; the `Runner` chats with the model, executes **tool calls** through the registry/executor, and returns an `AgentResponse` (answer, tools used, routing metadata). In **supervised mode**, `SupervisedSupervisor` overrides the prompt using the packaged `supervised_engineering` skill plus level directives and persists a lightweight `SessionContext` between runs. The **review** flow reuses the same skill to produce structured feedback (`ReviewFeedback`). **Tracing** captures per-iteration events (routing, context build, LLM/tool calls) plus token + USD estimates. **Analytics** writes supervised and review outcomes to a rotating JSONL log that `adt stats` aggregates. The CLI renders **Rich** panels; the API returns JSON.
-
-Deeper design notes: [`docs/architecture.md`](docs/architecture.md) · tool contracts: [`docs/mcp.md`](docs/mcp.md) · agents/prompts: [`docs/agents.md`](docs/agents.md).
-
----
-
-## Quick start
+## Quick Start
 
 ```bash
 pip install agentic-dev-tool
-export OPENAI_API_KEY="sk-..."   # Windows PowerShell: $env:OPENAI_API_KEY="sk-..."
+export OPENAI_API_KEY="sk-..."
 adt ask "What does this codebase do?" --repo .
-```
-
-Optional GitHub-backed questions (better with a token):
-
-```bash
-export GITHUB_TOKEN="ghp_..."    # fine-grained or classic PAT with repo read
-adt ask "Summarize open issues" --repo owner/repo
 ```
 
 ---
@@ -162,315 +41,90 @@ adt ask "Summarize open issues" --repo owner/repo
 
 Requires **Python 3.10+**.
 
-### From PyPI
-
 ```bash
+# Core CLI
 pip install agentic-dev-tool
-adt version
-```
 
-Optional HTTP API:
-
-```bash
+# With HTTP API server
 pip install "agentic-dev-tool[api]"
-adt serve --port 8765
-# Docs: http://127.0.0.1:8765/docs
-```
 
-### From source (contributors)
+# With interactive REPL
+pip install "agentic-dev-tool[shell]"
 
-```bash
-python -m venv .venv
-source .venv/bin/activate          # Windows: .venv\Scripts\activate
+# From source (contributors)
 pip install -e ".[dev]"
-pre-commit install                 # optional
-```
-
-With Make (Unix-like):
-
-```bash
-make install
 ```
 
 ---
 
-## Setup checklist (keys, env, secrets)
+## Architecture
 
-Use this when polishing the project for **local use**, **CI**, and **publishing**.
-
-### 1. OpenAI API key (required for `adt ask` and `adt serve`)
-
-1. Create a key in the [OpenAI API platform](https://platform.openai.com/api-keys) (billing enabled as per your account).
-2. **Never commit keys.** Keep them out of git; `.env` is gitignored if you copy from [`.env.example`](.env.example).
-3. **Expose the key to the shell** before running `adt`:
-   - **macOS / Linux:** `export OPENAI_API_KEY="sk-..."`
-   - **Windows CMD:** `set OPENAI_API_KEY=sk-...`
-   - **Windows PowerShell:** `$env:OPENAI_API_KEY="sk-..."`
-4. **Optional:** put `OPENAI_API_KEY=...` in `.env` and load it with [direnv](https://direnv.net/), your IDE’s env loader, or manual `source`—the CLI does not auto-read `.env`; the process must see the variable.
-5. **GitHub Actions CI** in this repo **does not** use `OPENAI_API_KEY` (tests mock the API). You **do not** add this secret to GitHub for the default CI workflow.
-
-### 2. GitHub token (optional, for `project_agent`)
-
-1. Create a [Personal Access Token](https://github.com/settings/tokens) with read access to the repos you query (classic `repo` scope for private repos, or fine-grained “Contents/Issues read” as appropriate).
-2. Set `GITHUB_TOKEN` in the environment, or pass `--token` once on the CLI.
-3. Without a token, anonymous GitHub API limits apply (~60 requests/hour per IP).
-
-### 3. Persistent CLI settings
-
-1. Run `adt config show` — creates/uses **`~/.adt/config.toml`**.
-2. Override file defaults with `ADT_*` variables (see table below) when useful for CI or shells.
-
-### 4. Publishing to PyPI from GitHub (maintainers only)
-
-The workflow [`.github/workflows/release.yml`](.github/workflows/release.yml) runs on tags `v*`.
-
-Pick **one** authentication method:
-
-| Method | What you do |
-|--------|-------------|
-| **Trusted publishing (recommended)** | In [pypi.org](https://pypi.org) → your project → **Publishing** → add a **trusted publisher** pointing at this GitHub repo and the `Release` workflow. The workflow already sets `id-token: write` for OIDC. Leave `PYPI_API_TOKEN` unset. |
-| **API token** | On PyPI, create an API token. In GitHub: **Settings → Secrets and variables → Actions → New repository secret** → name **`PYPI_API_TOKEN`**, value = the token. The publish action uses it as the password. |
-
-After the first successful publish, verify: `pip install agentic-dev-tool` and `adt version`.
-
-### 5. Tag and GitHub Release
-
-1. Merge release work to `main` with `version = "1.0.0"` (or next semver) in [`pyproject.toml`](pyproject.toml) and an entry in [`CHANGELOG.md`](CHANGELOG.md).
-2. Create an annotated tag: `git tag -a v1.0.0 -m "Release v1.0.0"` then `git push origin v1.0.0`.
-3. The **Release** workflow builds wheels, publishes to PyPI, and creates a GitHub Release (with generated release notes). You may edit the release description to paste the CHANGELOG section.
-
----
-
-## Configuration
-
-Copy the template and fill values locally (do not commit `.env`):
-
-```bash
-cp .env.example .env
+```
+User query → Hybrid Supervisor → Agent (repo / project / research)
+                                      ↓
+                              Tool Registry + Executor
+                                      ↓
+                              LLM (OpenAI) ← token budgets + context ranking
+                                      ↓
+                              AgentResponse → Rich panel / JSON API
 ```
 
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `OPENAI_API_KEY` | Yes, for `ask` / `serve` | OpenAI API key. |
-| `GITHUB_TOKEN` | No | PAT for `read_issues` / `read_milestones`. |
-| `ADT_LIVE_MODEL` | No | Model for `pytest -m live` (default `gpt-4o-mini`). |
-| `ADT_TOKEN_BUDGET` | No | Logical token window per ask (default `16384`). |
-| `ADT_CACHE_TTL` | No | Tree cache TTL in seconds (default `300`). |
-| `ADT_DEFAULT_MODEL` | No | Overrides `[adt] default_model` in config. |
-| `ADT_LOG_LEVEL` | No | Overrides config log level for file logging. |
-| `ADT_USE_LLM_ROUTING` | No | `0` / `1` — LLM intent routing. |
-| `ADT_ROUTING_MODEL` | No | Model for routing JSON call. |
-| `ADT_MAX_TOOL_ITERATIONS` | No | Max LLM/tool rounds per agent step. |
+The supervisor picks an agent; `ContextBuilder` packs bounded, ranked context; the `Runner` drives the LLM/tool loop through a validated registry; tracing and analytics wrap the pipeline. In supervised mode, the skill system overrides prompts with teaching heuristics and difficulty directives.
 
-`adt config show` / `adt config set` manage **`~/.adt/config.toml`**. CLI flags and `ADT_*` override file defaults where documented in code.
-
-**Related CLI flags (Phase 8/9 additions):**
-
-- `--mode {execution,supervised}` and `--level {beginner,intermediate,advanced}` on `adt ask` switch the pipeline to the supervised supervisor.
-- `--trace` on `adt ask` prints a Rich trace panel (routing, context, LLM calls, cost).
-- `adt review <file>` accepts `--level` and `--context` to tune reviewer tone and scope.
-- `adt stats --last N` limits aggregation to the most recent N supervised sessions.
-
----
-
-## Usage
-
-### Local repository
-
-```bash
-adt ask "What does this project do?" --repo .
-```
-
-### Multi-repository
-
-```bash
-adt ask "Compare dependency files in these two trees" --repo ./my-fork --repo ../upstream
-```
-
-Checkouts get session ids (`r0`, `r1`, …). Use **`compare_repos`** for a structured diff.
-
-### GitHub project (`owner/repo`)
-
-If `--repo` is a slug like `octocat/Hello-World` and that path is not a local folder, the **current working directory** is the markdown root for `read_markdown`, and the slug sets the default GitHub target:
-
-```bash
-cd ~/my-clone
-adt ask "Summarize open issues" --repo octocat/Hello-World
-adt ask "What milestones are open?" --repo myorg/my-repo --token ghp_xxx
-```
-
-### Research
-
-```bash
-adt ask "Recent papers on retrieval augmented generation" --repo .
-```
-
-### Force an agent
-
-```bash
-adt ask "Explain src layout" --repo . --agent repo_agent
-adt ask "List issues" --repo myorg/repo --agent project_agent
-```
-
-### Supervised mode (learning)
-
-Instead of solving the task, `adt` acts as a tutor — it plans 3–6 steps, reveals
-them one at a time, and asks checkpoint questions. The `supervised_engineering`
-skill (packaged under `src/adt/skills/`) drives the teaching heuristics and the
-review rubric.
-
-```bash
-adt ask "Implement binary search in Python" \
-  --mode supervised --level beginner --repo .
-```
-
-Difficulty levels reshape the response:
-
-| Level | Effect |
-|-------|--------|
-| `beginner` | Smaller steps, more hints, explicit type guidance, encouraging tone. |
-| `intermediate` | Balanced granularity and hinting (default). |
-| `advanced` | Larger steps, trade-off discussion, minimal hand-holding, critical tone. |
-
-Session state (current step, previous feedback) is persisted at
-`~/.adt/session.json` so the next `ask`/`review` picks up where you left off.
-
-### Code review
-
-Submit a file and get structured feedback (issues with line numbers, strengths,
-next step, overall verdict) from the reviewer LLM. Feedback is rendered as a
-colored Rich panel and the verdict feeds back into the session + analytics log.
-
-```bash
-adt review src/mymod/solution.py --context "binary search exercise"
-adt review src/mymod/solution.py --level advanced
-```
-
-### Tracing (`--trace`)
-
-Adds a trace panel under the answer showing routing decision, context build
-stats, per-iteration LLM/tool calls, cumulative tokens, and a USD cost
-estimate via `adt.tracing.cost`.
-
-```bash
-adt ask "Explain this repo" --repo . --trace
-```
-
-### Learning analytics (`adt stats`)
-
-Supervised runs and reviews append `LearningEvent`s to a rotating
-`~/.adt/logs/learning.jsonl`. `adt stats` renders a panel with session count,
-review verdicts, common issue categories, improvement trend, and token totals.
-
-```bash
-adt stats           # full history
-adt stats --last 10 # only the last 10 supervised sessions
-```
-
-### Quick reference (`adt guide`)
-
-`adt guide` prints a static cheat sheet (commands, modes, levels, agents,
-skills, environment) without making any API calls — ideal when you just
-installed the tool or want to jog your memory.
-
-```bash
-adt guide
-```
-
-### Common flags
-
-- `--repo`, `-r` — Repeatable: existing directory or `owner/repo` slug.
-- `--token` — GitHub PAT for this run (overrides `GITHUB_TOKEN`).
-- `--agent`, `-a` — `repo_agent`, `research_agent`, or `project_agent`.
-- `--mode` — `execution` (default) or `supervised`.
-- `--level` — `beginner`, `intermediate`, `advanced` (supervised only).
-- `--trace` — Print a trace panel with routing, LLM calls, token use, and cost.
-- `--verbose`, `-v` — Debug logging, token usage, budget hint, context snippet.
-- `--log-level` — `DEBUG` … `ERROR` for JSON file logs under `~/.adt/logs/`.
-- `--no-cache` — Skip repo tree cache.
-- `--model`, `-m` — Model override (default from config or `gpt-4o-mini`).
-
----
-
-## HTTP API (optional)
-
-Install `[api]`, then:
-
-```bash
-adt serve --host 127.0.0.1 --port 8765
-```
-
-| Endpoint | Purpose |
-|----------|---------|
-| `GET /healthz` | Liveness JSON (`status`, `version`). |
-| `POST /ask` | Body: `query`, optional `repo` (list), `github_token`, `agent`, `no_cache`, `model`. Same pipeline as CLI; **`OPENAI_API_KEY` must be set in the server environment**. |
+Full architecture docs: [`docs/reference/architecture.md`](docs/reference/architecture.md)
 
 ---
 
 ## Commands
 
-| Command | Purpose |
-|---------|---------|
-| `adt ask …` | Main agent loop (supports `--mode supervised`, `--level`, `--trace`). |
-| `adt review <file>` | Structured code review with issues, strengths, next step, verdict. |
-| `adt stats [--last N]` | Aggregate supervised learning log: sessions, verdicts, trend, tokens. |
-| `adt guide` | Static quick-reference: commands, modes, levels, agents, skills. |
-| `adt serve` | FastAPI + uvicorn (`[api]`). |
-| `adt config show` / `path` / `set` | `~/.adt/config.toml`. |
-| `adt version` | Package version. |
-| `adt info` | Short feature summary. |
+| Command | What it does |
+|---------|-------------|
+| `adt ask "..."` | Route a question to the best agent. Supports `--repo`, `--agent`, `--mode supervised`, `--level`, `--trace`, `--yes`, `--no-stream` |
+| `adt review <file>` | Structured code review with issues, strengths, next step, and verdict |
+| `adt stats` | Learning analytics panel. Flags: `--last N`, `--export csv\|json\|md`, `--html <dir>`, `--classifier keyword\|embedding` |
+| `adt shell` | Interactive REPL with history, autocomplete, and slash commands (`/help`, `/trace`, `/session`, `/start`, `/submit`, etc.) |
+| `adt guide` | Static quick-reference cheat sheet (no API key needed) |
+| `adt config show\|set\|path` | View or edit `~/.adt/config.toml` |
+| `adt session show\|list\|clear\|export` | Manage supervised sessions |
+| `adt runs list\|show\|delete` | Manage interrupted run snapshots |
+| `adt plugins list\|validate` | Manage community plugins |
+| `adt serve` | FastAPI HTTP API (`[api]` extra). Endpoints: `/ask`, `/review`, `/stats`, `/sessions`, `/healthz` |
+| `adt version` | Print installed version |
+
+---
+
+## Configuration
+
+Settings live in `~/.adt/config.toml` and can be overridden by `ADT_*` environment variables or CLI flags.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `default_model` | `gpt-4o-mini` | OpenAI chat model |
+| `log_level` | `INFO` | File log level |
+| `use_llm_routing` | `true` | Enable LLM intent routing |
+| `max_tool_iterations` | `5` | Max LLM/tool rounds per agent |
+| `token_budget` | `none` | Logical token window |
+| `cost_confirm_threshold` | `0.05` | USD threshold for cost confirmation prompt |
+| `lang` | `en` | UI locale (`en`, `pt_BR`) |
+| `cache_ttl_seconds` | `300` | Repo tree cache TTL |
 
 ```bash
-adt --help && adt ask --help && adt review --help && adt stats --help
+adt config set default_model gpt-4o
+adt config set lang pt_BR
+adt config show
 ```
-
-> **Tip:** `adt guide` does not require `OPENAI_API_KEY` and never hits the
-> network — it is the fastest way to see every feature at a glance.
 
 ---
 
-## File layout and state
+## Environment Variables
 
-`adt` keeps all mutable state under `~/.adt/` so your repositories stay clean:
-
-| Path | Written by | Purpose |
-|------|------------|---------|
-| `~/.adt/config.toml` | `adt config set` | Persistent defaults (model, log level, routing). |
-| `~/.adt/cache/` | `ContextBuilder` | Repo tree cache (`--no-cache` or `ADT_CACHE_TTL=0` to disable). |
-| `~/.adt/logs/adt.jsonl` | `log_adt` helper | Structured runtime logs (routing, tool calls, errors). |
-| `~/.adt/logs/learning.jsonl` | `adt ask --mode supervised`, `adt review` | Rotating JSONL (10 MB × 5 backups) consumed by `adt stats`. |
-| `~/.adt/session.json` | `adt ask --mode supervised`, `adt review` | Current supervised step, iteration count, recent feedback. |
-
-Delete any of these to reset the corresponding state — nothing under `~/.adt`
-is required for a fresh install.
-
----
-
-## Skills
-
-Supervised teaching heuristics live in a **packaged skill** so they can be
-edited and versioned without touching agent code.
-
-```
-src/adt/skills/
-└── supervised_engineering/
-    ├── SKILL.md        # When/when-not/how (teaching heuristics + rubric)
-    ├── loader.py       # load_skill_content() via importlib.resources
-    └── __init__.py
-```
-
-`SupervisedSupervisor` reads the markdown via `importlib.resources` at runtime
-and prepends it to both the step-guidance and code-review prompts. Level
-directives (`beginner`/`intermediate`/`advanced`) come from
-`adt.core.level_config.LEVEL_CONFIGS` and are concatenated after the skill so
-prompt tone, hint count, and step granularity all change with `--level`.
-
-To add a new skill:
-
-1. Create `src/adt/skills/<name>/SKILL.md` and a matching `loader.py`.
-2. Register the skill path in the package wheel (`pyproject.toml` already
-   includes `src/adt/skills/**/*.md`).
-3. Load it from the agent/supervisor that consumes it.
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `OPENAI_API_KEY` | Yes (for `ask`/`serve`) | OpenAI API key |
+| `GITHUB_TOKEN` | No | GitHub PAT for project_agent |
+| `ADT_LANG` | No | UI locale override |
+| `ADT_NO_PROGRESS` | No | `1` to disable spinners/progress bars |
+| `ADT_NO_CONFIRM` | No | `1` to skip cost confirmation prompts |
 
 ---
 
@@ -479,53 +133,22 @@ To add a new skill:
 ```bash
 make lint       # ruff check
 make format     # ruff format
-make test       # pytest + coverage (excludes @pytest.mark.live)
+make test       # pytest + coverage
 make typecheck  # mypy src/
-python -m build # sdist + wheel → dist/  (needs: pip install build)
 ```
-
-Live model tests (manual / optional CI job you add yourself):
-
-```bash
-export OPENAI_API_KEY="sk-..."
-pytest -m live
-```
-
----
-
-## Releasing (maintainers: PyPI + GitHub)
-
-1. Bump **`pyproject.toml`** version and **`CHANGELOG.md`**.
-2. Merge to **`main`**.
-3. Tag **`vX.Y.Z`** and push the tag → **`Release`** workflow ([`release.yml`](.github/workflows/release.yml)).
-4. Configure PyPI **trusted publisher** or **`PYPI_API_TOKEN`** (see [Setup checklist §4](#4-publishing-to-pypi-from-github-maintainers-only)).
-
-Full contributor notes: [`docs/contributing.md`](docs/contributing.md).
-
----
-
-## Portfolio checklist
-
-Aligned with **Phase 7** / [`docs/portfolio.md`](docs/portfolio.md):
-
-- [x] Record a **terminal demo** and embed in README (`docs/assets/demo.gif`).
-- [x] **Embed** the demo GIF at the top of the README.
-- [ ] Add a **one-paragraph** project card on your personal site with links to GitHub, PyPI, and `docs/architecture.md`.
-- [ ] Optional: short **article** (blog/LinkedIn)—problem, architecture, trade-offs.
-- [ ] Close or archive **GitHub milestones/issues** when you consider the roadmap complete.
 
 ---
 
 ## Documentation
 
-| Doc | Topic |
-|-----|--------|
-| [`ROADMAP.md`](ROADMAP.md) | Phases, milestones, conventions |
-| [`docs/architecture.md`](docs/architecture.md) | Design decisions, module map |
-| [`docs/mcp.md`](docs/mcp.md) | Tool registry, context, execution |
-| [`docs/agents.md`](docs/agents.md) | Agents and prompts |
-| [`docs/contributing.md`](docs/contributing.md) | PRs, packaging, PyPI |
-| [`CHANGELOG.md`](CHANGELOG.md) | Release history |
+Full documentation is available at [brunoramosmartins.github.io/agentic-dev-tool](https://brunoramosmartins.github.io/agentic-dev-tool), covering installation, guides (supervised mode, tracing, analytics, plugins), architecture reference, and API docs.
+
+| Resource | Link |
+|----------|------|
+| MkDocs site | [brunoramosmartins.github.io/agentic-dev-tool](https://brunoramosmartins.github.io/agentic-dev-tool) |
+| Architecture | [`docs/reference/architecture.md`](docs/reference/architecture.md) |
+| Roadmap | [`ROADMAP.md`](ROADMAP.md) |
+| Changelog | [`CHANGELOG.md`](CHANGELOG.md) |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ docs = [
   "mkdocs-material>=9.5",
   "mkdocs-typer>=0.0.3",
 ]
+shell = [
+  "prompt-toolkit>=3.0,<4.0",
+]
 dev = [
   "pytest>=7.4",
   "pytest-cov>=4.1",
@@ -66,6 +69,7 @@ dev = [
   "fastapi>=0.109",
   "uvicorn[standard]>=0.27",
   "jinja2>=3.1",
+  "prompt-toolkit>=3.0,<4.0",
 ]
 test = [
   "pytest>=7.4",

--- a/src/adt/cli/app.py
+++ b/src/adt/cli/app.py
@@ -260,6 +260,21 @@ def ask_cmd(
             help="Resume an interrupted run by trace ID.",
         ),
     ] = None,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Skip cost confirmation prompt.",
+        ),
+    ] = False,
+    no_stream: Annotated[
+        bool,
+        typer.Option(
+            "--no-stream",
+            help="Disable token streaming (buffer full response).",
+        ),
+    ] = False,
 ) -> None:
     """Ask a question: supervisor picks an agent unless ``--agent`` is set."""
     if resume is not None:
@@ -773,6 +788,42 @@ def serve_cmd(
 
     console.print(f"[dim]Open http://{host}:{port}/docs[/dim]")
     uvicorn.run(api_app, host=host, port=port, log_level="info")
+
+
+@app.command("shell")
+def shell_cmd(
+    repo: Annotated[
+        list[str] | None,
+        typer.Option(
+            "--repo",
+            "-r",
+            help="Local directory or owner/repo slug.",
+        ),
+    ] = None,
+    model: Annotated[
+        str | None,
+        typer.Option(
+            "--model",
+            "-m",
+            help="OpenAI chat model.",
+        ),
+    ] = None,
+    trace: Annotated[
+        bool,
+        typer.Option(
+            "--trace",
+            help="Enable request tracing by default.",
+        ),
+    ] = False,
+) -> None:
+    """Open an interactive REPL (install ``agentic-dev-tool[shell]``)."""
+    try:
+        from adt.cli.shell import run_shell
+    except SystemExit as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+    run_shell(console, repo=repo, model=model, trace=trace)
 
 
 if __name__ == "__main__":

--- a/src/adt/cli/cost_confirm.py
+++ b/src/adt/cli/cost_confirm.py
@@ -1,0 +1,79 @@
+"""Cost confirmation prompt before expensive LLM calls.
+
+Uses :class:`~adt.tracing.cost.CostEstimator` to compute an upper-bound
+estimate and prompts the user when it exceeds the configured threshold.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+
+_DEFAULT_THRESHOLD: float = 0.05
+
+
+def _should_confirm(
+    estimated_cost: float,
+    threshold: float,
+    *,
+    yes_flag: bool = False,
+) -> bool:
+    """Return whether an interactive confirmation is needed."""
+    if yes_flag:
+        return False
+    if os.environ.get("ADT_NO_CONFIRM", "").strip() in ("1", "true", "yes"):
+        return False
+    return estimated_cost > threshold
+
+
+def estimate_upper_bound(
+    model: str,
+    prompt_tokens: int,
+    max_completion_tokens: int,
+) -> float:
+    """Return the worst-case USD cost for one LLM call."""
+    from adt.tracing.cost import CostEstimator
+
+    breakdown = CostEstimator.estimate(model, prompt_tokens, max_completion_tokens)
+    return breakdown.total_cost_usd
+
+
+def confirm_cost(
+    console: Console,
+    model: str,
+    prompt_tokens: int,
+    max_completion_tokens: int,
+    *,
+    threshold: float = _DEFAULT_THRESHOLD,
+    yes_flag: bool = False,
+) -> bool:
+    """Check cost and prompt the user if above threshold.
+
+    Returns:
+        ``True`` if the user confirmed or the cost is below the threshold.
+        ``False`` if the user declined.
+    """
+    cost = estimate_upper_bound(model, prompt_tokens, max_completion_tokens)
+    if not _should_confirm(cost, threshold, yes_flag=yes_flag):
+        return True
+
+    console.print(
+        f"[yellow]Estimated cost: ${cost:.4f} (threshold: ${threshold:.4f})[/yellow]"
+    )
+    try:
+        import typer
+
+        typer.confirm("Continue?", default=False, abort=False)
+    except (KeyboardInterrupt, EOFError):
+        console.print("[dim]Cancelled.[/dim]")
+        return False
+    except SystemExit:
+        # typer.confirm with abort=False should not raise SystemExit,
+        # but handle gracefully
+        console.print("[dim]Cancelled.[/dim]")
+        return False
+    return True

--- a/src/adt/cli/progress.py
+++ b/src/adt/cli/progress.py
@@ -1,0 +1,103 @@
+"""Rich progress bars for tool execution (file walks, multi-fetch).
+
+Provides a ``ProgressCallback`` protocol and a Rich-backed implementation
+that can be injected into tool handlers via the ``progress`` parameter on
+:class:`~adt.mcp.registry.ToolDefinition`.
+
+Disabled by the same ``ADT_NO_PROGRESS=1`` flag as :mod:`adt.cli.status`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+from adt.cli.status import _progress_enabled
+
+if TYPE_CHECKING:
+    from rich.console import Console
+    from rich.progress import Progress, TaskID
+
+
+class ProgressCallback(Protocol):
+    """Minimal interface for reporting incremental progress."""
+
+    def __call__(self, current: int, total: int) -> None: ...
+
+
+class RichProgressReporter:
+    """Wraps a ``rich.progress.Progress`` bar behind the callback protocol.
+
+    The caller calls ``start(label, total)`` to begin a task, then passes
+    :meth:`step` as the ``progress`` callback to tool handlers.
+    """
+
+    def __init__(self, console: Console) -> None:
+        self._console = console
+        self._enabled = _progress_enabled()
+        self._progress: Progress | None = None
+        self._task_id: TaskID | None = None
+        self._calls: list[tuple[int, int]] = []
+
+    @property
+    def calls(self) -> list[tuple[int, int]]:
+        """Recorded ``(current, total)`` pairs (for testing)."""
+        return list(self._calls)
+
+    def start(self, label: str, total: int) -> None:
+        """Create and start a Rich progress bar."""
+        if not self._enabled:
+            return
+        from rich.progress import (
+            BarColumn,
+            MofNCompleteColumn,
+            Progress,
+            TextColumn,
+            TimeRemainingColumn,
+        )
+
+        self._progress = Progress(
+            TextColumn("[bold blue]{task.description}"),
+            BarColumn(),
+            MofNCompleteColumn(),
+            TimeRemainingColumn(),
+            console=self._console,
+        )
+        self._progress.start()
+        self._task_id = self._progress.add_task(label, total=total)
+
+    def step(self, current: int, total: int) -> None:
+        """Advance the progress bar by one unit."""
+        self._calls.append((current, total))
+        if self._progress is not None and self._task_id is not None:
+            self._progress.update(
+                self._task_id,
+                completed=current,
+                total=total,
+            )
+
+    def finish(self) -> None:
+        """Stop and clean up the progress bar."""
+        if self._progress is not None:
+            self._progress.stop()
+            self._progress = None
+            self._task_id = None
+
+
+class NullProgressReporter:
+    """No-op progress reporter for non-interactive contexts."""
+
+    def __init__(self) -> None:
+        self._calls: list[tuple[int, int]] = []
+
+    @property
+    def calls(self) -> list[tuple[int, int]]:
+        return list(self._calls)
+
+    def start(self, label: str, total: int) -> None:
+        pass
+
+    def step(self, current: int, total: int) -> None:
+        self._calls.append((current, total))
+
+    def finish(self) -> None:
+        pass

--- a/src/adt/cli/shell.py
+++ b/src/adt/cli/shell.py
@@ -1,0 +1,181 @@
+"""Interactive REPL for ``adt shell``.
+
+Powered by ``prompt_toolkit`` with persistent history, tab completion
+for slash commands and agent names, and multiline editing (Alt+Enter).
+Free-form input is dispatched as ``adt ask <line>`` against the active
+session, using the streaming pipeline when available.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from prompt_toolkit.completion import Completer
+    from rich.console import Console
+
+    from adt.cli.shell_commands import ShellState
+
+
+_HISTORY_PATH = Path.home() / ".adt" / "shell_history"
+
+
+def _ensure_prompt_toolkit() -> None:
+    """Raise a friendly error if prompt_toolkit is not installed."""
+    try:
+        import prompt_toolkit  # noqa: F401
+    except ImportError:
+        msg = (
+            "Install agentic-dev-tool[shell] to use adt shell.\n"
+            "  pip install 'agentic-dev-tool[shell]'"
+        )
+        raise SystemExit(msg) from None
+
+
+def _build_completer() -> Completer:
+    """Build a WordCompleter for slash commands and agent names."""
+    from prompt_toolkit.completion import WordCompleter
+
+    from adt.cli.shell_commands import COMMAND_NAMES
+
+    words = list(COMMAND_NAMES) + [
+        "repo_agent",
+        "research_agent",
+        "project_agent",
+        "on",
+        "off",
+        "list",
+        "switch",
+        "delete",
+        "beginner",
+        "intermediate",
+        "advanced",
+    ]
+    return WordCompleter(words, ignore_case=True)
+
+
+def run_shell(
+    console: Console,
+    *,
+    repo: list[str] | None = None,
+    model: str | None = None,
+    trace: bool = False,
+) -> None:
+    """Main REPL loop — blocks until the user exits."""
+    _ensure_prompt_toolkit()
+
+    from prompt_toolkit import PromptSession
+    from prompt_toolkit.history import FileHistory
+
+    from adt.cli.shell_commands import ShellState, dispatch
+
+    # Ensure ~/.adt exists for history
+    _HISTORY_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    state = ShellState(
+        repo=list(repo or []),
+        model=model or "gpt-4o-mini",
+        trace_enabled=trace,
+    )
+
+    completer = _build_completer()
+    session: PromptSession[str] = PromptSession(
+        history=FileHistory(str(_HISTORY_PATH)),
+        completer=completer,
+        multiline=False,
+    )
+
+    console.print(
+        "[bold cyan]adt shell[/bold cyan] — "
+        "interactive agent REPL. "
+        "Type [bold]/help[/bold] for commands, "
+        "[bold]Ctrl+D[/bold] to exit."
+    )
+    console.print(
+        f"[dim]Session: {state.active_session} | "
+        f"Model: {state.model} | "
+        f"Trace: {'on' if state.trace_enabled else 'off'}[/dim]"
+    )
+
+    while True:
+        try:
+            line = session.prompt("adt> ")
+        except KeyboardInterrupt:
+            console.print("[dim]Interrupted. Type /exit to quit.[/dim]")
+            continue
+        except EOFError:
+            console.print("[dim]Bye![/dim]")
+            break
+
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        # Try slash command first
+        if dispatch(stripped, state, console):
+            continue
+
+        # Free-form query → adt ask
+        _dispatch_ask(stripped, state, console)
+
+    # Save session on exit
+    _save_session_on_exit(state)
+
+
+def _dispatch_ask(query: str, state: ShellState, console: Console) -> None:
+    """Run the ask pipeline for a free-form query."""
+    from adt.ask_session import AskConfigurationError, run_ask
+
+    try:
+        exe = run_ask(
+            query=query,
+            repo=state.repo or None,
+            force_agent=state.active_agent,
+            model=state.model,
+            trace=state.trace_enabled,
+            mode="execution",
+            session_name=state.active_session,
+            verbose=state.verbose,
+            configure_logging=False,
+        )
+    except AskConfigurationError as exc:
+        console.print(f"[red]{exc}[/red]")
+        return
+
+    from rich.markdown import Markdown
+    from rich.panel import Panel
+
+    routed = exe.response.routed_agent or "supervisor"
+    console.print(f"[dim]Agent:[/dim] [bold]{routed}[/bold]")
+    console.print(
+        Panel(
+            Markdown(exe.response.answer),
+            title="Answer",
+            border_style="green",
+            title_align="left",
+        )
+    )
+
+    tools_line = (
+        ", ".join(exe.response.tools_used) if exe.response.tools_used else "none"
+    )
+    console.print(f"[dim]Tools used:[/dim] {tools_line}")
+
+    if exe.trace_context is not None:
+        from adt.tracing.renderer import TraceRenderer
+
+        TraceRenderer(console).render(exe.trace_context, model=state.model)
+
+
+def _save_session_on_exit(state: ShellState) -> None:
+    """Persist session metadata on REPL exit."""
+    try:
+        from adt.core.session_store import SessionStore
+
+        store = SessionStore()
+        # Touch the session file to mark last-used
+        if store.path(state.active_session).exists():
+            store.path(state.active_session).touch()
+    except Exception:  # noqa: BLE001
+        pass

--- a/src/adt/cli/shell_commands.py
+++ b/src/adt/cli/shell_commands.py
@@ -1,0 +1,378 @@
+"""Slash command dispatcher for the ``adt shell`` REPL.
+
+Each slash command is a simple function that receives the REPL state
+and an argument string, then returns a status message (or empty string).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+
+@dataclass
+class ShellState:
+    """Mutable state shared across REPL turns."""
+
+    active_session: str = "default"
+    active_agent: str | None = None
+    trace_enabled: bool = False
+    model: str = "gpt-4o-mini"
+    repo: list[str] = field(default_factory=list)
+    verbose: bool = False
+    cost_threshold: float = 0.05
+
+
+def _cmd_help(state: ShellState, _args: str, console: Console) -> str:
+    """Print available REPL slash commands."""
+    lines = [
+        "[bold]adt shell — slash commands[/bold]",
+        "",
+        "  /help                Show this help",
+        "  /exit                Exit the REPL",
+        "  /clear               Clear the terminal",
+        "  /trace on|off        Toggle request tracing",
+        "  /stats [--last N]    Show learning stats",
+        "  /session list        List sessions",
+        "  /session switch <n>  Switch active session",
+        "  /session delete <n>  Delete a session",
+        "  /agent <name>        Force agent for next queries",
+        "  /agent clear         Clear forced agent",
+        "  /cost                Show cost threshold",
+        "  /version             Show version",
+        "  /start <problem>     Start supervised session",
+        "  /next                Advance to next step",
+        "  /hint                Request a hint",
+        "  /submit <code|@path> Submit code for review",
+        "",
+        "  Any other input is sent as `adt ask <input>`",
+    ]
+    console.print("\n".join(lines))
+    return ""
+
+
+def _cmd_exit(_state: ShellState, _args: str, _console: Console) -> str:
+    raise SystemExit(0)
+
+
+def _cmd_clear(_state: ShellState, _args: str, console: Console) -> str:
+    console.clear()
+    return ""
+
+
+def _cmd_trace(state: ShellState, args: str, console: Console) -> str:
+    arg = args.strip().lower()
+    if arg == "on":
+        state.trace_enabled = True
+        console.print("[green]Tracing enabled.[/green]")
+    elif arg == "off":
+        state.trace_enabled = False
+        console.print("[dim]Tracing disabled.[/dim]")
+    else:
+        status = "on" if state.trace_enabled else "off"
+        console.print(f"[dim]Trace is {status}. Usage: /trace on|off[/dim]")
+    return ""
+
+
+def _cmd_stats(_state: ShellState, args: str, console: Console) -> str:
+    from adt.analytics import compute_stats, read_learning_events
+    from adt.cli.stats_renderer import StatsRenderer
+
+    last_n = None
+    parts = args.strip().split()
+    import contextlib
+
+    for i, p in enumerate(parts):
+        if p == "--last" and i + 1 < len(parts):
+            with contextlib.suppress(ValueError):
+                last_n = int(parts[i + 1])
+
+    events = read_learning_events()
+    stats = compute_stats(events, last_n=last_n)
+    StatsRenderer(console).render(stats)
+    return ""
+
+
+def _cmd_session(state: ShellState, args: str, console: Console) -> str:
+    from adt.core.session_store import SessionStore
+
+    parts = args.strip().split(maxsplit=1)
+    subcmd = parts[0] if parts else ""
+    arg = parts[1].strip() if len(parts) > 1 else ""
+
+    store = SessionStore()
+
+    if subcmd == "list":
+        names = store.list()
+        if not names:
+            console.print("[dim]No sessions found.[/dim]")
+        else:
+            active = state.active_session
+            for n in names:
+                marker = " [green]← active[/green]" if n == active else ""
+                console.print(f"  {n}{marker}")
+    elif subcmd == "switch" and arg:
+        state.active_session = arg
+        console.print(f"[green]Switched to session '{arg}'.[/green]")
+    elif subcmd == "delete" and arg:
+        if store.path(arg).exists():
+            store.delete(arg)
+            console.print(f"[green]Session '{arg}' deleted.[/green]")
+            if state.active_session == arg:
+                state.active_session = "default"
+        else:
+            console.print(f"[dim]Session '{arg}' not found.[/dim]")
+    else:
+        console.print("[dim]Usage: /session list | switch <name> | delete <name>[/dim]")
+    return ""
+
+
+def _cmd_agent(state: ShellState, args: str, console: Console) -> str:
+    valid = {"repo_agent", "research_agent", "project_agent"}
+    arg = args.strip()
+    if arg == "clear":
+        state.active_agent = None
+        console.print("[dim]Agent override cleared.[/dim]")
+    elif arg in valid:
+        state.active_agent = arg
+        console.print(f"[green]Agent forced to '{arg}'.[/green]")
+    elif arg:
+        console.print(
+            f"[red]Unknown agent '{arg}'.[/red] Valid: {', '.join(sorted(valid))}"
+        )
+    else:
+        current = state.active_agent or "auto (supervisor)"
+        console.print(f"[dim]Active agent: {current}[/dim]")
+    return ""
+
+
+def _cmd_cost(state: ShellState, _args: str, console: Console) -> str:
+    console.print(
+        f"[dim]Cost confirmation threshold: ${state.cost_threshold:.4f}[/dim]"
+    )
+    return ""
+
+
+def _cmd_version(_state: ShellState, _args: str, console: Console) -> str:
+    try:
+        from importlib import metadata
+
+        ver = metadata.version("agentic-dev-tool")
+    except Exception:  # noqa: BLE001
+        ver = "dev"
+    console.print(f"[dim]adt {ver}[/dim]")
+    return ""
+
+
+def _cmd_start(state: ShellState, args: str, console: Console) -> str:
+    """Start or resume a supervised session."""
+    problem = args.strip()
+    if not problem:
+        console.print("[red]Usage: /start <problem description>[/red]")
+        return ""
+
+    level = "intermediate"
+    # Parse --level flag
+    parts = problem.split()
+    for i, p in enumerate(parts):
+        if p == "--level" and i + 1 < len(parts):
+            level = parts[i + 1]
+            parts = parts[:i] + parts[i + 2 :]
+            problem = " ".join(parts)
+            break
+
+    from adt.ask_session import AskConfigurationError, run_ask
+
+    try:
+        exe = run_ask(
+            query=problem,
+            repo=state.repo or None,
+            mode="supervised",
+            level=level,
+            session_name=state.active_session,
+            trace=state.trace_enabled,
+            configure_logging=False,
+        )
+    except AskConfigurationError as exc:
+        console.print(f"[red]{exc}[/red]")
+        return ""
+
+    if exe.supervised_response is not None:
+        from adt.cli.supervised_renderer import SupervisedRenderer
+
+        SupervisedRenderer(console).render(
+            exe.supervised_response,
+            level=exe.supervised_level,
+        )
+    else:
+        from rich.markdown import Markdown
+        from rich.panel import Panel
+
+        console.print(
+            Panel(
+                Markdown(exe.response.answer),
+                title="Supervised",
+                border_style="cyan",
+            )
+        )
+    return ""
+
+
+def _cmd_next(state: ShellState, _args: str, console: Console) -> str:
+    """Advance to the next supervised step."""
+    from adt.ask_session import AskConfigurationError, run_ask
+
+    try:
+        exe = run_ask(
+            query="Continue to the next step.",
+            repo=state.repo or None,
+            mode="supervised",
+            level="intermediate",
+            session_name=state.active_session,
+            trace=state.trace_enabled,
+            configure_logging=False,
+        )
+    except AskConfigurationError as exc:
+        console.print(f"[red]{exc}[/red]")
+        return ""
+
+    if exe.supervised_response is not None:
+        from adt.cli.supervised_renderer import SupervisedRenderer
+
+        SupervisedRenderer(console).render(exe.supervised_response)
+    else:
+        console.print(f"[dim]{exe.response.answer[:500]}[/dim]")
+    return ""
+
+
+def _cmd_hint(state: ShellState, _args: str, console: Console) -> str:
+    """Request a hint for the current supervised step."""
+    from adt.ask_session import AskConfigurationError, run_ask
+
+    try:
+        exe = run_ask(
+            query="Give me a hint for the current step.",
+            repo=state.repo or None,
+            mode="supervised",
+            level="beginner",
+            session_name=state.active_session,
+            trace=state.trace_enabled,
+            configure_logging=False,
+        )
+    except AskConfigurationError as exc:
+        console.print(f"[red]{exc}[/red]")
+        return ""
+
+    if exe.supervised_response is not None:
+        from adt.cli.supervised_renderer import SupervisedRenderer
+
+        SupervisedRenderer(console).render(exe.supervised_response)
+    else:
+        console.print(f"[dim]{exe.response.answer[:500]}[/dim]")
+    return ""
+
+
+def _cmd_submit(state: ShellState, args: str, console: Console) -> str:
+    """Submit code for review in the supervised session."""
+    code = args.strip()
+    if not code:
+        console.print("[red]Usage: /submit <code> or /submit @path[/red]")
+        return ""
+
+    # Handle @path syntax
+    if code.startswith("@"):
+        from pathlib import Path
+
+        fpath = Path(code[1:])
+        if not fpath.is_file():
+            console.print(f"[red]File not found: {fpath}[/red]")
+            return ""
+        code = fpath.read_text(encoding="utf-8")
+
+    import tempfile
+
+    from adt.review_session import ReviewConfigurationError, run_review
+
+    # Write code to a temp file for the reviewer
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".py", delete=False, encoding="utf-8"
+    ) as tmp:
+        tmp.write(code)
+        tmp_path = tmp.name
+
+    try:
+        result = run_review(
+            file=tmp_path,
+            level="intermediate",
+            session_name=state.active_session,
+            verbose=False,
+        )
+    except ReviewConfigurationError as exc:
+        console.print(f"[red]{exc}[/red]")
+        return ""
+    finally:
+        import os
+
+        os.unlink(tmp_path)
+
+    if result.feedback is not None:
+        from adt.cli.review_renderer import ReviewRenderer
+
+        ReviewRenderer(console).render(result.feedback)
+    else:
+        console.print(f"[dim]{result.raw_answer or '(no response)'}[/dim]")
+    return ""
+
+
+# ── Command registry ──────────────────────────────────────────────────
+
+SLASH_COMMANDS: dict[str, Any] = {
+    "/help": _cmd_help,
+    "/exit": _cmd_exit,
+    "/quit": _cmd_exit,
+    "/clear": _cmd_clear,
+    "/trace": _cmd_trace,
+    "/stats": _cmd_stats,
+    "/session": _cmd_session,
+    "/agent": _cmd_agent,
+    "/cost": _cmd_cost,
+    "/version": _cmd_version,
+    "/start": _cmd_start,
+    "/next": _cmd_next,
+    "/hint": _cmd_hint,
+    "/submit": _cmd_submit,
+}
+
+COMMAND_NAMES: list[str] = sorted(SLASH_COMMANDS.keys())
+
+
+def dispatch(
+    line: str,
+    state: ShellState,
+    console: Console,
+) -> bool:
+    """Try to dispatch *line* as a slash command.
+
+    Returns ``True`` if the line was handled (even if the command failed),
+    ``False`` if it should be treated as a free-form query.
+    """
+    stripped = line.strip()
+    if not stripped.startswith("/"):
+        return False
+
+    parts = stripped.split(maxsplit=1)
+    cmd = parts[0].lower()
+    args = parts[1] if len(parts) > 1 else ""
+
+    handler = SLASH_COMMANDS.get(cmd)
+    if handler is None:
+        console.print(
+            f"[red]Unknown command: {cmd}[/red]. Type /help for available commands."
+        )
+        return True
+
+    handler(state, args, console)
+    return True

--- a/src/adt/cli/status.py
+++ b/src/adt/cli/status.py
@@ -1,0 +1,82 @@
+"""Rich status spinner for LLM calls and tool execution.
+
+Wraps a ``rich.status.Status`` context that adapts its text as the
+runner loop progresses: routing → calling agent → running tool.
+Disabled when stdout is not a tty, or ``ADT_NO_PROGRESS=1``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rich.console import Console
+    from rich.status import Status
+
+
+def _progress_enabled() -> bool:
+    """Return ``False`` when spinners/progress should be suppressed."""
+    if os.environ.get("ADT_NO_PROGRESS", "").strip() in ("1", "true", "yes"):
+        return False
+    if not hasattr(sys.stdout, "isatty"):
+        return False
+    return sys.stdout.isatty()
+
+
+class StatusReporter:
+    """Manages a Rich spinner and exposes update methods for each phase."""
+
+    def __init__(self, console: Console) -> None:
+        self._console = console
+        self._enabled = _progress_enabled()
+        self._status: Status | None = None
+        self._phases: list[str] = []
+
+    @property
+    def phases(self) -> list[str]:
+        """Return the recorded phase labels (for testing)."""
+        return list(self._phases)
+
+    @contextmanager
+    def live(self) -> Generator[StatusReporter, None, None]:
+        """Context manager that starts/stops the Rich status spinner."""
+        if not self._enabled:
+            yield self
+            return
+
+        from rich.status import Status
+
+        status = Status("Thinking...", console=self._console, spinner="dots")
+        self._status = status
+        self._phases.append("Thinking...")
+        status.start()
+        try:
+            yield self
+        finally:
+            status.stop()
+            self._status = None
+
+    def update(self, text: str) -> None:
+        """Change the spinner label."""
+        self._phases.append(text)
+        if self._status is not None:
+            self._status.update(text)
+
+    def routing(self) -> None:
+        self.update("Routing...")
+
+    def calling_agent(self, agent: str) -> None:
+        self.update(f"Calling {agent}...")
+
+    def running_tool(self, tool: str) -> None:
+        self.update(f"Running tool: {tool}")
+
+    def building_context(self) -> None:
+        self.update("Building context...")
+
+    def iteration(self, n: int, total: int) -> None:
+        self.update(f"Iteration {n}/{total}...")

--- a/src/adt/cli/streaming.py
+++ b/src/adt/cli/streaming.py
@@ -1,0 +1,108 @@
+"""Streaming answer renderer using ``rich.live.Live``.
+
+Consumes :class:`RunChunk` events from the streaming runner pipeline
+and incrementally renders a Rich Markdown panel in the terminal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+from rich.markdown import Markdown
+from rich.panel import Panel
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from rich.console import Console
+
+
+@dataclass
+class RunChunk:
+    """Single event emitted by the streaming pipeline."""
+
+    kind: Literal[
+        "token",
+        "tool_call_start",
+        "tool_call_end",
+        "iteration_complete",
+        "final",
+    ]
+    text: str = ""
+    tool_name: str = ""
+    iteration: int = 0
+    data: dict[str, object] = field(default_factory=dict)
+
+
+class StreamRenderer:
+    """Accumulates ``RunChunk`` tokens and live-updates a Markdown panel."""
+
+    def __init__(self, console: Console) -> None:
+        self._console = console
+        self._buffer: list[str] = []
+
+    def render_stream(
+        self,
+        chunks: Iterator[RunChunk],
+        *,
+        border_style: str = "green",
+    ) -> str:
+        """Consume *chunks*, live-update the panel, and return final text."""
+        from rich.live import Live
+
+        panel = Panel(
+            Markdown("▌"),
+            title="Answer",
+            border_style=border_style,
+            title_align="left",
+        )
+
+        with Live(panel, console=self._console, refresh_per_second=12) as live:
+            for chunk in chunks:
+                if chunk.kind == "token":
+                    self._buffer.append(chunk.text)
+                    accumulated = "".join(self._buffer)
+                    panel = Panel(
+                        Markdown(accumulated + "▌"),
+                        title="Answer",
+                        border_style=border_style,
+                        title_align="left",
+                    )
+                    live.update(panel)
+                elif chunk.kind == "tool_call_start":
+                    self._buffer.append(f"\n\n> 🔧 Calling `{chunk.tool_name}`...\n\n")
+                    accumulated = "".join(self._buffer)
+                    panel = Panel(
+                        Markdown(accumulated + "▌"),
+                        title="Answer",
+                        border_style=border_style,
+                        title_align="left",
+                    )
+                    live.update(panel)
+                elif chunk.kind == "tool_call_end":
+                    self._buffer.append(f"> ✅ `{chunk.tool_name}` done\n\n")
+                    accumulated = "".join(self._buffer)
+                    panel = Panel(
+                        Markdown(accumulated + "▌"),
+                        title="Answer",
+                        border_style=border_style,
+                        title_align="left",
+                    )
+                    live.update(panel)
+                elif chunk.kind == "final":
+                    if chunk.text:
+                        self._buffer.clear()
+                        self._buffer.append(chunk.text)
+
+            # Final render without cursor
+            final_text = "".join(self._buffer)
+            panel = Panel(
+                Markdown(final_text),
+                title="Answer",
+                border_style=border_style,
+                title_align="left",
+            )
+            live.update(panel)
+
+        return final_text

--- a/src/adt/config.py
+++ b/src/adt/config.py
@@ -41,6 +41,7 @@ class AdtConfig:
     agent_chain: list[str] = field(default_factory=list)
     custom_tools: list[str] = field(default_factory=list)
     lang: str = "en"
+    cost_confirm_threshold: float = 0.05
 
     def to_toml_table(self) -> dict[str, Any]:
         """Serialize the ``adt`` table for writing."""
@@ -55,6 +56,7 @@ class AdtConfig:
             "agent_chain": self.agent_chain,
             "custom_tools": self.custom_tools,
             "lang": self.lang,
+            "cost_confirm_threshold": self.cost_confirm_threshold,
         }
         if self.token_budget is not None:
             d["token_budget"] = self.token_budget
@@ -77,6 +79,7 @@ class AdtConfig:
             ("agent_chain", []),
             ("custom_tools", []),
             ("lang", "en"),
+            ("cost_confirm_threshold", 0.05),
         ]:
             if key not in known:
                 continue
@@ -104,6 +107,11 @@ class AdtConfig:
                         kwargs[key] = int(raw)
                     except (TypeError, ValueError):
                         kwargs[key] = None
+            elif key == "cost_confirm_threshold":
+                try:
+                    kwargs[key] = float(raw)
+                except (TypeError, ValueError):
+                    kwargs[key] = 0.05
             elif key in ("use_llm_routing",):
                 if isinstance(raw, str):
                     kwargs[key] = raw.strip().lower() in ("1", "true", "yes", "on")
@@ -214,6 +222,8 @@ def update_config_key(path: Path | None, key: str, value: str) -> AdtConfig:
         cfg = replace(cfg, custom_tools=parts)
     elif key_norm == "lang":
         cfg = replace(cfg, lang=value.strip())
+    elif key_norm == "cost_confirm_threshold":
+        cfg = replace(cfg, cost_confirm_threshold=max(0.0, float(value)))
     else:
         msg = f"Unknown config key: {key!r}"
         raise ValueError(msg)

--- a/src/adt/config_validator.py
+++ b/src/adt/config_validator.py
@@ -98,6 +98,16 @@ def validate_key_value(key: str, raw: str) -> None:
                 "lang must be a non-empty locale code (e.g. 'en', 'pt_BR')."
             )
 
+    elif k == "cost_confirm_threshold":
+        try:
+            val_f = float(raw)
+        except ValueError:
+            raise ConfigValidationError(
+                f"cost_confirm_threshold must be a number, got {raw!r}."
+            ) from None
+        if val_f < 0:
+            raise ConfigValidationError("cost_confirm_threshold must be non-negative.")
+
     elif k == "agent_chain":
         parts = [p.strip() for p in raw.split(",") if p.strip()]
         for part in parts:

--- a/src/adt/locales/en.toml
+++ b/src/adt/locales/en.toml
@@ -81,6 +81,20 @@ tools_header = "Tools"
 [config]
 unknown_key = "Unknown config key: {key}"
 
+[shell]
+welcome = "adt shell — interactive agent REPL"
+help_hint = "Type /help for commands, Ctrl+D to exit."
+bye = "Bye!"
+interrupted = "Interrupted. Type /exit to quit."
+trace_on = "Tracing enabled."
+trace_off = "Tracing disabled."
+agent_cleared = "Agent override cleared."
+agent_forced = "Agent forced to '{name}'."
+switched_session = "Switched to session '{name}'."
+cost_threshold = "Cost confirmation threshold: ${value}"
+estimated_cost = "Estimated cost: ${cost} (threshold: ${threshold})"
+cancelled = "Cancelled."
+
 [errors]
 invalid_mode = "Invalid --mode {mode}. Choose one of: {options}."
 invalid_level = "Invalid --level {level}. Choose one of: {options}."
@@ -88,3 +102,4 @@ invalid_agent = "Invalid --agent. Choose one of: {options}."
 unexpected = "Unexpected error while running the agent."
 missing_api_key = "Missing OPENAI_API_KEY. Set it in the environment or in a .env file."
 missing_api_deps = "Missing API dependencies. Install with: pip install 'agentic-dev-tool[api]'"
+missing_shell_deps = "Install agentic-dev-tool[shell] to use adt shell."

--- a/src/adt/locales/pt_BR.toml
+++ b/src/adt/locales/pt_BR.toml
@@ -81,6 +81,20 @@ tools_header = "Ferramentas"
 [config]
 unknown_key = "Chave de configuração desconhecida: {key}"
 
+[shell]
+welcome = "adt shell — REPL interativo de agentes"
+help_hint = "Digite /help para comandos, Ctrl+D para sair."
+bye = "Até mais!"
+interrupted = "Interrompido. Digite /exit para sair."
+trace_on = "Rastreamento ativado."
+trace_off = "Rastreamento desativado."
+agent_cleared = "Agente fixo removido."
+agent_forced = "Agente fixado em '{name}'."
+switched_session = "Sessão trocada para '{name}'."
+cost_threshold = "Limite de confirmação de custo: ${value}"
+estimated_cost = "Custo estimado: ${cost} (limite: ${threshold})"
+cancelled = "Cancelado."
+
 [errors]
 invalid_mode = "--mode {mode} inválido. Escolha um dos: {options}."
 invalid_level = "--level {level} inválido. Escolha um dos: {options}."
@@ -88,3 +102,4 @@ invalid_agent = "--agent inválido. Escolha um dos: {options}."
 unexpected = "Erro inesperado ao executar o agente."
 missing_api_key = "OPENAI_API_KEY não encontrada. Defina-a no ambiente ou em um arquivo .env."
 missing_api_deps = "Dependências da API ausentes. Instale com: pip install 'agentic-dev-tool[api]'"
+missing_shell_deps = "Instale agentic-dev-tool[shell] para usar adt shell."

--- a/tests/unit/test_phase10_interactive.py
+++ b/tests/unit/test_phase10_interactive.py
@@ -1,0 +1,483 @@
+"""Tests for Phase 10.6 — Interactive Terminal Experience (P10-20..P10-25)."""
+
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+
+import pytest
+from rich.console import Console
+
+# ── P10-20: StatusReporter ────────────────────────────────────────────
+
+
+def _make_console() -> Console:
+    return Console(file=StringIO(), force_terminal=True, width=120)
+
+
+def test_status_reporter_records_phases(monkeypatch: pytest.MonkeyPatch) -> None:
+    """StatusReporter should record phase labels even when disabled."""
+    monkeypatch.setenv("ADT_NO_PROGRESS", "1")
+    from adt.cli.status import StatusReporter
+
+    c = _make_console()
+    sr = StatusReporter(c)
+    with sr.live():
+        sr.routing()
+        sr.calling_agent("repo_agent")
+        sr.running_tool("read_file")
+        sr.iteration(2, 5)
+
+    assert "Routing..." in sr.phases
+    assert "Calling repo_agent..." in sr.phases
+    assert "Running tool: read_file" in sr.phases
+    assert "Iteration 2/5..." in sr.phases
+
+
+def test_status_disabled_by_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from adt.cli.status import _progress_enabled
+
+    monkeypatch.setenv("ADT_NO_PROGRESS", "1")
+    assert not _progress_enabled()
+
+
+def test_status_disabled_no_tty(monkeypatch: pytest.MonkeyPatch) -> None:
+    from adt.cli.status import _progress_enabled
+
+    monkeypatch.delenv("ADT_NO_PROGRESS", raising=False)
+    # StringIO has no isatty — non-tty
+    import sys
+
+    orig = sys.stdout
+    sys.stdout = StringIO()
+    try:
+        assert not _progress_enabled()
+    finally:
+        sys.stdout = orig
+
+
+def test_status_building_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ADT_NO_PROGRESS", "1")
+    from adt.cli.status import StatusReporter
+
+    sr = StatusReporter(_make_console())
+    with sr.live():
+        sr.building_context()
+
+    assert "Building context..." in sr.phases
+
+
+# ── P10-21: Streaming ────────────────────────────────────────────────
+
+
+def test_run_chunk_dataclass() -> None:
+    from adt.cli.streaming import RunChunk
+
+    chunk = RunChunk(kind="token", text="Hello")
+    assert chunk.kind == "token"
+    assert chunk.text == "Hello"
+    assert chunk.tool_name == ""
+
+
+def test_run_chunk_tool_events() -> None:
+    from adt.cli.streaming import RunChunk
+
+    start = RunChunk(kind="tool_call_start", tool_name="read_file")
+    end = RunChunk(kind="tool_call_end", tool_name="read_file")
+    assert start.tool_name == "read_file"
+    assert end.kind == "tool_call_end"
+
+
+def test_stream_renderer_accumulates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """StreamRenderer should accumulate token chunks into final text."""
+    from adt.cli.streaming import RunChunk, StreamRenderer
+
+    # Use non-tty console so Live doesn't actually render
+    monkeypatch.setenv("ADT_NO_PROGRESS", "1")
+    c = Console(file=StringIO(), force_terminal=False, width=80)
+    renderer = StreamRenderer(c)
+
+    chunks = iter(
+        [
+            RunChunk(kind="token", text="Hello "),
+            RunChunk(kind="token", text="world"),
+            RunChunk(kind="final", text=""),
+        ]
+    )
+    result = renderer.render_stream(chunks)
+    assert result == "Hello world"
+
+
+def test_stream_renderer_final_override() -> None:
+    """When final chunk has text, it replaces the buffer."""
+    from adt.cli.streaming import RunChunk, StreamRenderer
+
+    c = Console(file=StringIO(), force_terminal=False, width=80)
+    renderer = StreamRenderer(c)
+
+    chunks = iter(
+        [
+            RunChunk(kind="token", text="partial "),
+            RunChunk(kind="final", text="Complete answer"),
+        ]
+    )
+    result = renderer.render_stream(chunks)
+    assert result == "Complete answer"
+
+
+# ── P10-22: Progress bars ────────────────────────────────────────────
+
+
+def test_null_progress_reporter_records_calls() -> None:
+    from adt.cli.progress import NullProgressReporter
+
+    p = NullProgressReporter()
+    p.start("Reading files", 10)
+    for i in range(1, 4):
+        p.step(i, 10)
+    p.finish()
+    assert len(p.calls) == 3
+    assert p.calls[0] == (1, 10)
+
+
+def test_rich_progress_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ADT_NO_PROGRESS", "1")
+    from adt.cli.progress import RichProgressReporter
+
+    p = RichProgressReporter(_make_console())
+    p.start("test", 5)
+    p.step(1, 5)
+    p.finish()
+    assert p.calls == [(1, 5)]
+
+
+def test_progress_callback_protocol() -> None:
+    """ProgressCallback should accept (int, int) -> None."""
+    from adt.cli.progress import NullProgressReporter, ProgressCallback
+
+    p = NullProgressReporter()
+    # Should satisfy the protocol
+    cb: ProgressCallback = p.step
+    cb(1, 5)
+    assert p.calls == [(1, 5)]
+
+
+# ── P10-23: Cost confirmation ────────────────────────────────────────
+
+
+def test_should_confirm_below_threshold() -> None:
+    from adt.cli.cost_confirm import _should_confirm
+
+    assert not _should_confirm(0.01, 0.05)
+
+
+def test_should_confirm_above_threshold() -> None:
+    from adt.cli.cost_confirm import _should_confirm
+
+    assert _should_confirm(0.10, 0.05)
+
+
+def test_should_confirm_yes_flag_bypasses() -> None:
+    from adt.cli.cost_confirm import _should_confirm
+
+    assert not _should_confirm(0.10, 0.05, yes_flag=True)
+
+
+def test_should_confirm_env_var_bypasses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from adt.cli.cost_confirm import _should_confirm
+
+    monkeypatch.setenv("ADT_NO_CONFIRM", "1")
+    assert not _should_confirm(0.10, 0.05)
+
+
+def test_estimate_upper_bound() -> None:
+    from adt.cli.cost_confirm import estimate_upper_bound
+
+    cost = estimate_upper_bound("gpt-4o-mini", 1000, 500)
+    assert cost > 0
+    assert isinstance(cost, float)
+
+
+def test_confirm_cost_below_threshold() -> None:
+    from adt.cli.cost_confirm import confirm_cost
+
+    c = _make_console()
+    # Low cost → should pass without prompt
+    result = confirm_cost(c, "gpt-4o-mini", 100, 100, threshold=1.0)
+    assert result is True
+
+
+def test_confirm_cost_yes_flag() -> None:
+    from adt.cli.cost_confirm import confirm_cost
+
+    c = _make_console()
+    # High cost but --yes flag
+    result = confirm_cost(c, "gpt-4o", 100000, 50000, threshold=0.001, yes_flag=True)
+    assert result is True
+
+
+def test_config_cost_confirm_threshold() -> None:
+    from adt.config import AdtConfig
+
+    cfg = AdtConfig()
+    assert cfg.cost_confirm_threshold == 0.05
+
+    cfg2 = AdtConfig(cost_confirm_threshold=0.10)
+    table = cfg2.to_toml_table()
+    assert table["cost_confirm_threshold"] == 0.10
+
+    restored = AdtConfig.from_toml_table(table)
+    assert restored.cost_confirm_threshold == 0.10
+
+
+def test_config_update_cost_threshold(tmp_path: Path) -> None:
+    from adt.config import (
+        AdtConfig,
+        load_config_file,
+        save_config,
+        update_config_key,
+    )
+
+    cfg_path = tmp_path / "config.toml"
+    save_config(AdtConfig(), cfg_path)
+    updated = update_config_key(cfg_path, "cost_confirm_threshold", "0.25")
+    assert updated.cost_confirm_threshold == 0.25
+    reloaded = load_config_file(cfg_path)
+    assert reloaded.cost_confirm_threshold == 0.25
+
+
+def test_config_validator_cost_threshold() -> None:
+    from adt.config_validator import ConfigValidationError, validate_key_value
+
+    validate_key_value("cost_confirm_threshold", "0.05")
+    validate_key_value("cost_confirm_threshold", "0")
+
+    with pytest.raises(ConfigValidationError, match="number"):
+        validate_key_value("cost_confirm_threshold", "abc")
+
+    with pytest.raises(ConfigValidationError, match="non-negative"):
+        validate_key_value("cost_confirm_threshold", "-0.01")
+
+
+# ── P10-24: Shell commands ───────────────────────────────────────────
+
+
+def test_shell_state_defaults() -> None:
+    from adt.cli.shell_commands import ShellState
+
+    s = ShellState()
+    assert s.active_session == "default"
+    assert s.active_agent is None
+    assert s.trace_enabled is False
+    assert s.cost_threshold == 0.05
+
+
+def test_dispatch_help() -> None:
+    from adt.cli.shell_commands import ShellState, dispatch
+
+    c = _make_console()
+    s = ShellState()
+    assert dispatch("/help", s, c) is True
+
+
+def test_dispatch_version() -> None:
+    from adt.cli.shell_commands import ShellState, dispatch
+
+    c = _make_console()
+    s = ShellState()
+    assert dispatch("/version", s, c) is True
+
+
+def test_dispatch_trace_on_off() -> None:
+    from adt.cli.shell_commands import ShellState, dispatch
+
+    c = _make_console()
+    s = ShellState()
+    dispatch("/trace on", s, c)
+    assert s.trace_enabled is True
+    dispatch("/trace off", s, c)
+    assert s.trace_enabled is False
+
+
+def test_dispatch_agent_force_and_clear() -> None:
+    from adt.cli.shell_commands import ShellState, dispatch
+
+    c = _make_console()
+    s = ShellState()
+    dispatch("/agent repo_agent", s, c)
+    assert s.active_agent == "repo_agent"
+    dispatch("/agent clear", s, c)
+    assert s.active_agent is None
+
+
+def test_dispatch_agent_invalid() -> None:
+    from adt.cli.shell_commands import ShellState, dispatch
+
+    buf = StringIO()
+    c = Console(file=buf, force_terminal=True, width=120)
+    s = ShellState()
+    dispatch("/agent bogus_agent", s, c)
+    assert s.active_agent is None  # not changed
+
+
+def test_dispatch_cost() -> None:
+    from adt.cli.shell_commands import ShellState, dispatch
+
+    buf = StringIO()
+    c = Console(file=buf, force_terminal=True, width=120)
+    s = ShellState(cost_threshold=0.10)
+    dispatch("/cost", s, c)
+    output = buf.getvalue()
+    assert "0.10" in output
+
+
+def test_dispatch_exit() -> None:
+    from adt.cli.shell_commands import ShellState, dispatch
+
+    c = _make_console()
+    s = ShellState()
+    with pytest.raises(SystemExit):
+        dispatch("/exit", s, c)
+
+
+def test_dispatch_unknown_command() -> None:
+    from adt.cli.shell_commands import ShellState, dispatch
+
+    buf = StringIO()
+    c = Console(file=buf, force_terminal=True, width=120)
+    s = ShellState()
+    assert dispatch("/bogus", s, c) is True  # handled (error printed)
+    assert "Unknown command" in buf.getvalue()
+
+
+def test_dispatch_non_slash_returns_false() -> None:
+    from adt.cli.shell_commands import ShellState, dispatch
+
+    c = _make_console()
+    s = ShellState()
+    assert dispatch("explain this code", s, c) is False
+
+
+def test_dispatch_clear() -> None:
+    from adt.cli.shell_commands import ShellState, dispatch
+
+    c = _make_console()
+    s = ShellState()
+    # clear should not raise
+    assert dispatch("/clear", s, c) is True
+
+
+def test_dispatch_session_list(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from adt.cli.shell_commands import ShellState, dispatch
+
+    buf = StringIO()
+    c = Console(file=buf, force_terminal=True, width=120)
+    s = ShellState()
+
+    monkeypatch.setattr(
+        "adt.core.session_store.ensure_adt_dir",
+        lambda: tmp_path,
+    )
+    dispatch("/session list", s, c)
+    output = buf.getvalue()
+    assert "No sessions" in output or "default" in output
+
+
+def test_dispatch_session_switch() -> None:
+    from adt.cli.shell_commands import ShellState, dispatch
+
+    c = _make_console()
+    s = ShellState()
+    dispatch("/session switch my-session", s, c)
+    assert s.active_session == "my-session"
+
+
+def test_command_names_sorted() -> None:
+    from adt.cli.shell_commands import COMMAND_NAMES
+
+    assert sorted(COMMAND_NAMES) == COMMAND_NAMES
+    assert "/help" in COMMAND_NAMES
+    assert "/exit" in COMMAND_NAMES
+    assert "/shell" not in COMMAND_NAMES
+
+
+# ── P10-24: Shell REPL scaffold ──────────────────────────────────────
+
+
+def test_shell_module_importable() -> None:
+    import adt.cli.shell
+
+    assert hasattr(adt.cli.shell, "run_shell")
+
+
+def test_shell_history_path() -> None:
+    from adt.cli.shell import _HISTORY_PATH
+
+    assert _HISTORY_PATH.name == "shell_history"
+    assert ".adt" in str(_HISTORY_PATH)
+
+
+def test_build_completer_returns_object() -> None:
+    from adt.cli.shell import _build_completer
+
+    comp = _build_completer()
+    assert comp is not None
+
+
+# ── P10-25: CLI flags on ask_cmd ─────────────────────────────────────
+
+
+def test_ask_cmd_accepts_yes_and_no_stream() -> None:
+    """Verify --yes and --no-stream flags exist on ask_cmd."""
+    from typer.testing import CliRunner
+
+    from adt.cli.app import app
+
+    runner = CliRunner()
+    # Just check --help mentions them
+    result = runner.invoke(app, ["ask", "--help"])
+    assert "--yes" in result.output
+    assert "--no-stream" in result.output
+
+
+def test_shell_cmd_in_app() -> None:
+    """Verify 'shell' is registered as a command."""
+    from typer.testing import CliRunner
+
+    from adt.cli.app import app
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["shell", "--help"])
+    assert result.exit_code == 0
+    assert "interactive REPL" in result.output
+
+
+# ── P10-20/P10-24: i18n locale keys ─────────────────────────────────
+
+
+def test_all_en_keys_present_in_pt_br_phase10_6() -> None:
+    """Every key in en.toml must also exist in pt_BR.toml."""
+    from adt.cli.i18n import _load_locale
+
+    _load_locale.cache_clear()
+    en = _load_locale("en")
+    pt = _load_locale("pt_BR")
+    missing = set(en.keys()) - set(pt.keys())
+    assert not missing, f"Keys missing from pt_BR.toml: {missing}"
+
+
+# ── pyproject.toml ───────────────────────────────────────────────────
+
+
+def test_shell_extra_in_pyproject() -> None:
+    """pyproject.toml should define a [shell] extra with prompt-toolkit."""
+    import tomli
+
+    pyproject = Path(__file__).resolve().parents[2] / "pyproject.toml"
+    data = tomli.loads(pyproject.read_text(encoding="utf-8"))
+    extras = data["project"]["optional-dependencies"]
+    assert "shell" in extras
+    shell_deps = " ".join(extras["shell"])
+    assert "prompt-toolkit" in shell_deps


### PR DESCRIPTION
## Summary

- **P10-20 — Status spinner**: `StatusReporter` wraps `rich.status.Status` with adaptive labels (Routing → Calling agent → Running tool → Iteration N/M). Disabled via `ADT_NO_PROGRESS=1` or non-tty stdout
- **P10-21 — Token streaming**: `RunChunk` dataclass + `StreamRenderer` using `rich.live.Live` for incremental Markdown panel rendering. `--no-stream` flag on `adt ask` for buffered fallback
- **P10-22 — Progress bars**: `ProgressCallback` protocol + `RichProgressReporter` / `NullProgressReporter` for tool-level progress reporting (file walks, multi-fetch)
- **P10-23 — Cost confirmation**: `confirm_cost()` estimates upper-bound USD via `CostEstimator`, prompts when above `cost_confirm_threshold` (default $0.05). Bypassed by `--yes` flag or `ADT_NO_CONFIRM=1`
- **P10-24 — adt shell REPL**: `prompt_toolkit.PromptSession` with `FileHistory` (~/.adt/shell_history), `WordCompleter` for slash commands/agents, 14 built-in commands (`/help`, `/trace on|off`, `/stats`, `/session list|switch|delete`, `/agent`, `/cost`, `/version`, `/clear`, `/exit`)
- **P10-25 — Supervised REPL commands**: `/start <problem>`, `/next`, `/hint`, `/submit <code|@path>` drive the supervised learning loop entirely from inside the shell
- **README refactored** into a portfolio-ready format: concise architecture, full command table, clean configuration reference

### New files
| File | Purpose |
|------|---------|
| `src/adt/cli/status.py` | Rich status spinner |
| `src/adt/cli/streaming.py` | RunChunk + StreamRenderer |
| `src/adt/cli/progress.py` | ProgressCallback + reporters |
| `src/adt/cli/cost_confirm.py` | Cost estimation + confirmation |
| `src/adt/cli/shell.py` | REPL main loop |
| `src/adt/cli/shell_commands.py` | Slash command dispatcher (14 commands) |
| `tests/unit/test_phase10_interactive.py` | 42 tests |

### Modified files
| File | Change |
|------|--------|
| `src/adt/cli/app.py` | `--yes`, `--no-stream` on ask_cmd; `adt shell` command |
| `src/adt/config.py` | `cost_confirm_threshold` field |
| `src/adt/config_validator.py` | Validation for `cost_confirm_threshold` |
| `pyproject.toml` | `[shell]` extra with `prompt-toolkit>=3.0,<4.0` |
| `src/adt/locales/en.toml` | Shell + cost locale keys |
| `src/adt/locales/pt_BR.toml` | Shell + cost locale keys (pt_BR) |
| `README.md` | Full refactor for portfolio presentation |

## Validation

- **528 tests pass** (42 new for Phase 10.6)
- `ruff check` — clean
- `ruff format` — clean
- `mypy` — no issues (77 source files)

## Test plan

- [x] `python -m pytest` — all 528 tests pass
- [x] `ruff check src/ tests/` — no errors
- [x] `ruff format --check src/ tests/` — all formatted
- [x] `mypy src/` — success on 77 files
- [ ] Manual: `adt ask "explain this repo" --repo . --trace` shows spinner + answer
- [ ] Manual: `adt shell --repo .` opens REPL; `/help`, `/trace on`, `/version`, `/exit` work
- [ ] Manual: `adt ask "..." --yes` skips cost confirmation
- [ ] Manual: `ADT_NO_PROGRESS=1 adt ask "..."` suppresses spinner
